### PR TITLE
Version 3.0.4

### DIFF
--- a/schemas/IDLs/latest/GelBamMetrics.avdl
+++ b/schemas/IDLs/latest/GelBamMetrics.avdl
@@ -878,17 +878,42 @@ record  InsertSizeGel{
 
 record CoverageSummary {
 
-    string wellId;
-    double n;
-    double mean;
-    double sd;
-    double pct25;
-    double median;
-    double pct75;
-    string scope;
-    double localRMSD;
-    double COSMIC30Xcov;
+    /** Average coverage - renamed from mean */
+    double avg;
 
+    /** median of the coverage - renamed from median */
+    double med;
+
+    /** Number of bases - renamed from "n" */
+    double bases;
+
+    /** Percentile 25 */
+    double pct25;
+
+    /** Percentile 75 */
+    double pct75;
+
+    /** Fraction of coverage values with a depth of coverage less than 15x */
+    double lt15x;
+
+    /** Fraction of coverage values with a depth of coverage greater than or equal to 15x */
+    double gte15x;
+
+    /** Fraction of coverage values with a depth of coverage greater than or equal to 30x */
+    double gte30x;
+
+    /** Fraction of coverage values with a depth of coverage greater than or equal to 50x */
+    double gte50x;
+
+    /** Standard deviation of coverage values */
+    double sd;
+
+    /** estimation of root mean square deviation: weighted average RMSD of chunks of 100k bases */
+    double localRMSD;
+
+    /** Scope to which these summary stats refer to.
+    *   Examples: "allchrs" (all chromosomes), "X", "chr6", "6", "autosomes" */
+    string scope;
 }
 
 record WholeGenomeCoverage {
@@ -897,10 +922,16 @@ record WholeGenomeCoverage {
 
 }
 
-record ExonCoverage {
+/** Renamed from ExonCoverage */
+record ExomeCoverage {
 
     array <CoverageSummary> coverageSummary;
 
+}
+
+record VariantsCoverage {
+    string bedName;
+    array <CoverageSummary> coverageSummary;
 }
 
 record BamHeaderOther {

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ reqs = [
 
 # BASE_DIR = os.path.dirname(__file__)
 # VERSION = json.load(open(os.path.join(BASE_DIR, "schemas", "JSONs", "VersionControl", "VersionControl.avsc")))["fields"][0]["default"]
-VERSION = "3.0.3"
+VERSION = "3.0.4"
 setup(
     name='GelReportModels',
     version=VERSION,


### PR DESCRIPTION
Changes: 
* `CoverageSummary`:
    * added field `lt15x`
    * added field `gte15x`
    * added field `gte30x`
    * added field `gte50x`
    * removed field `COSMIC30Xcov`
    * field `mean` renamed to `avg`
    * field `median` renamed to `med`
    * field `n` renamed to `bases`
* `ExonCoverage` renamed to `ExomeCoverage`
* Added record `VariantsCoverage`