### PR TITLE
Corrected Dockerfile commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ RUN cd GelReportModels && \
     cd ../biodata && \
     mvn clean install -DskipTests && \
     pip install --upgrade pysam && \
+    mvn clean generate-sources && \
+    cd ../GelReportModels && \
     mvn clean generate-sources
 ```
 


### PR DESCRIPTION
Added extra commands in Dockerfile to actually create the python model files in protocols, otherwise they're not built when you run this.