### PR TITLE
Update RD Participant Model to better reflect LabKey

### DIFF
--- a/schemas/IDLs/org.gel.models.participant.avro/1.0.1/CancerParticipant.avdl
+++ b/schemas/IDLs/org.gel.models.participant.avro/1.0.1/CancerParticipant.avdl
@@ -1,0 +1,240 @@
+@namespace("org.gel.models.participant.avro")
+/**
+This protocol defines the `CancerParticipant`
+*/
+protocol CancerParticipants {
+
+import idl "CommonParticipant.avdl";
+import idl "VersionControl.avdl";
+
+enum TumourType {ADULT_GLIOMA, BLADDER, BREAST,	CARCINOMA_OF_UNKNOWN_PRIMARY, CHILDHOOD, COLORECTAL,
+ENDOMETRIAL_CARCINOMA, HAEMONC, HEPATOPANCREATOBILIARY, LUNG, MALIGNANT_MELANOMA, NASOPHARYNGEAL, ORAL_OROPHARYNGEAL,
+OVARIAN, PROSTATE, RENAL, SARCOMA, SINONASAL, TESTICULAR_GERM_CELL_TUMOURS, UPPER_GASTROINTESTINAL,
+NON_HODGKINS_B_CELL_LYMPHOMA_LOW_MOD_GRADE, CLASSICAL_HODGKINS, NODULAR_LYMPHOCYTE_PREDOMINANT_HODGKINS, T_CELL_LYMPHOMA}
+
+enum PreparationMethod {EDTA, ORAGENE, FF, FFPE, CD128_SORTED_CELLS, ASPIRATE}
+
+enum Phase {PRIMARY, METASTATIC_RECURRENCE, RECURRENCE_OF_PRIMARY_TUMOUR, METASTASES}
+
+enum ProgrammePhase {CRUK, OXFORD, CLL, IIP, MAIN, EXPT}
+
+enum Method {RESECTION, BIOPSY, BLOOD}
+
+enum SampleSource {TUMOUR, BONE_MARROW_ASPIRATE_TUMOUR_SORTED_CELLS, BONE_MARROW_ASPIRATE_TUMOUR_CELLS,  BLOOD, SALIVA, FIBROBLAST, TISSUE}
+
+enum Product {DNA, RNA}
+
+enum Sex {FEMALE, MALE, UNKNOWN}
+
+enum TumourContent {High, Medium, Low}
+
+enum TissueSource {BMA_TUMOUR_SORTED_CELLS, CT_GUIDED_BIOPSY, ENDOSCOPIC_BIOPSY, ENDOSCOPIC_ULTRASOUND_GUIDED_BIOPSY,
+ENDOSCOPIC_ULTRASOUND_GUIDED_FNA, LAPAROSCOPIC_BIOPSY, LAPAROSCOPIC_EXCISION, MRI_GUIDED_BIOPSY, NON_GUIDED_BIOPSY,
+SURGICAL_RESECTION, STEREOTACTICALLY_GUIDED_BIOPSY, USS_GUIDED_BIOPSY, NON_STANDARD_BIOPSY}
+
+record GermlineSample {
+
+    /**
+    Sample Id (e.g, LP00012645_5GH))
+    */
+    string sampleId;
+
+    /**
+    Lab sample Id
+    */
+    int labSampleId;
+
+    /**
+    Source
+    */
+    union {null, SampleSource} source;
+
+    /**
+    Product
+    */
+    union {null, Product} product;
+
+    /**
+    preparationMethod
+    */
+    union {null, PreparationMethod} preparationMethod;
+
+    /**
+    gelPhase (eg cruk, brc, cll, iip, main)
+    */
+    union {null, ProgrammePhase} programmePhase;
+
+    /**
+    In the format YYYY-MM-DDTHH:MM:SS+0000
+    */
+    union {null,string} clinicalSampleDateTime;
+
+}
+
+record TumourSample {
+
+    /**
+    Sample Id (e.g, LP00012645_5GH))
+    */
+    string sampleId;
+
+    /**
+    Lab sample Id
+    */
+    int labSampleId;
+
+    /**
+    Id of each one of the tumors for a participant
+    */
+    int tumourId;
+
+    /**
+    gelPhase (eg cruk, brc, cll, iip, main)
+    */
+    union {null, ProgrammePhase} programmePhase;
+
+    /**
+    tumour Type
+    */
+    union {null, TumourType} tumourType;
+
+    /**
+    Tumor Subtype
+    */
+    union {null, string} tumourSubType;
+
+    /**
+    In the format YYYY-MM-DDTHH:MM:SS+0000
+    */
+    union {null, string} clinicalSampleDateTime;
+
+    /**
+    Tumor Phase
+    */
+    union {null, Phase} phase;
+
+    /**
+    tumourContent
+    */
+    union {null, TumourContent} tumourContent;
+
+    /**
+    Method
+    */
+    union {null, SampleSource} source;
+
+    /**
+    preparationMethod
+    */
+    union {null, PreparationMethod} preparationMethod;
+
+
+    /**
+    Method
+    */
+    union {null, TissueSource} tissueSource;
+
+    /**
+    Product
+    */
+    union {null, Product} product;
+
+    /**
+    TMN version
+    */
+    union {null, string} TNMStageVersion;
+
+    /**
+    TMN stage grouping
+    */
+    union {null, string} TNMStageGrouping;
+
+}
+
+/**
+This define a pair of germline and tumor, this pair should/must be analyzed together
+*/
+record MatchedSamples{
+
+    /**
+    Sample Id (e.g, LP00012645_5GH)) for the germline
+    */
+    union {null, string} germlineSampleId;
+
+    /**
+    Sample Id (e.g, LP00012643_7JS)) for the tumor
+    */
+    union {null, string} tumourSampleId;
+
+}
+
+/**
+This defines a Cancer Demographics
+*/
+record CancerParticipant{
+
+
+    boolean readyForAnalysis;
+
+    /**
+    What has this participant consented to?
+    A participant that has been consented to the programme should also have sequence data associated with them; however
+    this needs to be programmatically checked
+    */
+    union {null, ConsentStatus} consentStatus;
+
+    /**
+    Center
+    */
+    union {null, string} center;
+
+
+    union {null, string} LDPCode;
+
+    /**
+    Individual Id
+    */
+    string individualId;
+
+
+    /**
+    This should be an enumeration when it is well defined
+    blood, breast, prostate, colorectal, cll, aml, renal, ovarian, skin, lymphNode, bone, saliva //for individual - there could be more than I have listed here, in fact there definitely will.
+    */
+    union {null, string} primaryDiagnosisDisease;
+
+    /**
+    This should be an enumeration when it is well defined
+    blood, breast, prostate, colorectal, cll, aml, renal, ovarian, skin, lymphNode, bone, saliva //for individual - there could be more than I have listed here, in fact there definitely will.
+    */
+    union {null, string} primaryDiagnosisSubDisease;
+
+    /**
+    Sex
+    */
+    Sex sex;
+
+    /**
+    We could add a map here to store additional information for example URIs to images, ECGs, etc
+    */
+    union {null, map<string>} additionalInformation;
+
+    /**
+    assigned ICD10 code
+    */
+    union {null, string} assignedICD10;
+
+
+    array<TumourSample> tumourSamples;
+    array<GermlineSample> germlineSamples;
+    union {null, array<MatchedSamples>} matchedSamples;
+
+    /**
+    Model version number
+    */
+    union {null, VersionControl} versionControl;
+
+
+}
+
+}

--- a/schemas/IDLs/org.gel.models.participant.avro/1.0.1/CommonParticipant.avdl
+++ b/schemas/IDLs/org.gel.models.participant.avro/1.0.1/CommonParticipant.avdl
@@ -1,0 +1,166 @@
+@namespace("org.gel.models.participant.avro")
+/**
+This protocol defines the Common things between participant models
+*/
+protocol CommonParticipant {
+
+/**
+Sex
+*/
+enum Sex {MALE, FEMALE, UNKNOWN}
+
+/**
+Karyotipic Sex
+*/
+enum PersonKaryotipicSex {UNKNOWN, XX, XY, XO, XXY, XXX, XXYY, XXXY, XXXX, XYY, OTHER}
+
+
+/**
+Penetrance assumed in the analysis
+*/
+enum Penetrance {complete, incomplete}
+
+/**
+This the define a yes/no/unknown case
+*/
+enum TernaryOption {yes, no, unknown}
+
+/**
+This is the list of ethnics in ONS16
+
+* `D`:  Mixed: White and Black Caribbean
+* `E`:  Mixed: White and Black African
+* `F`:  Mixed: White and Asian
+* `G`:  Mixed: Any other mixed background
+* `A`:  White: British
+* `B`:  White: Irish
+* `C`:  White: Any other White background
+* `L`:  Asian or Asian British: Any other Asian background
+* `M`:  Black or Black British: Caribbean
+* `N`:  Black or Black British: African
+* `H`:  Asian or Asian British: Indian
+* `J`:  Asian or Asian British: Pakistani
+* `K`:  Asian or Asian British: Bangladeshi
+* `P`:  Black or Black British: Any other Black background
+* `S`:  Other Ethnic Groups: Any other ethnic group
+* `R`:  Other Ethnic Groups: Chinese
+* `Z`:  Not stated
+*/
+enum EthnicCategory {D, E, F, G, A, B, C, L, M, N, H, J, K, P, S, R, Z}
+
+/**
+1K Population
+*/
+enum KGPopCategory {ACB, ASW, BEB, CDX, CEU, CHB, CHS, CLM, ESN, FIN, GBR, GIH, GWD, IBS, ITU, JPT, KHV, LWK, MSL, MXL, PEL, PJL, PUR, STU, TSI, YRI}
+/**
+1K Super Population
+*/
+enum KGSuperPopCategory {AFR, AMR, EAS, EUR, SAS}
+
+/**
+Chi-square test for goodness of fit of this sample to 1000 Genomes Phase 3 populations
+*/
+record ChiSquare1KGenomesPhase3Pop {
+    /**
+    1K Super Population
+    */
+    KGSuperPopCategory kGSuperPopCategory;
+    /**
+    1K Population
+    */
+    union {null, KGPopCategory} kGPopCategory;
+    /**
+    Chi-square test for goodness of fit of this sample to this 1000 Genomes Phase 3 population
+    */
+    double chiSquare;
+}
+
+/**
+Ancestries, defined as Ethnic category(ies) and Chi-square test
+*/
+record Ancestries {
+    /**
+    Mother's Ethnic Origin
+    */
+    union{null, EthnicCategory} mothersEthnicOrigin;
+    /**
+    Mother's Ethnic Origin Description
+    */
+    union{null, string} mothersOtherRelevantAncestry;
+    /**
+    Father's Ethnic Origin
+    */
+    union{null, EthnicCategory} fathersEthnicOrigin;
+    /**
+    Father's Ethnic Origin Description
+    */
+    union{null, string} fathersOtherRelevantAncestry;
+    /**
+    Chi-square test for goodness of fit of this sample to 1000 Genomes Phase 3 populations
+    */
+    union{null, array<ChiSquare1KGenomesPhase3Pop>} chiSquare1KGenomesPhase3Pop;
+
+
+}
+
+/**
+Consent Status
+*/
+record ConsentStatus {
+
+    /**
+    Is this individual consented to the programme?
+    It could simple be a family member that is not consented but for whom affection status is known
+    */
+    boolean programmeConsent=false;
+
+    /**
+    Consent for feedback of primary findings?
+    */
+    boolean primaryFindingConsent=false;
+
+    /**
+    Consent for secondary finding lookup
+    */
+    boolean secondaryFindingConsent=false;
+
+    /**
+    Consent for carrier status check?
+    */
+    boolean carrierStatusConsent=false;
+}
+
+/**
+Inbreeding coefficient
+*/
+record InbreedingCoefficient {
+
+    /**
+    This is the sample id against which the coefficient was estimated
+    */
+    string sampleId;
+    /**
+    Name of program used to calculate the coefficient
+    */
+    string program;
+    /**
+    Version of the programme
+    */
+    string version;
+    /**
+    Where various methods for estimation exist, which method was used.
+    */
+    string estimationMethod;
+    /**
+    Inbreeding coefficient ideally a real number in [0,1]
+    */
+    double coefficient;
+    /**
+    Standard error of the Inbreeding coefficient
+    */
+    union {null, double} standardError;
+}
+
+
+
+}

--- a/schemas/IDLs/org.gel.models.participant.avro/1.0.1/ParticipantSensitiveInformation.avdl
+++ b/schemas/IDLs/org.gel.models.participant.avro/1.0.1/ParticipantSensitiveInformation.avdl
@@ -1,0 +1,32 @@
+@namespace("org.gel.models.participant.avro")
+/**
+This protocol defines the Participants and Pedigree
+*/
+
+
+protocol SensitiveInformation {
+import idl "VersionControl.avdl";
+record SensitiveInformation {
+    /**
+    Model version number
+    */
+    VersionControl versionControl;
+
+
+    string gelID;
+
+    union {null, array<string>} externalIds; //should be hide for external companies
+
+    union {null, string} genomicMedicineCenter;
+    union {null, string} fullNameOfResponsibleConsultant;
+    union {null, string} contactNumber;
+    union {null, string} hospitalOfResponsibleConsultant;
+
+    union {null, string} centerSampleId;
+
+    union {null, string} originatingCenter;
+
+    union {null, string} centerPatientId;
+
+}
+}

--- a/schemas/IDLs/org.gel.models.participant.avro/1.0.1/RDParticipant.avdl
+++ b/schemas/IDLs/org.gel.models.participant.avro/1.0.1/RDParticipant.avdl
@@ -1,0 +1,341 @@
+@namespace("org.gel.models.participant.avro")
+/**
+This protocol defines the Participants and Pedigree
+*/
+protocol Pedigrees {
+
+import idl "CommonParticipant.avdl";
+import idl "VersionControl.avdl";
+
+/**
+This is quite GEL specific. This is the way is stored in ModelCatalogue and PanelApp.
+Currently all specific disease titles are assigned to a disease subgroup so really only specificDisease needs to be
+completed but we add the others for generality
+*/
+record Disorder {
+    /**
+    This is Level2 Title for this disorder
+    */
+    union {null,string} diseaseGroup;
+
+    /**
+    This is Level3 Title for this disorder
+    */
+    union {null,string} diseaseSubGroup;
+
+    /**
+    This is Level4 Title for this disorder
+    */
+    union {null,string} specificDisease;
+
+    /**
+    Age of onset in years
+    */
+    union {null, float} ageOfOnset;
+}
+
+enum Laterality {RIGHT, UNILATERAL, BILATERAL, LEFT}
+
+enum Progression {PROGRESSIVE, NONPROGRESSIVE}
+
+enum Severity {BORDERLINE, MILD, MODERATE, SEVERE, PROFOUND}
+
+enum SpatialPattern {DISTAL, GENERALIZED, LOCALIZED, PROXIMAL}
+
+
+record HpoTermModifiers{
+    union {null, Laterality} laterality;
+    union {null, Progression} progression;
+    union {null, Severity} severity;
+    union {null, SpatialPattern} spatialPattern;
+}
+
+
+enum AgeOfOnset {EMBRYONAL_ONSET, FETAL_ONSET, NEONATAL_ONSET, INFANTILE_ONSET, CHILDHOOD_ONSET, JUVENILE_ONSET, YOUNG_ADULT_ONSET, LATE_ONSET, MIDDLE_AGE_ONSET}
+
+/**
+This defines an HPO term and its modifiers (possibly multiple)
+If HPO term presence is unknown we don't have a entry on the list
+*/
+record HpoTerm {
+    /**
+    Identifier of the HPO term
+    */
+    string term;
+
+    /**
+    This is whether the term is present in the participant (default is unknown) yes=term is present in participant,
+    no=term is not present
+    */
+    union {null, TernaryOption} termPresence;
+
+    /**
+    hpoBuildNumber
+    */
+    union {null, string} hpoBuildNumber;
+
+    /**
+    Modifier associated with the HPO term
+    */
+    union {null, HpoTermModifiers} modifiers;
+
+    /**
+    Age of onset in months
+    */
+    union {null, AgeOfOnset} ageOfOnset;
+
+}
+
+
+
+/**
+Affection Status
+*/
+enum AffectionStatus {UNAFFECTED, AFFECTED, UNCERTAIN}
+
+/**
+QCState Status
+*/
+enum ParticipantQCState {noState, passedMedicalReviewReadyForInterpretation, passedMedicalReviewNotReadyForInterpretation, queryToGel,	queryToGMC,	failed}
+
+/**
+Life Status
+*/
+enum LifeStatus {ALIVE, ABORTED, DECEASED, UNBORN, STILLBORN, MISCARRIAGE}
+
+/**
+FamilyQCState
+*/
+enum FamilyQCState {noState, passedMedicalReviewReadyForInterpretation, passedMedicalReviewNotReadyForInterpretation, queryToGel, queryToGMC, failed}
+
+
+enum SampleSource {BLOOD, SALIVA, FIBROBLAST, TISSUE}
+
+enum Product {DNA, RNA}
+
+enum PreparationMethod {EDTA, ORAGENE, FF}
+
+/**
+adoptedin means adopted into the family
+adoptedout means child belonged to the family and was adopted out
+*/
+enum AdoptedStatus {notadopted, adoptedin, adoptedout}
+
+
+
+record Sample{
+    /**
+    Sample Id (e.g, LP00012645_5GH))
+    */
+    string sampleId;
+
+    /**
+    Lab Sample Id
+    */
+    int labSampleId;
+
+    /**
+    Source
+    */
+    union {null, SampleSource} source;
+
+    /**
+    Product
+    */
+    union {null, Product} product;
+
+    /**
+    preparationMethod
+    */
+    union {null, PreparationMethod} preparationMethod;
+
+}
+
+
+/**
+This defines a RD Participant (demographics and pedigree information)
+*/
+record PedigreeMember {
+
+    /**
+    Numbering used to refer to each member of the pedigree
+    */
+    union {null, int} pedigreeId;
+
+    /**
+    If this field is true, the member should be consider the proband of this family
+    */
+    union {null, boolean} isProband;
+
+    /**
+    participantId
+    */
+    union {null, string} participantId;
+
+
+    /**
+    participantQCState
+    */
+    union {null, ParticipantQCState} participantQCState;
+
+
+    /**
+    superFamily id, this id is built as a concatenation of all families id in this superfamily i.e, fam10024_fam100457
+    */
+    union {null, string} gelSuperFamilyId;
+
+    /**
+    Sex of the Participant
+    */
+    Sex sex;
+
+    /**
+    Karyotypic sex of the participant as previously established or by looking at the GEL genome
+    */
+    union {null, PersonKaryotipicSex} personKaryotypicSex;
+
+    /**
+    Year of Birth
+    */
+    union {null, int} yearOfBirth;
+
+
+    /**
+    refers to the pedigreeId of the father
+    Id of the parent, if unknown then no parent is referenced. Parents may need to be entered even if no data is known
+    about them in order to unambiguously reconstruct the pedigree.
+    */
+    union {null, int}  fatherId;
+    /**
+    refers to the pedigreeId of the mother
+    Id of the parent, if unknown then no parent is referenced. Parents may need to be entered even if no data is known
+    about them in order to unambiguously reconstruct the pedigree.
+    */
+    union {null, int}  motherId;
+
+    /**
+    this id is built using the original familyId and the original pedigreeId of the father
+    */
+    union {null, int}  superFatherId;
+
+    /**
+    this id is built using the original familyId and the original pedigreeId of the mother
+    */
+    union {null, int}  superMotherId;
+
+    /**
+    Each twin group is numbered, i.e. all members of a group of multiparous births receive the same number
+    */
+    union {null, int} twinGroup;
+
+    /**
+    A property of the twinning group but should be entered for all members
+    */
+    union {null, TernaryOption} monozygotic;
+
+    /**
+    Adopted Status
+    */
+    union {null, AdoptedStatus} adoptedStatus;
+
+    /**
+    Life Status
+    */
+    union {null, LifeStatus} lifeStatus;
+
+    /**
+    The parents of this participant has a consanguineous relationship
+    */
+    union {null, TernaryOption} consanguineousParents;
+
+
+    /**
+    Affection Status
+    */
+    union {null, AffectionStatus} affectionStatus;
+
+    /**
+    Clinical Data (disorders). If the family member is unaffected as per affectionStatus then this list is empty
+    */
+    union {null, array<Disorder>} disorderList;
+
+    /**
+    Clinical Data (HPO terms)
+    */
+    union {null, array<HpoTerm>} hpoTermList;
+
+    /**
+    Participant's ancestries, defined as Mother's/Father's Ethnic Origin and Chi-square test for goodness of fit of this sample to 1000 Genomes Phase 3 populations
+    */
+    union {null, Ancestries} ancestries;
+
+    /**
+    What has this participant consented to?
+    A participant that has been consented to the programme should also have sequence data associated with them; however
+    this needs to be programmatically checked
+    */
+    union {null, ConsentStatus} consentStatus;
+
+    /**
+    This is an array containing all the samples that belong to this individual, e.g ["LP00002255_GA4"]
+    */
+    union {null, array<Sample>} samples;
+
+
+    /**
+    Inbreeding Coefficient Estimation
+    */
+    union {null, InbreedingCoefficient} inbreedingCoefficient;
+
+
+    /**
+    We could add a map here to store additional information for example URIs to images, ECGs, etc
+    Null by default
+    */
+    union {null, map<string>} additionalInformation;
+
+}
+
+record AnalysisPanel {
+    string specificDisease;
+    string panelName;
+    union {null, string} panelVersion;
+    string reviewOutcome;
+    string multipleGeneticOrigins;
+}
+
+
+record DiseasePenetrance {
+    string specificDisease;
+    Penetrance penetrance;
+}
+
+
+/**
+This is the concept of a family with associated phenotypes as present in the record RDParticipant
+*/
+record Pedigree {
+    /**
+    Model version number
+    */
+    union {null, VersionControl} versionControl;
+
+    union {null, string} LDPCode;
+
+    /**
+    Family id which internally translate to a sample set
+    */
+    string familyId;
+
+    array <PedigreeMember> members;
+
+    union {null, array<AnalysisPanel>} analysisPanels;
+
+    union {null, array<DiseasePenetrance>} diseasePenetrances;
+
+    boolean readyForAnalysis;
+
+    union {null, FamilyQCState} familyQCState;
+}
+
+}

--- a/schemas/IDLs/org.gel.models.participant.avro/1.0.1/RDParticipantChangeLog.avdl
+++ b/schemas/IDLs/org.gel.models.participant.avro/1.0.1/RDParticipantChangeLog.avdl
@@ -1,0 +1,53 @@
+@namespace("org.gel.models.participant.avro")
+/**
+This protocol defines the minimum information that Genomics England needs to ingest/modify clinical data.
+*/
+protocol ParticipantChangeLogs {
+
+import idl "RDParticipant.avdl";
+
+/**
+This code define the change type:
+
+* `FamilyAdded`: This is a new family.
+* `FamilyDeleted`: This family should be removed.
+* `ProbandChanged`: The proband participant is now a different member of the family.
+* `ParticipantAdded`: A new participant has been sequenced and added to the family.
+* `ParticipantRemoved`: A participant has been removed.
+* `ConsentStatusChanged`: One or more participant in this family has a different consent status.
+* `AffectionStatusChanged`: HPOterms or Disorder changed in one or more participants in this family.
+* `PanelAssignmentChanged`: Gene Panels has changed in this family.
+* `SexChanged`: Sex has changed for one or more participants in this family.
+* `SampleChanged`: The sample/s associated to one or more participant in this family has changed.
+*/
+enum RDFamilyChangeCode {FamilyAdded,
+                         FamilyDeleted,
+                         ProbandChanged,
+                         ParticipantAdded,
+                         ParticipantRemoved,
+                         ConsentStatusChanged,
+                         AffectionStatusChanged,
+                         PanelAssignmentChanged,
+                         SexChanged,
+                         SampleChanged
+                         }
+
+
+record RDFamilyChange {
+
+    /**
+    This is the FamilyId - it is expected to be unique across the whole project
+    */
+    string FamilyId;
+
+    /**
+    This code define a change type
+    */
+    RDFamilyChangeCode code;
+
+    /**
+    This is the family data tha need to be ingested
+    */
+    Pedigree Family;
+}
+}

--- a/schemas/IDLs/org.gel.models.participant.avro/1.0.1/VersionControl.avdl
+++ b/schemas/IDLs/org.gel.models.participant.avro/1.0.1/VersionControl.avdl
@@ -1,0 +1,16 @@
+@namespace("org.gel.models.participant.avro")
+/**
+This protocol defines the Participants and Pedigree
+*/
+protocol GitVersionControl {
+
+record VersionControl{
+
+    /** This is the version for the entire set of data models as referred to the Git release tag
+    */
+    string GitVersionControl="1.0.0";
+
+
+    }
+}
+


### PR DESCRIPTION
* Add defined fields and enum values for HpoTermModifiers
* Add defined string enum values for HpoTerm.ageOfOnset
* Change Disorder.ageOfOnset a Float (representing years)

Because I've copied accross everything from  schemas/IDLs/org.gel.models.participant.avro/1.0.0 - /1.0.1 it's difficult to see the changes It's best to diff the two directories.

```
diff schemas/IDLs/org.gel.models.participant.avro/1.0.0 schemas/IDLs/org.gel.models.participant.avro/1.0.1/
diff schemas/IDLs/org.gel.models.participant.avro/1.0.0/RDParticipant.avdl schemas/IDLs/org.gel.models.participant.avro/1.0.1/RDParticipant.avdl
32c32
<     Age of onset in months
---
>     Age of onset in years
34c34
<     union {null, string} ageOfOnset;
---
>     union {null, float} ageOfOnset;
36a37,54
> enum Laterality {RIGHT, UNILATERAL, BILATERAL, LEFT}
> 
> enum Progression {PROGRESSIVE, NONPROGRESSIVE}
> 
> enum Severity {BORDERLINE, MILD, MODERATE, SEVERE, PROFOUND}
> 
> enum SpatialPattern {DISTAL, GENERALIZED, LOCALIZED, PROXIMAL}
> 
> 
> record HpoTermModifiers{
>     union {null, Laterality} laterality;
>     union {null, Progression} progression;
>     union {null, Severity} severity;
>     union {null, SpatialPattern} spatialPattern;
> }
> 
> 
> enum AgeOfOnset {EMBRYONAL_ONSET, FETAL_ONSET, NEONATAL_ONSET, INFANTILE_ONSET, CHILDHOOD_ONSET, JUVENILE_ONSET, YOUNG_ADULT_ONSET, LATE_ONSET, MIDDLE_AGE_ONSET}
62c80
<     union {null, map<string>} modifiers;
---
>     union {null, HpoTermModifiers} modifiers;
67c85
<     union {null, string} ageOfOnset;
---
>     union {null, AgeOfOnset} ageOfOnset;
```


