### PR TITLE
Feature - Add debug parameter to protocols.validate

### DIFF
--- a/protocols/protocol.py
+++ b/protocols/protocol.py
@@ -31,10 +31,10 @@ class ValidationResult(object):
     def __init__(self, result=None, messages=None):
         self.result = result or True
         self.messages = messages or []
-        self.msg = "Class: {class_name} expects field: {field_name} "
-        self.msg += "with schema type: {schema_type} but received value: {value}"
-        self.schema_type_msg = "Schema: {expected_schema} has type: {schema_type} "
-        self.schema_type_msg += "but received datum: {datum}"
+        self.msg = "Class: [{class_name}] expects field: [{field_name}] "
+        self.msg += "with schema type: [{schema_type}] but received value: [{value}]"
+        self.schema_type_msg = "Schema: [{expected_schema}] has type: [{schema_type}] "
+        self.schema_type_msg += "but received datum: [{datum}]"
 
     def update_class(self, class_name, field_name, schema_type, value):
         self.messages.append(self.msg.format(
@@ -147,12 +147,12 @@ class ProtocolElement(object):
         return self.validate(self.toJsonDict())
 
     @classmethod
-    def validate(cls, jsonDict, debug=False):
+    def validate(cls, jsonDict, verbose=False):
         """
         Validates the specified JSON dictionary to determine if it is an
         instance of this element's schema.
         """
-        if debug:
+        if verbose:
             validation_result = ValidationResult()
             return cls.validate_debug(jsonDict=jsonDict, validation_result=validation_result)
         return avro.io.validate(expected_schema=cls.schema, datum=jsonDict)
@@ -211,7 +211,7 @@ class ProtocolElement(object):
         elif schema_type == 'enum':
             if datum not in expected_schema.symbols:
                 validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
-                custom_message = "datum: {datum} not contained within symbols: {enum}".format(
+                custom_message = "datum: [{datum}] not contained within symbols: [{enum}]".format(
                     datum=datum, enum=expected_schema.symbols,
                 )
                 validation_result.update_custom(custom_message=custom_message)

--- a/protocols/protocol.py
+++ b/protocols/protocol.py
@@ -5,7 +5,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import copy
 import sys
 import json
 import inspect
@@ -25,6 +24,37 @@ class ProtocolElementEncoder(json.JSONEncoder):
         else:
             ret = super(ProtocolElementEncoder, self).default(obj)
         return ret
+
+
+class ValidationResult(object):
+
+    def __init__(self, result=None, messages=None):
+        self.result = result or True
+        self.messages = messages or []
+        self.msg = "Class: {class_name} expects field: {field_name} "
+        self.msg += "with schema type: {schema_type} but received value: {value}"
+        self.schema_type_msg = "Schema: {expected_schema} has type: {schema_type} "
+        self.schema_type_msg += "but received datum: {datum}"
+
+    def update_class(self, class_name, field_name, schema_type, value):
+        self.messages.append(self.msg.format(
+            class_name=class_name,
+            field_name=field_name,
+            schema_type=schema_type,
+            value=value
+        ))
+
+    def update_simple(self, expected_schema, schema_type, datum):
+        self.result = False
+        self.messages.append(self.schema_type_msg.format(
+            expected_schema=expected_schema,
+            schema_type=schema_type,
+            datum=datum,
+        ))
+
+    def update_custom(self, custom_message):
+        self.result = False
+        self.messages.append(custom_message)
 
 
 class ProtocolElement(object):
@@ -106,7 +136,6 @@ class ProtocolElement(object):
             else:
                 out[field.name] = avro.io.validate(field.type, val)
 
-
         return out
 
     def extended_validation(self):
@@ -117,15 +146,122 @@ class ProtocolElement(object):
                     return False
         return self.validate(self.toJsonDict())
 
-
     @classmethod
-    def validate(cls, jsonDict):
+    def validate(cls, jsonDict, debug=False):
         """
         Validates the specified JSON dictionary to determine if it is an
         instance of this element's schema.
         """
-        return avro.io.validate(cls.schema, jsonDict)
+        if debug:
+            validation_result = ValidationResult()
+            return cls.validate_debug(jsonDict=jsonDict, validation_result=validation_result)
+        return avro.io.validate(expected_schema=cls.schema, datum=jsonDict)
 
+    @classmethod
+    def validate_debug(cls, jsonDict, validation_result, expected_schema=None):
+        """
+        Returns ValidationResult with fields:
+                - result (True or False)
+                - messages (List of message strings ideally to help debug the problem)
+        """
+        INT_MIN_VALUE = -(1 << 31)
+        INT_MAX_VALUE = (1 << 31) - 1
+        LONG_MIN_VALUE = -(1 << 63)
+        LONG_MAX_VALUE = (1 << 63) - 1
+        expected_schema = expected_schema or cls.schema
+        datum = jsonDict
+        schema_type = expected_schema.type
+        if schema_type == 'null':
+            if not (datum is None):
+                validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
+        elif schema_type == 'boolean':
+            if not isinstance(datum, bool):
+                validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
+        elif schema_type == 'string':
+            if not isinstance(datum, basestring):
+                validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
+        elif schema_type == 'bytes':
+            if not isinstance(datum, str):
+                validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
+        elif schema_type == 'int':
+            if not ((isinstance(datum, int) or isinstance(datum, long)) and INT_MIN_VALUE <= datum <= INT_MAX_VALUE):
+                validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
+                custom_message = "{INT_MIN_VALUE} <= {datum} <= {INT_MAX_VALUE}".format(
+                    INT_MIN_VALUE=INT_MIN_VALUE, datum=datum, INT_MAX_VALUE=INT_MAX_VALUE,
+                )
+                validation_result.update_custom(custom_message=custom_message)
+        elif schema_type == 'long':
+            if not ((isinstance(datum, int) or isinstance(datum, long)) and LONG_MIN_VALUE <= datum <= LONG_MAX_VALUE):
+                validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
+                custom_message = "{LONG_MIN_VALUE} <= {datum} <= {LONG_MAX_VALUE}".format(
+                    LONG_MIN_VALUE=LONG_MIN_VALUE, datum=datum, LONG_MAX_VALUE=LONG_MAX_VALUE,
+                )
+                validation_result.update_custom(custom_message=custom_message)
+        elif schema_type in ['float', 'double']:
+            if not (isinstance(datum, int) or isinstance(datum, long) or isinstance(datum, float)):
+                validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
+        elif schema_type == 'fixed':
+            if not (isinstance(datum, str) and len(datum) == expected_schema.size):
+                validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
+                message_template = "Length of datum: {datum_length} does not match expected schema size: {schema_size}"
+                custom_message = message_template.format(
+                    datum_length=len(datum), schema_size=expected_schema.size,
+                )
+                validation_result.update_custom(custom_message=custom_message)
+        elif schema_type == 'enum':
+            if datum not in expected_schema.symbols:
+                validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
+                custom_message = "datum: {datum} not contained within symbols: {enum}".format(
+                    datum=datum, enum=expected_schema.symbols,
+                )
+                validation_result.update_custom(custom_message=custom_message)
+        elif schema_type == 'array':
+            if not isinstance(datum, list):
+                validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
+            if isinstance(datum, list):
+                for data in datum:
+                    if not avro.io.validate(expected_schema=expected_schema.items, datum=data):
+                        validation_result.update_simple(
+                            expected_schema=expected_schema.items, schema_type=expected_schema.items.type, datum=data
+                        )
+        elif schema_type == 'map':
+            if not isinstance(datum, dict):
+                validation_result.update_simple(expected_schema=expected_schema, schema_type=schema_type, datum=datum)
+            elif isinstance(datum, dict):
+                for key in datum.keys():
+                    if not isinstance(key, basestring):
+                        custom_message = "key: {key} must be of type str but it of type: {key_type}".format(
+                            key=key, key_type=type(key),
+                        )
+                        validation_result.update_custom(custom_message=custom_message)
+                for value in datum.values():
+                    if not avro.io.validate(expected_schema=expected_schema.values, datum=value):
+                        validation_result.update_simple(
+                            expected_schema=expected_schema.values, schema_type=expected_schema.values.type, datum=value
+                        )
+        elif schema_type in ['union', 'error_union']:
+            if not any([avro.io.validate(s, datum) for s in expected_schema.schemas]):
+                for expected_schema in expected_schema.schemas:
+                    if not avro.io.validate(expected_schema=expected_schema, datum=datum):
+                        validation_result.update_simple(
+                            expected_schema=expected_schema.values, schema_type=expected_schema.values.type, datum=datum
+                        )
+        elif schema_type in ['record', 'error', 'request']:
+            if isinstance(datum, dict):
+                for f in expected_schema.fields:
+                    if not avro.io.validate(expected_schema=f.type, datum=datum.get(f.name)):
+                        cls.validate_debug(
+                            jsonDict=datum.get(f.name),
+                            validation_result=validation_result,
+                            expected_schema=f.type)
+                        validation_result.update_class(
+                            class_name=expected_schema.name,
+                            field_name=f.name,
+                            schema_type=f.type,
+                            value=datum.get(f.name)
+                        )
+
+        return validation_result
 
     @classmethod
     def fromJsonString(cls, jsonStr):
@@ -201,8 +337,9 @@ def getProtocolClasses(superclass=ProtocolElement):
     # We keep a manual list of the superclasses that we define here
     # so we can filter them out when we're getting the protocol
     # classes.
-    superclasses = set([
-        ProtocolElement, SearchRequest, SearchResponse])
+    superclasses = {
+        ProtocolElement, SearchRequest, SearchResponse
+    }
     thisModule = sys.modules[__name__]
     subclasses = []
     for name, class_ in inspect.getmembers(thisModule):
@@ -211,9 +348,3 @@ def getProtocolClasses(superclass=ProtocolElement):
                 class_ not in superclasses)):
             subclasses.append(class_)
     return subclasses
-
-
-# We can now import the definitions of the protocol elements from the
-# generated file.
-#from participant import *  # NOQA
-

--- a/protocols/tests/test_protocol.py
+++ b/protocols/tests/test_protocol.py
@@ -13,13 +13,13 @@ class TestValidate(TestCase):
         self.assertFalse(variant.validate(jsonDict=variant.toJsonDict()))
 
         # Check the result of validation_result is False
-        validation_result = variant.validate(jsonDict=variant.toJsonDict(), debug=True)
+        validation_result = variant.validate(jsonDict=variant.toJsonDict(), verbose=True)
         self.assertFalse(validation_result.result)
 
         # Check the validation returns the expected messages
-        expected_message_2 = 'Class: ReportedStructuralVariantCancer expects field: end with schema type: "int" but received value: None'
+        expected_message_2 = 'Class: [ReportedStructuralVariantCancer] expects field: [end] with schema type: ["int"] but received value: [None]'
         self.assertEqual(validation_result.messages[2], expected_message_2)
         expected_message_1 = '-2147483648 <= None <= 2147483647'
         self.assertEqual(validation_result.messages[1], expected_message_1)
-        expected_message_0 = 'Schema: "int" has type: int but received datum: None'
+        expected_message_0 = 'Schema: ["int"] has type: [int] but received datum: [None]'
         self.assertEqual(validation_result.messages[0], expected_message_0)

--- a/protocols/tests/test_protocol.py
+++ b/protocols/tests/test_protocol.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+
+from protocols.tests import get_valid_reported_somatic_structural_variant
+
+
+class TestValidate(TestCase):
+
+    def test_validate_debug(self):
+        variant = get_valid_reported_somatic_structural_variant()
+        variant.reportedStructuralVariantCancer.end = None
+
+        # Check variant is not a valid ReportedSomaticStructuralVariants object
+        self.assertFalse(variant.validate(jsonDict=variant.toJsonDict()))
+
+        # Check the result of validation_result is False
+        validation_result = variant.validate(jsonDict=variant.toJsonDict(), debug=True)
+        self.assertFalse(validation_result.result)
+
+        # Check the validation returns the expected messages
+        expected_message_2 = 'Class: ReportedStructuralVariantCancer expects field: end with schema type: "int" but received value: None'
+        self.assertEqual(validation_result.messages[2], expected_message_2)
+        expected_message_1 = '-2147483648 <= None <= 2147483647'
+        self.assertEqual(validation_result.messages[1], expected_message_1)
+        expected_message_0 = 'Schema: "int" has type: int but received datum: None'
+        self.assertEqual(validation_result.messages[0], expected_message_0)


### PR DESCRIPTION
Summary of Changes
=================

* Adds non-breaking change: `debug=False` default parameter to the `ProtocolElement.validate` method
* Tests this in `protocols/tests/test_protocol.py` with the following:
  - Gets a valid `ReportedSomaticStructuralVariants` object
  - Changes `variant.reportedStructuralVariantCancer.end` to `None`
  - Runs `validate` with the new `debug` parameter set to `True`
  - Checks for the presence of the error messages such as: `Class: ReportedStructuralVariantCancer expects field: end with schema type: "int" but received value: None`

Open to ideas for clearer messages or a better way to implement this ! :smile: 

Running Locally:
```
(.env) $ python -m unittest discover protocols
.....
----------------------------------------------------------------------
Ran 5 tests in 0.015s

OK
(.env) $ 
```