### PR TITLE
Feature - Change line length for schema string

### DIFF
--- a/resources/CodeGenerationFromGA4GH/process_schemas.py
+++ b/resources/CodeGenerationFromGA4GH/process_schemas.py
@@ -127,7 +127,9 @@ class SchemaClass(object):
                         if isinstance(dic, dict):
                             stack.append(dic)
         jsonData = json.dumps(schema)
-        output = "\n".join(textwrap.wrap(jsonData)) + "\n"
+        # TODO(Greg): Find a long-term solution for making sure the end of the line
+        # TODO(Greg): in a schema string is not a - character (dash)
+        output = "\n".join(textwrap.wrap(text=jsonData, width=100)) + "\n"
         return output
 
     def writeRequiredFields(self, outputFile):


### PR DESCRIPTION
Summary of Changes
==================

Increasing the line width from the standard 70 to 100 when calling `textwrap.wrap` makes sure that we don't end up with a dash character at the end of a line in a schema string in the python files after they're converted from avro.

We need a more robust solution to this in the future.

After running `python build.py` we can now import models from `protocols.cva`:
```
In [1]: from protocols.cva_0_3_1 import TieredVariantInjectRD

In [2]: from protocols.cva_0_3_1 import ReportedVariantInjectRD

In [3]: from protocols.cva_0_3_1 import EvidenceEntry

In [4]: new_evidence_entry = EvidenceEntry()

In [5]: new_evidence_entry.validate_parts()
Out[5]: 
{u'additionalProperties': [],
 u'alleleOrigin': True,
 u'bibliography': [],
 u'confidence': True,
 u'consistencyStatus': True,
 u'description': True,
 u'ethnicity': False,
 u'genomicFeatures': [],
 u'heritableTraits': [],
 u'id': True,
 u'impact': True,
 u'penetrance': True,
 u'somaticInformation': True,
 u'source': False,
 u'submissions': [],
 u'url': True,
 u'variableExpressivity': True,
 u'variantClassification': True}
```
Tests passing locally:
=================
```
(.env) $ python -m unittest discover protocols
....
----------------------------------------------------------------------
Ran 4 tests in 0.015s

OK
(.env) $ 
```