### PR TITLE
Feature - Build all models by default

### DIFF
--- a/build.py
+++ b/build.py
@@ -174,15 +174,21 @@ def build(models, skip_doc):
 def main():
     parser = argparse.ArgumentParser(
         description='Generate AVPR, JSON, HTML, PYTHON Classes and JAVA Classes from the idls models')
-    parser.add_argument('--models', metavar='models and version',
-                        nargs='+',
-                        default=['org.gel.models.participant.avro::1.0.0', 'org.gel.models.participant.avro::1.0.1',
-                                 'org.gel.models.participant.avro::1.0.2',
-                                 'org.gel.models.metrics.avro::1.0.0', 'org.gel.models.metrics.avro::1.0.1',
-                                 'org.ga4gh.models::3.0.0', 'org.gel.models.report.avro::2.1.0',
-                                 'org.gel.models.report.avro::3.0.0', 'org.gel.models.report.avro::3.1.0',
-                                 'org.opencb.biodata.models::1.2.0-SNAPSHOT'],
-                        help='List of models packages and versions to generated, in the following format package::version')
+    parser.add_argument(
+        '--models',
+        metavar='models and version',
+        nargs='+',
+        default=[
+            'org.gel.models.participant.avro::1.0.0', 'org.gel.models.participant.avro::1.0.1',
+            'org.gel.models.participant.avro::1.0.2',
+            'org.gel.models.metrics.avro::1.0.0', 'org.gel.models.metrics.avro::1.0.1',
+            'org.ga4gh.models::3.0.0',
+            'org.gel.models.report.avro::2.1.0', 'org.gel.models.report.avro::3.0.0',
+            'org.gel.models.report.avro::3.1.0', 'org.gel.models.report.avro::4.0.0',
+            'org.gel.models.cva.avro::0.3.1', 'org.opencb.biodata.models::1.2.0-SNAPSHOT'
+        ],
+        help='List of models packages and versions to generated, in the following format package::version'
+    )
     parser.add_argument('--skip_doc', default=False, action='store_true', help='Documentation will be skipped')
     args = parser.parse_args()
 


### PR DESCRIPTION
Currently in jenkins we use:
```
python build.py --models org.ga4gh.models::3.0.0 org.gel.models.participant.avro::1.0.0 org.gel.models.participant.avro::1.0.1 org.gel.models.participant.avro::1.0.2 org.gel.models.metrics.avro::1.0.0 org.gel.models.metrics.avro::1.0.1  org.gel.models.report.avro::2.1.0 org.gel.models.report.avro::3.0.0 org.gel.models.report.avro::3.1.0 org.gel.models.report.avro::4.0.0 org.gel.models.cva.avro::0.3.1
```
which is annoyingly long to keep track of and add to as we have additional models....
Let's keep them in `build.py` instead.