### PR TITLE
IP-300 - Clinical Report Cancer Object Generation

### DIFF
--- a/protocols/tests/test_util/test_generate_mock_objects.py
+++ b/protocols/tests/test_util/test_generate_mock_objects.py
@@ -47,6 +47,15 @@ class TestGenerateMockObjects4(TestCase):
         self.assertTrue(isinstance(test_cir, self.model.CancerInterpretationRequest))
         self.assertTrue(test_cir.validate(test_cir.toJsonDict()))
 
+    def test_clinical_report_cancer(self):
+        """
+        Ensure generate_mock_objects.get_valid_clinical_report_cancer_4_0_0 returns a valid
+        reports_4_0_0.ClinicalReportCancer object
+        """
+        test_cir = generate_mock_objects.get_valid_clinical_report_cancer_4_0_0()
+        self.assertTrue(isinstance(test_cir, self.model.ClinicalReportCancer))
+        self.assertTrue(test_cir.validate(test_cir.toJsonDict()))
+
 
 class TestGenerateMockObjects31(TestCase):
 
@@ -86,6 +95,15 @@ class TestGenerateMockObjects31(TestCase):
         """
         test_cir = generate_mock_objects.get_valid_cancer_interpretation_request_3_1_0()
         self.assertTrue(isinstance(test_cir, self.model.CancerInterpretationRequest))
+        self.assertTrue(test_cir.validate(test_cir.toJsonDict()))
+
+    def test_clinical_report_cancer(self):
+        """
+        Ensure generate_mock_objects.get_valid_clinical_report_cancer_3_1_0 returns a valid
+        reports_3_1_0.ClinicalReportCancer object
+        """
+        test_cir = generate_mock_objects.get_valid_clinical_report_cancer_3_1_0()
+        self.assertTrue(isinstance(test_cir, self.model.ClinicalReportCancer))
         self.assertTrue(test_cir.validate(test_cir.toJsonDict()))
 
     def test_called_genotype(self):
@@ -165,6 +183,15 @@ class TestGenerateMockObjects3(TestCase):
         self.assertTrue(isinstance(test_cir, self.model.CancerInterpretationRequest))
         self.assertTrue(test_cir.validate(test_cir.toJsonDict()))
 
+    def test_clinical_report_cancer(self):
+        """
+        Ensure generate_mock_objects.get_valid_clinical_report_cancer_3_0_0 returns a valid
+        reports_3_0_0.ClinicalReportCancer object
+        """
+        test_cir = generate_mock_objects.get_valid_clinical_report_cancer_3_0_0()
+        self.assertTrue(isinstance(test_cir, self.model.ClinicalReportCancer))
+        self.assertTrue(test_cir.validate(test_cir.toJsonDict()))
+
 
 class TestGenerateMockObjects21(TestCase):
 
@@ -204,4 +231,13 @@ class TestGenerateMockObjects21(TestCase):
         """
         test_cir = generate_mock_objects.get_valid_cancer_interpretation_request_2_1_0()
         self.assertTrue(isinstance(test_cir, self.model.CancerInterpretationRequest))
+        self.assertTrue(test_cir.validate(test_cir.toJsonDict()))
+
+    def test_clinical_report_cancer(self):
+        """
+        Ensure generate_mock_objects.get_valid_clinical_report_cancer_2_1_0 returns a valid
+        reports_2_1_0.ClinicalReportCancer object
+        """
+        test_cir = generate_mock_objects.get_valid_clinical_report_cancer_2_1_0()
+        self.assertTrue(isinstance(test_cir, self.model.ClinicalReportCancer))
         self.assertTrue(test_cir.validate(test_cir.toJsonDict()))

--- a/protocols/util/__init__.py
+++ b/protocols/util/__init__.py
@@ -24,7 +24,10 @@ from .generate_mock_objects import get_valid_interpreted_genome_rd_4_0_0
 
 from .generate_mock_objects import get_valid_rd_exit_questionnaire_3_0_0
 
+from .generate_mock_objects import get_valid_clinical_report_cancer_2_1_0
 from .generate_mock_objects import get_valid_clinical_report_cancer_3_0_0
+from .generate_mock_objects import get_valid_clinical_report_cancer_3_1_0
+from .generate_mock_objects import get_valid_clinical_report_cancer_4_0_0
 
 from .generate_mock_objects import get_valid_report_version_control_4_0_0
 

--- a/protocols/util/generate_mock_objects.py
+++ b/protocols/util/generate_mock_objects.py
@@ -112,6 +112,21 @@ def validate_object(object_to_validate, object_type):
         raise Exception("New {object_type} object is not valid".format(object_type=object_type))
 
 
+def get_valid_cancer_participant_2_1_0():
+    object_type = reports_2_1_0.CancerParticipant
+    participant = MockModelObject(object_type=object_type).get_valid_empty_object()
+
+    participant.cancerSamples[0].sampleType = reports_2_1_0.SampleType.tumor
+    participant.cancerSamples[0].labId = '1'
+
+    additional_sample = deepcopy(participant.cancerSamples[0])
+    participant.cancerSamples.append(additional_sample)
+    participant.cancerSamples[1].sampleType = reports_2_1_0.SampleType.germline
+    participant.cancerSamples[1].labId = '2'
+
+    return validate_object(object_to_validate=participant, object_type=object_type)
+
+
 def get_valid_cancer_participant_3_0_0():
     participant = MockModelObject(object_type=reports_3_0_0.CancerParticipant).get_valid_empty_object()
     participant.cancerDemographics.sex = 'M'
@@ -570,22 +585,71 @@ def get_valid_cancer_interpreted_genome_3_1_0():
 
 
 def get_valid_cancer_sample_3_0_0():
-    new_sample = MockModelObject(object_type=reports_3_0_0.CancerSample).get_valid_empty_object()
+    object_type = reports_3_0_0.CancerSample
+    new_sample = MockModelObject(object_type=object_type).get_valid_empty_object()
     new_sample.sampleType = reports_3_0_0.SampleType.germline
 
-    return validate_object(object_to_validate=new_sample, object_type=reports_3_0_0.CancerSample)
+    return validate_object(object_to_validate=new_sample, object_type=object_type)
+
+
+def get_valid_cancer_sample_3_1_0():
+    object_type = reports_3_0_0.CancerSample
+    new_sample = MockModelObject(object_type=object_type).get_valid_empty_object()
+    new_sample.sampleType = reports_3_0_0.SampleType.germline
+
+    return validate_object(object_to_validate=new_sample, object_type=object_type)
+
+
+def get_valid_clinical_report_cancer_2_1_0():
+    object_type = reports_2_1_0.ClinicalReportCancer
+    new_crc = MockModelObject(object_type=object_type).get_valid_empty_object()
+    new_crc.softwareVersions = {'this': 'that'}
+    new_crc.referenceDatabasesVersions = {'this': 'that'}
+    new_crc.candidateStructuralVariants[0] = get_valid_reported_structural_variant_2_1_0()
+    new_crc.candidateVariants[0] = get_valid_reported_variant_2_1_0()
+    new_crc.genePanelsCoverage = {"panel_name": [{"gene1": "gene1_coverage"}]}
+    new_crc.cancerParticipant = get_valid_cancer_participant_2_1_0()
+
+    return validate_object(object_to_validate=new_crc, object_type=object_type)
 
 
 def get_valid_clinical_report_cancer_3_0_0():
-    new_crc = MockModelObject(object_type=reports_3_0_0.ClinicalReportCancer).get_valid_empty_object()
+    object_type = reports_3_0_0.ClinicalReportCancer
+    new_crc = MockModelObject(object_type=object_type).get_valid_empty_object()
     new_crc.softwareVersions = {'this': 'that'}
     new_crc.referenceDatabasesVersions = {'this': 'that'}
     new_crc.candidateStructuralVariants[0] = get_valid_reported_somatic_structural_variant_3_0_0()
     new_crc.candidateVariants[0] = get_valid_reported_somatic_variant_3_0_0()
     new_crc.genePanelsCoverage = {"panel_name": [{"gene1": "gene1_coverage"}]}
-    new_crc.cancerParticipant.cancerSamples[0] = get_valid_cancer_sample_3_0_0()
+    new_crc.cancerParticipant = get_valid_cancer_participant_3_0_0()
 
-    return validate_object(object_to_validate=new_crc, object_type=reports_3_0_0.ClinicalReportCancer)
+    return validate_object(object_to_validate=new_crc, object_type=object_type)
+
+
+def get_valid_clinical_report_cancer_3_1_0():
+    object_type = reports_3_1_0.ClinicalReportCancer
+    new_crc = MockModelObject(object_type=object_type).get_valid_empty_object()
+    new_crc.softwareVersions = {'this': 'that'}
+    new_crc.referenceDatabasesVersions = {'this': 'that'}
+    new_crc.candidateStructuralVariants[0] = get_valid_reported_somatic_structural_variant_3_1_0()
+    new_crc.candidateVariants[0] = get_valid_reported_somatic_variant_3_1_0()
+    new_crc.genePanelsCoverage = {"panel_name": [{"gene1": "gene1_coverage"}]}
+    new_crc.cancerParticipant = get_valid_cancer_participant_3_1_0()
+
+    return validate_object(object_to_validate=new_crc, object_type=object_type)
+
+
+def get_valid_clinical_report_cancer_4_0_0():
+    object_type = reports_4_0_0.ClinicalReportCancer
+    new_crc = MockModelObject(object_type=object_type).get_valid_empty_object()
+    new_crc.softwareVersions = {'this': 'that'}
+    new_crc.referenceDatabasesVersions = {'this': 'that'}
+    new_crc.candidateStructuralVariants[0] = get_valid_reported_somatic_structural_variant_4_0_0()
+    new_crc.candidateVariants[0] = get_valid_reported_somatic_variant_4_0_0()
+    new_crc.genePanelsCoverage = {"panel_name": [{"gene1": "gene1_coverage"}]}
+    new_crc.cancerParticipant = get_valid_cancer_participant_1_0_0()
+
+    return validate_object(object_to_validate=new_crc, object_type=object_type)
 
 
 def get_valid_called_genotype_2_1_0():


### PR DESCRIPTION
[IP-300 - Clinical Report Cancer Object Generation](https://jira.extge.co.uk/browse/IP-300)
====================

Summary of Changes
==================
Allows the generation of valid `ClinicalReportCancer` objects in each version of the model
* Add `get_valid_clinical_report_cancer_2_1_0`, `3_1_0` and `4_0_0`
* Add tests for `get_valid_clinical_report_cancer_2_1_0`, `3_0_0`, `3_1_0` and `4_0_0`

Tests Passing Locally
=================
```
(.env) $ python -m unittest discover
...............................
----------------------------------------------------------------------
Ran 31 tests in 0.283s

OK
(.env) $ 
```