### PR TITLE
IP-311 - Clinical Report RD Object Generaton

### DIFF
--- a/protocols/tests/test_util/test_generate_mock_objects.py
+++ b/protocols/tests/test_util/test_generate_mock_objects.py
@@ -65,6 +65,16 @@ class TestGenerateMockObjects4(TestCase):
         self.assertTrue(isinstance(test_cir, self.model.RareDiseaseExitQuestionnaire))
         self.assertTrue(test_cir.validate(test_cir.toJsonDict()))
 
+    def test_clinical_report_rd(self):
+        """
+        Ensure generate_mock_objects.get_valid_clinical_report_rd_4_0_0 returns a valid
+        reports_4_0_0.ClinicalReportRD object
+        """
+        test_cr_rd = generate_mock_objects.get_valid_clinical_report_rd_4_0_0()
+        self.assertTrue(isinstance(test_cr_rd, self.model.ClinicalReportRD))
+        self.assertTrue(test_cr_rd.validate(test_cr_rd.toJsonDict()))
+
+
 
 class TestGenerateMockObjects31(TestCase):
 
@@ -105,6 +115,15 @@ class TestGenerateMockObjects31(TestCase):
         test_cir = generate_mock_objects.get_valid_cancer_interpretation_request_3_1_0()
         self.assertTrue(isinstance(test_cir, self.model.CancerInterpretationRequest))
         self.assertTrue(test_cir.validate(test_cir.toJsonDict()))
+
+    def test_clinical_report_rd(self):
+        """
+        Ensure generate_mock_objects.get_valid_clinical_report_rd_3_1_0 returns a valid
+        reports_3_1_0.ClinicalReportRD object
+        """
+        test_cr_rd = generate_mock_objects.get_valid_clinical_report_rd_3_1_0()
+        self.assertTrue(isinstance(test_cr_rd, self.model.ClinicalReportRD))
+        self.assertTrue(test_cr_rd.validate(test_cr_rd.toJsonDict()))
 
     def test_clinical_report_cancer(self):
         """
@@ -201,6 +220,15 @@ class TestGenerateMockObjects3(TestCase):
         self.assertTrue(isinstance(test_cir, self.model.CancerInterpretationRequest))
         self.assertTrue(test_cir.validate(test_cir.toJsonDict()))
 
+    def test_clinical_report_rd(self):
+        """
+        Ensure generate_mock_objects.get_valid_clinical_report_rd_3_0_0 returns a valid
+        reports_3_0_0.ClinicalReportRD object
+        """
+        test_cr_rd = generate_mock_objects.get_valid_clinical_report_rd_3_0_0()
+        self.assertTrue(isinstance(test_cr_rd, self.model.ClinicalReportRD))
+        self.assertTrue(test_cr_rd.validate(test_cr_rd.toJsonDict()))
+
     def test_clinical_report_cancer(self):
         """
         Ensure generate_mock_objects.get_valid_clinical_report_cancer_3_0_0 returns a valid
@@ -259,6 +287,15 @@ class TestGenerateMockObjects21(TestCase):
         test_cir = generate_mock_objects.get_valid_cancer_interpretation_request_2_1_0()
         self.assertTrue(isinstance(test_cir, self.model.CancerInterpretationRequest))
         self.assertTrue(test_cir.validate(test_cir.toJsonDict()))
+
+    def test_clinical_report_rd(self):
+        """
+        Ensure generate_mock_objects.get_valid_clinical_report_rd_2_1_0 returns a valid
+        reports_2_1_0.ClinicalReportRD object
+        """
+        test_cr_rd = generate_mock_objects.get_valid_clinical_report_rd_2_1_0()
+        self.assertTrue(isinstance(test_cr_rd, self.model.ClinicalReportRD))
+        self.assertTrue(test_cr_rd.validate(test_cr_rd.toJsonDict()))
 
     def test_clinical_report_cancer(self):
         """

--- a/protocols/util/__init__.py
+++ b/protocols/util/__init__.py
@@ -1,4 +1,3 @@
-# TODO(Greg): Generate functionality for the commented imports
 from .avro_util import handle_avro_errors
 
 from .generate_mock_objects import get_valid_file_4_0_0
@@ -8,9 +7,10 @@ from .generate_mock_objects import get_valid_reported_variant_3_0_0
 from .generate_mock_objects import get_valid_reported_variant_3_1_0
 from .generate_mock_objects import get_valid_reported_variant_4_0_0
 
+from .generate_mock_objects import get_valid_clinical_report_rd_2_1_0
 from .generate_mock_objects import get_valid_clinical_report_rd_3_0_0
-# from .generate_mock_objects import get_valid_clinical_report_rd_3_1_0
-# from .generate_mock_objects import get_valid_clinical_report_rd_4_0_0
+from .generate_mock_objects import get_valid_clinical_report_rd_3_1_0
+from .generate_mock_objects import get_valid_clinical_report_rd_4_0_0
 
 from .generate_mock_objects import get_valid_cancer_participant_3_0_0
 from .generate_mock_objects import get_valid_cancer_participant_3_1_0

--- a/protocols/util/generate_mock_objects.py
+++ b/protocols/util/generate_mock_objects.py
@@ -70,6 +70,7 @@ class MockModelObject(object):
             reports_2_1_0.ReportedStructuralVariant,
             reports_3_0_0.ReportedStructuralVariant,
             reports_3_1_0.ReportedStructuralVariant,
+            reports_4_0_0.ReportedStructuralVariant,
             reports_3_0_0.VariantGroupLevelQuestions,
             reports_3_1_0.VariantGroupLevelQuestions,
             reports_4_0_0.VariantGroupLevelQuestions,
@@ -566,15 +567,51 @@ def get_valid_cancer_interpretation_request_3_0_0():
     return validate_object(object_to_validate=new_cir, object_type=reports_3_0_0.CancerInterpretationRequest)
 
 
+def get_valid_clinical_report_rd_2_1_0():
+    object_type = reports_2_1_0.ClinicalReportRD
+    new_cr_rd = MockModelObject(object_type=object_type).get_valid_empty_object()
+    new_cr_rd.candidateVariants[0] = get_valid_reported_variant_2_1_0()
+    new_cr_rd.candidateStructuralVariants[0] = get_valid_reported_structural_variant_2_1_0()
+    new_cr_rd.softwareVersions = {'this': 'that'}
+    new_cr_rd.referenceDatabasesVersions = {'this': 'that'}
+
+    return validate_object(object_to_validate=new_cr_rd, object_type=object_type)
+
+
 def get_valid_clinical_report_rd_3_0_0():
-    new_cr_rd = MockModelObject(object_type=reports_3_0_0.ClinicalReportRD).get_valid_empty_object()
+    object_type = reports_3_0_0.ClinicalReportRD
+    new_cr_rd = MockModelObject(object_type=object_type).get_valid_empty_object()
     new_cr_rd.candidateVariants[0] = get_valid_reported_variant_3_0_0()
     new_cr_rd.candidateStructuralVariants[0] = get_valid_reported_structural_variant_3_0_0()
     new_cr_rd.softwareVersions = {'this': 'that'}
     new_cr_rd.referenceDatabasesVersions = {'this': 'that'}
     new_cr_rd.additionalAnalysisPanels = [new_cr_rd.additionalAnalysisPanels]
 
-    return validate_object(object_to_validate=new_cr_rd, object_type=reports_3_0_0.ClinicalReportRD)
+    return validate_object(object_to_validate=new_cr_rd, object_type=object_type)
+
+
+def get_valid_clinical_report_rd_3_1_0():
+    object_type = reports_3_1_0.ClinicalReportRD
+    new_cr_rd = MockModelObject(object_type=object_type).get_valid_empty_object()
+    new_cr_rd.candidateVariants[0] = get_valid_reported_variant_3_1_0()
+    new_cr_rd.candidateStructuralVariants[0] = get_valid_reported_structural_variant_3_1_0()
+    new_cr_rd.softwareVersions = {'this': 'that'}
+    new_cr_rd.referenceDatabasesVersions = {'this': 'that'}
+    new_cr_rd.additionalAnalysisPanels = [new_cr_rd.additionalAnalysisPanels]
+
+    return validate_object(object_to_validate=new_cr_rd, object_type=object_type)
+
+
+def get_valid_clinical_report_rd_4_0_0():
+    object_type = reports_4_0_0.ClinicalReportRD
+    new_cr_rd = MockModelObject(object_type=object_type).get_valid_empty_object()
+    new_cr_rd.candidateVariants[0] = get_valid_reported_variant_4_0_0()
+    new_cr_rd.candidateStructuralVariants[0] = get_valid_reported_structural_variant_4_0_0()
+    new_cr_rd.softwareVersions = {'this': 'that'}
+    new_cr_rd.referenceDatabasesVersions = {'this': 'that'}
+    new_cr_rd.additionalAnalysisPanels = [new_cr_rd.additionalAnalysisPanels]
+
+    return validate_object(object_to_validate=new_cr_rd, object_type=object_type)
 
 
 def get_valid_cancer_interpreted_genome_3_0_0():


### PR DESCRIPTION
[IP-311 - Clinical Report RD Object Generaton](https://jira.extge.co.uk/browse/IP-311)
===================

Summary of Changes
=================
* Functionality for generating `ClinicalReportRD` objects at versions 2.1, 3.1 and 4.0 of the models
* Add tests for functions for versions 2.1, 3.0, 3.1 and 4.0

Tests Passing Locally
=================
```
(.env) $ python -m unittest discover
......................................
----------------------------------------------------------------------
Ran 38 tests in 0.188s

OK
(.env) $ 
```