### PR TITLE
Feature - Migrations to reports_4_2_0_SNAPSHOT

### DIFF
--- a/protocols/migration/__init__.py
+++ b/protocols/migration/__init__.py
@@ -1,0 +1,3 @@
+from .migration import Migration2_1To3
+
+from .migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT import MigrateReports3To420SNAPSHOT

--- a/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -1,0 +1,126 @@
+from protocols import reports_3_0_0
+from protocols import reports_4_2_0_SNAPSHOT
+from protocols.util import handle_avro_errors
+from protocols.migration.participants import MigrationReportsToParticipants1
+from protocols.migration.participants import MigrationParticipants100To103SNAPSHOT
+
+
+class MigrateReports3To420SNAPSHOT(object):
+    old_model = reports_3_0_0
+    new_model = reports_4_2_0_SNAPSHOT
+
+    def migrate_interpretation_request_rd(self, old_interpretation_request_rd):
+        """
+        :type old_interpretation_request_rd: reports_3_0_0.InterpretationRequestRD
+        :rtype: reports_4_2_0_SNAPSHOT.InterpretationRequestRD
+        """
+        new_interpretation_request = self.new_model.InterpretationRequestRD.fromJsonDict(
+            jsonDict=old_interpretation_request_rd.toJsonDict()
+        )
+
+        for participant in old_interpretation_request_rd.pedigree.participants:
+            if participant.samples is None:
+                participant.samples = []
+
+        migrated_pedigree_1_0_1 = MigrationReportsToParticipants1().migrate_pedigree(pedigree=old_interpretation_request_rd.pedigree)
+        migrated_pedigree = MigrationParticipants100To103SNAPSHOT().migrate_pedigree(old_pedigree=migrated_pedigree_1_0_1)
+
+        new_interpretation_request.pedigree = reports_4_2_0_SNAPSHOT.Pedigree.fromJsonDict(migrated_pedigree.toJsonDict())
+
+        new_interpretation_request.interpretationRequestVersion = old_interpretation_request_rd.InterpretationRequestVersion
+        new_interpretation_request.interpretationRequestId = old_interpretation_request_rd.InterpretationRequestID
+        new_interpretation_request.tieringVersion = old_interpretation_request_rd.TieringVersion
+        new_interpretation_request.tieredVariants = self.migrate_tiered_variants(old_tiered_variants=old_interpretation_request_rd.TieredVariants)
+        new_interpretation_request.bams = self.migrate_files(old_files=old_interpretation_request_rd.BAMs)
+        new_interpretation_request.vcfs = self.migrate_files(old_files=old_interpretation_request_rd.VCFs)
+        new_interpretation_request.bigWigs = self.migrate_files(old_files=old_interpretation_request_rd.bigWigs)
+        new_interpretation_request.pedigreeDiagram = self.migrate_file(old_file=old_interpretation_request_rd.pedigreeDiagram)
+        new_interpretation_request.annotationFile = self.migrate_file(old_file=old_interpretation_request_rd.annotationFile)
+        new_interpretation_request.analysisReturnUri = old_interpretation_request_rd.analysisReturnURI
+        new_interpretation_request.internalStudyId = ''
+
+        if new_interpretation_request.validate(new_interpretation_request.toJsonDict()):
+            return new_interpretation_request
+        else:
+            raise Exception(
+                'This model can not be converted: ', handle_avro_errors(new_interpretation_request.validate_parts())
+            )
+
+    def migrate_report_event(self, old_report_event):
+        new_report_event = self.new_model.ReportEvent.fromJsonDict(old_report_event.toJsonDict())
+        variant_classification_map = {
+            self.old_model.VariantClassification.PATHOGENIC: self.new_model.VariantClassification.pathogenic_variant,
+            self.old_model.VariantClassification.LIKELY_PATHOGENIC: self.new_model.VariantClassification.likely_pathogenic_variant,
+            self.old_model.VariantClassification.VUS: self.new_model.VariantClassification.variant_of_unknown_clinical_significance,
+            self.old_model.VariantClassification.LIKELY_BENIGN: self.new_model.VariantClassification.likely_benign_variant,
+            self.old_model.VariantClassification.BENIGN: self.new_model.VariantClassification.benign_variant,
+        }
+        new_report_event.variantClassification = variant_classification_map.get(
+            old_report_event.variantClassification, self.new_model.VariantClassification.not_assessed
+        )
+
+        if new_report_event.validate(new_report_event.toJsonDict()):
+            return new_report_event
+        else:
+            raise Exception(
+                'This model can not be converted: ', handle_avro_errors(new_report_event.validate_parts())
+            )
+
+    def migrate_report_events(self, old_report_events):
+        return [self.migrate_report_event(old_report_event) for old_report_event in old_report_events]
+
+    def migrate_tiered_variant(self, old_tiered_variant):
+        new_tiered_variant = self.new_model.ReportedVariant.fromJsonDict(old_tiered_variant.toJsonDict())
+        new_tiered_variant.dbSnpId = old_tiered_variant.dbSNPid
+        new_tiered_variant.reportEvents = self.migrate_report_events(old_report_events=old_tiered_variant.reportEvents)
+
+        if new_tiered_variant.validate(new_tiered_variant.toJsonDict()):
+            return new_tiered_variant
+        else:
+            raise Exception(
+                'This model can not be converted: ', handle_avro_errors(new_tiered_variant.validate_parts())
+            )
+
+    def migrate_tiered_variants(self, old_tiered_variants):
+        return [self.migrate_tiered_variant(old_tiered_variant=old_tiered_variant) for old_tiered_variant in old_tiered_variants]
+
+    def migrate_file(self, old_file):
+        new_file = self.new_model.File(
+                fileType=old_file.fileType,
+                uriFile=old_file.URIFile,
+                sampleId=old_file.SampleId,
+                md5Sum=old_file.md5Sum,
+            )
+        if new_file.validate(new_file.toJsonDict()):
+            return new_file
+        else:
+            raise Exception(
+                'This model can not be converted: ', handle_avro_errors(new_file.validate_parts())
+            )
+
+    def migrate_files(self, old_files):
+        return [self.migrate_file(old_file=old_file) for old_file in old_files]
+
+    def migrate_life_status(self, life_status):
+        life_status_map = {
+            self.old_model.LifeStatus.alive: self.new_model.LifeStatus.ALIVE,
+            self.old_model.LifeStatus.aborted: self.new_model.LifeStatus.ABORTED,
+            self.old_model.LifeStatus.deceased: self.new_model.LifeStatus.DECEASED,
+            self.old_model.LifeStatus.unborn: self.new_model.LifeStatus.UNBORN,
+            self.old_model.LifeStatus.stillborn: self.new_model.LifeStatus.STILLBORN,
+            self.old_model.LifeStatus.miscarriage: self.new_model.LifeStatus.MISCARRIAGE,
+        }
+        migrated_life_status = life_status_map.get(life_status)
+        if migrated_life_status is None:
+            raise ValueError(
+                "Life status: [{life_status}] is not a valid life status for {object_type}".format(
+                    life_status=life_status, object_type=self.old_model.LifeStatus
+                )
+            )
+
+        if migrated_life_status.validate(migrated_life_status.toJsonDict()):
+            return migrated_life_status
+        else:
+            raise Exception(
+                'This model can not be converted: ', handle_avro_errors(migrated_life_status.validate_parts())
+            )

--- a/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -85,17 +85,23 @@ class MigrateReports3To420SNAPSHOT(object):
         return [self.migrate_tiered_variant(old_tiered_variant=old_tiered_variant) for old_tiered_variant in old_tiered_variants]
 
     def migrate_file(self, old_file):
+        if old_file is None:
+            return None
+        if isinstance(old_file.SampleId, list):
+            sampleId = old_file.SampleId
+        else:
+            sampleId = [old_file.SampleId]
         new_file = self.new_model.File(
                 fileType=old_file.fileType,
                 uriFile=old_file.URIFile,
-                sampleId=old_file.SampleId,
+                sampleId=sampleId,
                 md5Sum=old_file.md5Sum,
             )
         if new_file.validate(new_file.toJsonDict()):
             return new_file
         else:
             raise Exception(
-                'This model can not be converted: ', handle_avro_errors(new_file.validate_parts())
+                'This model can not be converted: ', handle_avro_errors(new_file.validate_parts()), new_file.validate(new_file.toJsonDict(), verbose=True).messages
             )
 
     def migrate_files(self, old_files):

--- a/protocols/migration/participants.py
+++ b/protocols/migration/participants.py
@@ -1,6 +1,66 @@
 from protocols import reports_3_0_0 as participant_old
 from protocols import participant_1_0_0
 from protocols import participant_1_0_1
+from protocols import participant_1_0_3_SNAPSHOT
+from protocols.util import handle_avro_errors
+
+
+class MigrationParticipants100To103SNAPSHOT(object):
+    old_model = participant_1_0_1
+    new_model = participant_1_0_3_SNAPSHOT
+
+    def migrate_pedigree(self, old_pedigree):
+        new_pedigree = self.new_model.Pedigree.fromJsonDict(old_pedigree.toJsonDict())
+        new_pedigree.versionControl = self.new_model.VersionControl()
+
+        new_pedigree.members = self.migrate_members(old_members=old_pedigree.members)
+
+        if new_pedigree.validate(new_pedigree.toJsonDict()):
+            return new_pedigree
+        else:
+            raise Exception(
+                'This model can not be converted: ', handle_avro_errors(new_pedigree.validate_parts())
+            )
+
+    def migrate_chiSquare1KGenomesPhase3Pop(self, old_chiSquare1KGenomesPhase3Pop):
+        new_chiSquare1KGenomesPhase3Pop = self.new_model.ChiSquare1KGenomesPhase3Pop.fromJsonDict(old_chiSquare1KGenomesPhase3Pop.toJsonDict())
+        new_chiSquare1KGenomesPhase3Pop.kgPopCategory = old_chiSquare1KGenomesPhase3Pop.kGPopCategory
+        new_chiSquare1KGenomesPhase3Pop.kgSuperPopCategory = old_chiSquare1KGenomesPhase3Pop.kGSuperPopCategory
+
+        if new_chiSquare1KGenomesPhase3Pop.validate(new_chiSquare1KGenomesPhase3Pop.toJsonDict()):
+            return new_chiSquare1KGenomesPhase3Pop
+        else:
+            raise Exception(
+                'This model can not be converted: ', handle_avro_errors(new_chiSquare1KGenomesPhase3Pop.validate_parts())
+            )
+
+    def migrate_chiSquare1KGenomesPhase3Pops(self, old_chiSquare1KGenomesPhase3Pops):
+        return [self.migrate_chiSquare1KGenomesPhase3Pop(old_chiSquare1KGenomesPhase3Pop) for old_chiSquare1KGenomesPhase3Pop in old_chiSquare1KGenomesPhase3Pops]
+
+    def migrate_ancestries(self, old_ancestries):
+        new_ancestries = self.new_model.Ancestries.fromJsonDict(old_ancestries.toJsonDict())
+        new_ancestries.chiSquare1KGenomesPhase3Pop = self.migrate_chiSquare1KGenomesPhase3Pops(old_ancestries.chiSquare1KGenomesPhase3Pop)
+
+        if new_ancestries.validate(new_ancestries.toJsonDict()):
+            return new_ancestries
+        else:
+            raise Exception(
+                'This model can not be converted: ', handle_avro_errors(new_ancestries.validate_parts())
+            )
+
+    def migrate_member(self, old_member):
+        new_member = self.new_model.PedigreeMember.fromJsonDict(old_member.toJsonDict())
+        new_member.ancestries = self.migrate_ancestries(old_ancestries=old_member.ancestries)
+
+        if new_member.validate(new_member.toJsonDict()):
+            return new_member
+        else:
+            raise Exception(
+                'This model can not be converted: ', handle_avro_errors(new_member.validate_parts())
+            )
+
+    def migrate_members(self, old_members):
+        return [self.migrate_member(old_member=old_member) for old_member in old_members]
 
 
 class MigrationReportsToParticipants1(object):

--- a/protocols/migration/participants.py
+++ b/protocols/migration/participants.py
@@ -35,6 +35,8 @@ class MigrationParticipants100To103SNAPSHOT(object):
             )
 
     def migrate_chiSquare1KGenomesPhase3Pops(self, old_chiSquare1KGenomesPhase3Pops):
+        if old_chiSquare1KGenomesPhase3Pops is None:
+            return None
         return [self.migrate_chiSquare1KGenomesPhase3Pop(old_chiSquare1KGenomesPhase3Pop) for old_chiSquare1KGenomesPhase3Pop in old_chiSquare1KGenomesPhase3Pops]
 
     def migrate_ancestries(self, old_ancestries):
@@ -82,7 +84,6 @@ class MigrationReportsToParticipants1(object):
         if new_pedigree.validate(new_pedigree.toJsonDict()):
             return new_pedigree
         else:
-            print new_pedigree.validate_parts()
             raise Exception('This model can not be converted')
 
     def migrate_pedigree_member(self, member, sample_id_to_lab_sample_id=None):
@@ -296,10 +297,3 @@ class MigrationParticipants1ToReports(object):
         else:
             print new_analysis_panel.validate_parts()
             raise Exception('This model can not be converted')
-
-
-
-
-
-
-

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+
+from protocols.migration import MigrateReports3To420SNAPSHOT
+from protocols.reports_4_2_0_SNAPSHOT import InterpretationRequestRD as InterpretationRequestRD_new
+from protocols.reports_3_0_0 import InterpretationRequestRD as InterpretationRequestRD_old
+from protocols.util import get_valid_interpretation_request_rd_3_0_0
+
+
+class TestMigrateReports3To420SNAPSHOT(TestCase):
+
+    def test_migrate_interpretation_request(self):
+
+        old_interpretation_request_rd = get_valid_interpretation_request_rd_3_0_0()
+
+        # Check old_interpretation_request_rd is a valid reports_3_0_0 ReportedSomaticVariants object
+        self.assertTrue(isinstance(old_interpretation_request_rd, InterpretationRequestRD_old))
+        self.assertTrue(old_interpretation_request_rd.validate(jsonDict=old_interpretation_request_rd.toJsonDict()))
+
+        migrated_object = MigrateReports3To420SNAPSHOT().migrate_interpretation_request_rd(
+            old_interpretation_request_rd=old_interpretation_request_rd
+        )
+
+        # Check migrated_object is a valid reports_4_2_0_SNAPSHOT InterpretationRequestRD object
+        self.assertTrue(isinstance(migrated_object, InterpretationRequestRD_new))
+        self.assertTrue(migrated_object.validate(jsonDict=migrated_object.toJsonDict()))

--- a/protocols/tests/test_util/test_generate_mock_objects.py
+++ b/protocols/tests/test_util/test_generate_mock_objects.py
@@ -4,7 +4,22 @@ from protocols import reports_2_1_0
 from protocols import reports_3_0_0
 from protocols import reports_3_1_0
 from protocols import reports_4_0_0
+from protocols import reports_4_2_0_SNAPSHOT
 from protocols.util import generate_mock_objects
+
+
+class TestGenerateMockObjects420SNAPSHOT(TestCase):
+
+    model = reports_4_2_0_SNAPSHOT
+
+    def test_interpretation_request_rd(self):
+        """
+        Ensure generate_mock_objects.get_valid_interpretation_request_rd_4_2_0_SNAPSHOT returns a valid
+        reports_4_2_0_SNAPSHOT.InterpretationRequestRD object
+        """
+        test_ir_rd = generate_mock_objects.get_valid_interpretation_request_rd_4_2_0_SNAPSHOT()
+        self.assertTrue(isinstance(test_ir_rd, self.model.InterpretationRequestRD))
+        self.assertTrue(test_ir_rd.validate(test_ir_rd.toJsonDict()))
 
 
 class TestGenerateMockObjects4(TestCase):

--- a/protocols/util/__init__.py
+++ b/protocols/util/__init__.py
@@ -2,6 +2,9 @@ from .avro_util import handle_avro_errors
 
 from .generate_mock_objects import get_valid_file_4_0_0
 
+from .generate_mock_objects import get_valid_pedigree_3_0_0
+from .generate_mock_objects import get_valid_pedigree_4_2_0_SNAPSHOT
+
 from .generate_mock_objects import get_valid_reported_variant_2_1_0
 from .generate_mock_objects import get_valid_reported_variant_3_0_0
 from .generate_mock_objects import get_valid_reported_variant_3_1_0
@@ -20,7 +23,6 @@ from .generate_mock_objects import get_valid_interpreted_genome_rd_2_1_0
 from .generate_mock_objects import get_valid_interpreted_genome_rd_3_0_0
 from .generate_mock_objects import get_valid_interpreted_genome_rd_3_1_0
 from .generate_mock_objects import get_valid_interpreted_genome_rd_4_0_0
-
 
 from .generate_mock_objects import get_valid_rd_exit_questionnaire_3_0_0
 from .generate_mock_objects import get_valid_rd_exit_questionnaire_3_1_0

--- a/protocols/util/generate_mock_objects.py
+++ b/protocols/util/generate_mock_objects.py
@@ -4,6 +4,7 @@ from protocols import reports_2_1_0
 from protocols import reports_3_0_0
 from protocols import reports_3_1_0
 from protocols import reports_4_0_0
+from protocols import reports_4_2_0_SNAPSHOT
 from protocols import participant_1_0_0
 
 
@@ -16,22 +17,27 @@ class MockModelObject(object):
     def types_contained_within_array(self):
         return (
             reports_4_0_0.Sample,
+            reports_4_2_0_SNAPSHOT.Sample,
             reports_2_1_0.HpoTerm,
             reports_3_0_0.HpoTerm,
             reports_3_1_0.HpoTerm,
             reports_4_0_0.HpoTerm,
+            reports_4_2_0_SNAPSHOT.HpoTerm,
             reports_2_1_0.Actions,
             reports_3_0_0.Actions,
             reports_3_1_0.Actions,
             reports_4_0_0.Actions,
+            reports_4_2_0_SNAPSHOT.Actions,
             reports_2_1_0.Disorder,
             reports_3_0_0.Disorder,
             reports_3_1_0.Disorder,
             reports_4_0_0.Disorder,
+            reports_4_2_0_SNAPSHOT.Disorder,
             reports_2_1_0.ReportEvent,
             reports_3_0_0.ReportEvent,
             reports_3_1_0.ReportEvent,
             reports_4_0_0.ReportEvent,
+            reports_4_2_0_SNAPSHOT.ReportEvent,
             reports_2_1_0.CancerSample,
             reports_3_0_0.CancerSample,
             reports_3_1_0.CancerSample,
@@ -39,6 +45,7 @@ class MockModelObject(object):
             reports_3_0_0.AnalysisPanel,
             reports_3_1_0.AnalysisPanel,
             reports_4_0_0.AnalysisPanel,
+            reports_4_2_0_SNAPSHOT.AnalysisPanel,
             reports_2_1_0.RDParticipant,
             reports_3_0_0.RDParticipant,
             reports_3_1_0.RDParticipant,
@@ -46,42 +53,53 @@ class MockModelObject(object):
             reports_3_0_0.CalledGenotype,
             reports_3_1_0.CalledGenotype,
             reports_4_0_0.CalledGenotype,
+            reports_4_2_0_SNAPSHOT.CalledGenotype,
             reports_2_1_0.MatchedSamples,
             reports_3_0_0.MatchedSamples,
             reports_3_1_0.MatchedSamples,
             reports_4_0_0.PedigreeMember,
+            reports_4_2_0_SNAPSHOT.PedigreeMember,
             reports_2_1_0.ReportedVariant,
             reports_3_0_0.ReportedVariant,
             reports_3_1_0.ReportedVariant,
             reports_4_0_0.ReportedVariant,
+            reports_4_2_0_SNAPSHOT.ReportedVariant,
             reports_3_0_0.DiseasePenetrance,
             reports_3_1_0.DiseasePenetrance,
             reports_4_0_0.DiseasePenetrance,
+            reports_4_2_0_SNAPSHOT.DiseasePenetrance,
             reports_3_0_0.ReportEventCancer,
             reports_3_1_0.ReportEventCancer,
             reports_4_0_0.ReportEventCancer,
+            reports_4_2_0_SNAPSHOT.ReportEventCancer,
             reports_3_0_0.VariantLevelQuestions,
             reports_3_1_0.VariantLevelQuestions,
             reports_4_0_0.VariantLevelQuestions,
+            reports_4_2_0_SNAPSHOT.VariantLevelQuestions,
             reports_2_1_0.ReportedSomaticVariants,
             reports_3_0_0.ReportedSomaticVariants,
             reports_3_1_0.ReportedSomaticVariants,
             reports_4_0_0.ReportedSomaticVariants,
+            reports_4_2_0_SNAPSHOT.ReportedSomaticVariants,
             reports_2_1_0.ReportedStructuralVariant,
             reports_3_0_0.ReportedStructuralVariant,
             reports_3_1_0.ReportedStructuralVariant,
             reports_4_0_0.ReportedStructuralVariant,
+            reports_4_2_0_SNAPSHOT.ReportedStructuralVariant,
             reports_3_0_0.VariantGroupLevelQuestions,
             reports_3_1_0.VariantGroupLevelQuestions,
             reports_4_0_0.VariantGroupLevelQuestions,
+            reports_4_2_0_SNAPSHOT.VariantGroupLevelQuestions,
             reports_2_1_0.ChiSquare1KGenomesPhase3Pop,
             reports_3_0_0.ChiSquare1KGenomesPhase3Pop,
             reports_3_1_0.ChiSquare1KGenomesPhase3Pop,
             reports_4_0_0.ChiSquare1KGenomesPhase3Pop,
+            reports_4_2_0_SNAPSHOT.ChiSquare1KGenomesPhase3Pop,
             reports_2_1_0.ReportedSomaticStructuralVariants,
             reports_3_0_0.ReportedSomaticStructuralVariants,
             reports_3_1_0.ReportedSomaticStructuralVariants,
             reports_4_0_0.ReportedSomaticStructuralVariants,
+            reports_4_2_0_SNAPSHOT.ReportedSomaticStructuralVariants,
         )
 
     def set_embedded_objects(self, new_gel_object):
@@ -354,6 +372,14 @@ def get_valid_called_genotype_4_0_0():
     return validate_object(object_to_validate=new_cg, object_type=object_type)
 
 
+def get_valid_called_genotype_4_2_0_SNAPSHOT():
+    object_type = reports_4_2_0_SNAPSHOT.CalledGenotype
+    new_cg = MockModelObject(object_type=object_type).get_valid_empty_object()
+    new_cg.genotype = reports_4_2_0_SNAPSHOT.Zygosity.unk
+
+    return validate_object(object_to_validate=new_cg, object_type=object_type)
+
+
 def get_valid_report_event_4_0_0():
     object_type = reports_4_0_0.ReportEvent
     new_report_event = MockModelObject(object_type=object_type).get_valid_empty_object()
@@ -361,6 +387,17 @@ def get_valid_report_event_4_0_0():
     new_report_event.penetrance = reports_4_0_0.Penetrance.complete
     new_report_event.modeOfInheritance = reports_4_0_0.ReportedModeOfInheritance.unknown
     new_report_event.genomicFeature.featureType = reports_4_0_0.FeatureTypes.RegulatoryRegion
+
+    return validate_object(object_to_validate=new_report_event, object_type=object_type)
+
+
+def get_valid_report_event_4_2_0_SNAPSHOT():
+    object_type = reports_4_2_0_SNAPSHOT.ReportEvent
+    new_report_event = MockModelObject(object_type=object_type).get_valid_empty_object()
+    new_report_event.score = 0.0
+    new_report_event.penetrance = reports_4_2_0_SNAPSHOT.Penetrance.complete
+    new_report_event.modeOfInheritance = reports_4_2_0_SNAPSHOT.ReportedModeOfInheritance.unknown
+    new_report_event.genomicFeature.featureType = reports_4_2_0_SNAPSHOT.FeatureTypes.RegulatoryRegion
 
     return validate_object(object_to_validate=new_report_event, object_type=object_type)
 
@@ -374,6 +411,21 @@ def get_valid_reported_variant_4_0_0():
     new_rv.evidenceIds = {}
     new_rv.comments = ['']
     new_rv.dbSNPid = ''
+    new_rv.additionalNumericVariantAnnotations = {}
+    new_rv.additionalTextualVariantAnnotations = {}
+
+    return validate_object(object_to_validate=new_rv, object_type=object_type)
+
+
+def get_valid_reported_variant_4_2_0_SNAPSHOT():
+    object_type = reports_4_2_0_SNAPSHOT.ReportedVariant
+    new_rv = MockModelObject(object_type=object_type).get_valid_empty_object()
+    new_rv.calledGenotypes[0] = get_valid_called_genotype_4_2_0_SNAPSHOT()
+    new_rv.reportEvents[0] = get_valid_report_event_4_2_0_SNAPSHOT()
+    new_rv.position = 0
+    new_rv.evidenceIds = {}
+    new_rv.comments = ['']
+    new_rv.dbSnpId = ''
     new_rv.additionalNumericVariantAnnotations = {}
     new_rv.additionalTextualVariantAnnotations = {}
 
@@ -804,6 +856,13 @@ def get_valid_disease_penetrance_4_0_0():
 
     return validate_object(object_to_validate=dp, object_type=object_type)
 
+def get_valid_disease_penetrance_4_2_0_SNAPSHOT():
+    object_type = reports_4_2_0_SNAPSHOT.DiseasePenetrance
+    dp = MockModelObject(object_type=object_type).get_valid_empty_object()
+    dp.penetrance = reports_4_2_0_SNAPSHOT.Penetrance.incomplete
+
+    return validate_object(object_to_validate=dp, object_type=object_type)
+
 
 def get_valid_disease_penetrance_3_1_0():
     object_type = reports_3_1_0.DiseasePenetrance
@@ -813,8 +872,24 @@ def get_valid_disease_penetrance_3_1_0():
     return validate_object(object_to_validate=dp, object_type=object_type)
 
 
+def get_valid_disease_penetrance_3_0_0():
+    object_type = reports_3_0_0.DiseasePenetrance
+    dp = MockModelObject(object_type=object_type).get_valid_empty_object()
+    dp.penetrance = reports_3_0_0.Penetrance.incomplete
+
+    return validate_object(object_to_validate=dp, object_type=object_type)
+
+
 def get_valid_sample_4_0_0():
     object_type = reports_4_0_0.Sample
+    sample = MockModelObject(object_type=object_type).get_valid_empty_object()
+    sample.labSampleId = 1
+
+    return validate_object(object_to_validate=sample, object_type=object_type)
+
+
+def get_valid_sample_4_2_0_SNAPSHOT():
+    object_type = reports_4_2_0_SNAPSHOT.Sample
     sample = MockModelObject(object_type=object_type).get_valid_empty_object()
     sample.labSampleId = 1
 
@@ -829,8 +904,23 @@ def get_valid_inbreeding_coefficient_4_0_0():
     return validate_object(object_to_validate=ic, object_type=object_type)
 
 
+def get_valid_inbreeding_coefficient_4_2_0_SNAPSHOT():
+    object_type = reports_4_2_0_SNAPSHOT.InbreedingCoefficient
+    ic = MockModelObject(object_type=object_type).get_valid_empty_object()
+    ic.coefficient = 0.0
+
+    return validate_object(object_to_validate=ic, object_type=object_type)
+
+
 def get_valid_inbreeding_coefficient_3_1_0():
     object_type = reports_3_1_0.InbreedingCoefficient
+    ic = MockModelObject(object_type=object_type).get_valid_empty_object()
+    ic.coefficient = 0.0
+
+    return validate_object(object_to_validate=ic, object_type=object_type)
+
+def get_valid_inbreeding_coefficient_3_0_0():
+    object_type = reports_3_0_0.InbreedingCoefficient
     ic = MockModelObject(object_type=object_type).get_valid_empty_object()
     ic.coefficient = 0.0
 
@@ -854,11 +944,29 @@ def get_valid_chi_square_1k_genomes_phase_3_pop_4_0_0():
     return validate_object(object_to_validate=cs, object_type=object_type)
 
 
+def get_valid_chi_square_1k_genomes_phase_3_pop_4_2_0_SNAPSHOT():
+    object_type = reports_4_2_0_SNAPSHOT.ChiSquare1KGenomesPhase3Pop
+    cs = MockModelObject(object_type=object_type).get_valid_empty_object()
+    cs.chiSquare = 0.0
+    cs.kgSuperPopCategory = reports_4_2_0_SNAPSHOT.KgSuperPopCategory.AFR
+
+    return validate_object(object_to_validate=cs, object_type=object_type)
+
+
 def get_valid_chi_square_1k_genomes_phase_3_pop_3_1_0():
     object_type = reports_3_1_0.ChiSquare1KGenomesPhase3Pop
     cs = MockModelObject(object_type=object_type).get_valid_empty_object()
     cs.chiSquare = 0.0
     cs.kgSuperPopCategory = reports_3_1_0.KGSuperPopCategory.AFR
+
+    return validate_object(object_to_validate=cs, object_type=object_type)
+
+
+def get_valid_chi_square_1k_genomes_phase_3_pop_3_0_0():
+    object_type = reports_3_0_0.ChiSquare1KGenomesPhase3Pop
+    cs = MockModelObject(object_type=object_type).get_valid_empty_object()
+    cs.chiSquare = 0.0
+    cs.kGSuperPopCategory = reports_3_0_0.KGSuperPopCategory.AFR
 
     return validate_object(object_to_validate=cs, object_type=object_type)
 
@@ -880,10 +988,26 @@ def get_valid_ancestries_4_0_0():
     return validate_object(object_to_validate=ancestries, object_type=object_type)
 
 
+def get_valid_ancestries_4_2_0_SNAPSHOT():
+    object_type = reports_4_2_0_SNAPSHOT.Ancestries
+    ancestries = MockModelObject(object_type=object_type).get_valid_empty_object()
+    ancestries.chiSquare1KGenomesPhase3Pop[0] = get_valid_chi_square_1k_genomes_phase_3_pop_4_2_0_SNAPSHOT()
+
+    return validate_object(object_to_validate=ancestries, object_type=object_type)
+
+
 def get_valid_ancestries_3_1_0():
     object_type = reports_3_1_0.Ancestries
     ancestries = MockModelObject(object_type=object_type).get_valid_empty_object()
     ancestries.chiSquare1KGenomesPhase3Pop[0] = get_valid_chi_square_1k_genomes_phase_3_pop_3_1_0()
+
+    return validate_object(object_to_validate=ancestries, object_type=object_type)
+
+
+def get_valid_ancestries_3_0_0():
+    object_type = reports_3_0_0.Ancestries
+    ancestries = MockModelObject(object_type=object_type).get_valid_empty_object()
+    ancestries.chiSquare1KGenomesPhase3Pop[0] = get_valid_chi_square_1k_genomes_phase_3_pop_3_0_0()
 
     return validate_object(object_to_validate=ancestries, object_type=object_type)
 
@@ -896,7 +1020,6 @@ def get_valid_ancestries_2_1_0():
     return validate_object(object_to_validate=ancestries, object_type=object_type)
 
 
-
 def get_valid_pedigree_members_4_0_0():
     object_type = reports_4_0_0.PedigreeMember
     member = MockModelObject(object_type=object_type).get_valid_empty_object()
@@ -904,6 +1027,17 @@ def get_valid_pedigree_members_4_0_0():
     member.samples[0] = get_valid_sample_4_0_0()
     member.inbreedingCoefficient = get_valid_inbreeding_coefficient_4_0_0()
     member.ancestries = get_valid_ancestries_4_0_0()
+
+    return validate_object(object_to_validate=member, object_type=object_type)
+
+
+def get_valid_pedigree_members_4_2_0_SNAPSHOT():
+    object_type = reports_4_2_0_SNAPSHOT.PedigreeMember
+    member = MockModelObject(object_type=object_type).get_valid_empty_object()
+    member.sex = reports_4_2_0_SNAPSHOT.Sex.UNKNOWN
+    member.samples[0] = get_valid_sample_4_2_0_SNAPSHOT()
+    member.inbreedingCoefficient = get_valid_inbreeding_coefficient_4_2_0_SNAPSHOT()
+    member.ancestries = get_valid_ancestries_4_2_0_SNAPSHOT()
 
     return validate_object(object_to_validate=member, object_type=object_type)
 
@@ -921,6 +1055,23 @@ def get_valid_pedigree_participant_rd_3_1_0():
     participant.affectionStatus = reports_3_1_0.AffectionStatus.unknown
     participant.consanguineousParents = reports_3_1_0.TernaryOption.unknown
     participant.inbreedingCoefficient = get_valid_inbreeding_coefficient_3_1_0()
+
+    return validate_object(object_to_validate=participant, object_type=object_type)
+
+
+def get_valid_pedigree_participant_rd_3_0_0():
+    object_type = reports_3_0_0.RDParticipant
+    participant = MockModelObject(object_type=object_type).get_valid_empty_object()
+
+    participant.pedigreeId = 1
+    participant.isProband = False
+    participant.sex = reports_3_0_0.Sex.undetermined
+    participant.ancestries = get_valid_ancestries_3_0_0()
+    participant.lifeStatus = reports_3_0_0.LifeStatus.alive
+    participant.adoptedStatus = reports_3_0_0.AdoptedStatus.not_adopted
+    participant.affectionStatus = reports_3_0_0.AffectionStatus.unknown
+    participant.consanguineousParents = reports_3_0_0.TernaryOption.unknown
+    participant.inbreedingCoefficient = get_valid_inbreeding_coefficient_3_0_0()
 
     return validate_object(object_to_validate=participant, object_type=object_type)
 
@@ -952,12 +1103,32 @@ def get_valid_pedigree_4_0_0():
     return validate_object(object_to_validate=pedigree, object_type=object_type)
 
 
+def get_valid_pedigree_4_2_0_SNAPSHOT():
+    object_type = reports_4_2_0_SNAPSHOT.Pedigree
+    pedigree = MockModelObject(object_type=object_type).get_valid_empty_object()
+    pedigree.diseasePenetrances[0] = get_valid_disease_penetrance_4_2_0_SNAPSHOT()
+    pedigree.readyForAnalysis = True
+    pedigree.members[0] = get_valid_pedigree_members_4_2_0_SNAPSHOT()
+
+    return validate_object(object_to_validate=pedigree, object_type=object_type)
+
+
 def get_valid_pedigree_3_1_0():
     object_type = reports_3_1_0.Pedigree
     pedigree = MockModelObject(object_type=object_type).get_valid_empty_object()
     pedigree.diseasePenetrances[0] = get_valid_disease_penetrance_3_1_0()
     pedigree.readyForAnalysis = True
     pedigree.participants[0] = get_valid_pedigree_participant_rd_3_1_0()
+
+    return validate_object(object_to_validate=pedigree, object_type=object_type)
+
+
+def get_valid_pedigree_3_0_0():
+    object_type = reports_3_0_0.Pedigree
+    pedigree = MockModelObject(object_type=object_type).get_valid_empty_object()
+    pedigree.diseasePenetrances[0] = get_valid_disease_penetrance_3_0_0()
+    pedigree.readyForAnalysis = True
+    pedigree.participants[0] = get_valid_pedigree_participant_rd_3_0_0()
 
     return validate_object(object_to_validate=pedigree, object_type=object_type)
 
@@ -985,6 +1156,25 @@ def get_valid_interpretation_request_rd_4_0_0():
     new_ir_rd.pedigreeDiagram.fileType = reports_4_0_0.FileType.OTHER
     new_ir_rd.tieredVariants[0] = get_valid_reported_variant_4_0_0()
     new_ir_rd.pedigree = get_valid_pedigree_4_0_0()
+
+    return validate_object(object_to_validate=new_ir_rd, object_type=object_type)
+
+
+def get_valid_interpretation_request_rd_4_2_0_SNAPSHOT():
+    object_type = reports_4_2_0_SNAPSHOT.InterpretationRequestRD
+    new_ir_rd = MockModelObject(object_type=object_type).get_valid_empty_object()
+    new_ir_rd.workspace = ['']
+    new_ir_rd.annotationFile.fileType = reports_4_2_0_SNAPSHOT.FileType.ANN
+    new_ir_rd.bams = [new_ir_rd.bams]
+    new_ir_rd.bams[0].fileType = reports_4_2_0_SNAPSHOT.FileType.BAM
+    new_ir_rd.bigWigs = [new_ir_rd.bigWigs]
+    new_ir_rd.bigWigs[0].fileType = reports_4_2_0_SNAPSHOT.FileType.BigWig
+    new_ir_rd.vcfs = [new_ir_rd.vcfs]
+    new_ir_rd.vcfs[0].fileType = reports_4_2_0_SNAPSHOT.FileType.VCF_CNV
+    new_ir_rd.interpretationRequestVersion = 1
+    new_ir_rd.pedigreeDiagram.fileType = reports_4_2_0_SNAPSHOT.FileType.OTHER
+    new_ir_rd.tieredVariants[0] = get_valid_reported_variant_4_2_0_SNAPSHOT()
+    new_ir_rd.pedigree = get_valid_pedigree_4_2_0_SNAPSHOT()
 
     return validate_object(object_to_validate=new_ir_rd, object_type=object_type)
 


### PR DESCRIPTION
Summary of Changes
=================
* Add `MigrateReports3To420SNAPSHOT.migrate_interpretation_request_rd` to migrate interpretation requests from version `3.0.0` to `4.2.0-SNAPSHOT`, required by the CIP API.
* Add `TestMigrateReports3To420SNAPSHOT.test_migrate_interpretation_request` to test this

Tests Passing Locally
================
```
(.env) $ python -m unittest discover
............................................
----------------------------------------------------------------------
Ran 44 tests in 2.602s

OK
(.env) $ 
```