### PR TITLE
IP-346 - Migrate InterpretedGenomeRD

### DIFF
--- a/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -93,7 +93,18 @@ class MigrateReports3To420SNAPSHOT(object):
             old_report_event.variantClassification, new_classification.not_assessed
         )
 
+        new_report_event.genomicFeature = self.migrate_genomic_feature(old_genomic_feature=old_report_event.genomicFeature)
+
         return self.validate_object(object_to_validate=new_report_event, object_type=self.new_model.ReportEvent)
+
+    def migrate_genomic_feature(self, old_genomic_feature):
+        new_genomic_feature = self.new_model.GenomicFeature()
+        new_genomic_feature.featureType = old_genomic_feature.featureType
+        new_genomic_feature.ensemblId = old_genomic_feature.ensemblId
+        new_genomic_feature.hgnc = old_genomic_feature.HGNC
+        new_genomic_feature.otherIds = old_genomic_feature.other_ids
+
+        return self.validate_object(object_to_validate=new_genomic_feature, object_type=self.new_model.GenomicFeature)
 
     def migrate_report_events(self, old_report_events):
         return [self.migrate_report_event(old_report_event) for old_report_event in old_report_events]

--- a/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -47,6 +47,8 @@ class MigrateReports3To420SNAPSHOT(object):
         new_interpretation_request.analysisReturnUri = old_interpretation_request_rd.analysisReturnURI
         new_interpretation_request.internalStudyId = ''
 
+        new_interpretation_request.vesionControl = self.new_model.ReportVersionControl()
+
         return self.validate_object(
             object_to_validate=new_interpretation_request, object_type=self.new_model.InterpretationRequestRD
         )

--- a/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -42,6 +42,7 @@ class MigrateReports3To420SNAPSHOT(object):
         new_interpretation_request.bams = self.migrate_files(old_files=old_interpretation_request_rd.BAMs)
         new_interpretation_request.vcfs = self.migrate_files(old_files=old_interpretation_request_rd.VCFs)
         new_interpretation_request.bigWigs = self.migrate_files(old_files=old_interpretation_request_rd.bigWigs)
+        new_interpretation_request.otherFiles = self.migrate_files(old_files=old_interpretation_request_rd.otherFiles)
         new_interpretation_request.pedigreeDiagram = self.migrate_file(old_file=old_interpretation_request_rd.pedigreeDiagram)
         new_interpretation_request.annotationFile = self.migrate_file(old_file=old_interpretation_request_rd.annotationFile)
         new_interpretation_request.analysisReturnUri = old_interpretation_request_rd.analysisReturnURI
@@ -174,6 +175,8 @@ class MigrateReports3To420SNAPSHOT(object):
             )
 
     def migrate_files(self, old_files):
+        if old_files is None:
+            return None
         return [self.migrate_file(old_file=old_file) for old_file in old_files]
 
     def migrate_life_status(self, life_status):

--- a/protocols/migration/participants.py
+++ b/protocols/migration/participants.py
@@ -1,13 +1,13 @@
 from protocols import reports_3_0_0 as participant_old
 from protocols import participant_1_0_0
 from protocols import participant_1_0_1
-from protocols import participant_1_0_3_SNAPSHOT
+from protocols import participant_1_0_3
 from protocols.util import handle_avro_errors
 
 
 class MigrationParticipants100To103SNAPSHOT(object):
     old_model = participant_1_0_1
-    new_model = participant_1_0_3_SNAPSHOT
+    new_model = participant_1_0_3
 
     def migrate_pedigree(self, old_pedigree):
         new_pedigree = self.new_model.Pedigree.fromJsonDict(old_pedigree.toJsonDict())

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -1,19 +1,22 @@
 from unittest import TestCase
 
 from protocols.migration import MigrateReports3To420SNAPSHOT
-from protocols.reports_4_2_0_SNAPSHOT import InterpretationRequestRD as InterpretationRequestRD_new
-from protocols.reports_3_0_0 import InterpretationRequestRD as InterpretationRequestRD_old
-from protocols.util import get_valid_interpretation_request_rd_3_0_0
+from protocols import reports_4_2_0_SNAPSHOT
+from protocols import reports_3_0_0
+from protocols import util
 
 
 class TestMigrateReports3To420SNAPSHOT(TestCase):
 
-    def test_migrate_interpretation_request(self):
+    old_model = reports_3_0_0
+    new_model = reports_4_2_0_SNAPSHOT
 
-        old_interpretation_request_rd = get_valid_interpretation_request_rd_3_0_0()
+    def test_migrate_interpretation_request_rd(self):
 
-        # Check old_interpretation_request_rd is a valid reports_3_0_0 ReportedSomaticVariants object
-        self.assertTrue(isinstance(old_interpretation_request_rd, InterpretationRequestRD_old))
+        old_interpretation_request_rd = util.get_valid_interpretation_request_rd_3_0_0()
+
+        # Check old_interpretation_request_rd is a valid reports_3_0_0 InterpretationRequestRD object
+        self.assertTrue(isinstance(old_interpretation_request_rd, self.old_model.InterpretationRequestRD))
         self.assertTrue(old_interpretation_request_rd.validate(jsonDict=old_interpretation_request_rd.toJsonDict()))
 
         migrated_object = MigrateReports3To420SNAPSHOT().migrate_interpretation_request_rd(
@@ -21,5 +24,37 @@ class TestMigrateReports3To420SNAPSHOT(TestCase):
         )
 
         # Check migrated_object is a valid reports_4_2_0_SNAPSHOT InterpretationRequestRD object
-        self.assertTrue(isinstance(migrated_object, InterpretationRequestRD_new))
+        self.assertTrue(isinstance(migrated_object, self.new_model.InterpretationRequestRD))
+        self.assertTrue(migrated_object.validate(jsonDict=migrated_object.toJsonDict()))
+
+    def test_migrate_interpreted_genome_rd(self):
+
+        old_interpreted_genome_rd = util.get_valid_interpreted_genome_rd_3_0_0()
+
+        # Check old_interpretation_request_rd is a valid reports_3_0_0 InterpretedGenomeRD object
+        self.assertTrue(isinstance(old_interpreted_genome_rd, self.old_model.InterpretedGenomeRD))
+        self.assertTrue(old_interpreted_genome_rd.validate(jsonDict=old_interpreted_genome_rd.toJsonDict()))
+
+        migrated_object = MigrateReports3To420SNAPSHOT().migrate_interpreted_genome_rd(
+            old_interpreted_genome_rd=old_interpreted_genome_rd
+        )
+
+        # Check migrated_object is a valid reports_4_2_0_SNAPSHOT InterpretedGenomeRD object
+        self.assertTrue(isinstance(migrated_object, self.new_model.InterpretedGenomeRD))
+        self.assertTrue(migrated_object.validate(jsonDict=migrated_object.toJsonDict()))
+
+    def test_migrate_reported_structural_variant(self):
+
+        old_reported_structural_variant = util.get_valid_reported_structural_variant_3_0_0()
+
+        # Check old_reported_structural_variant is a valid reports_3_0_0 ReportedStructuralVariant object
+        self.assertTrue(isinstance(old_reported_structural_variant, self.old_model.ReportedStructuralVariant))
+        self.assertTrue(old_reported_structural_variant.validate(jsonDict=old_reported_structural_variant.toJsonDict()))
+
+        migrated_object = MigrateReports3To420SNAPSHOT().migrate_reported_structural_variant(
+            old_reported_structural_variant=old_reported_structural_variant
+        )
+
+        # Check migrated_object is a valid reports_4_2_0_SNAPSHOT ReportedStructuralVariant object
+        self.assertTrue(isinstance(migrated_object, self.new_model.ReportedStructuralVariant))
         self.assertTrue(migrated_object.validate(jsonDict=migrated_object.toJsonDict()))

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -27,6 +27,10 @@ class TestMigrateReports3To420SNAPSHOT(TestCase):
         self.assertTrue(isinstance(migrated_object, self.new_model.InterpretationRequestRD))
         self.assertTrue(migrated_object.validate(jsonDict=migrated_object.toJsonDict()))
 
+        # Check version control field is now a ReportVersionControl object and has the correct details
+        self.assertTrue(isinstance(migrated_object.versionControl, self.new_model.ReportVersionControl))
+        self.assertDictEqual(migrated_object.versionControl.toJsonDict(), {u'gitVersionControl': '4.2.0'})
+
     def test_migrate_interpreted_genome_rd(self):
 
         old_interpreted_genome_rd = util.get_valid_interpreted_genome_rd_3_0_0()

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -37,6 +37,21 @@ class TestMigrateReports3To420SNAPSHOT(TestCase):
         # Check old InterpretationRequestID is migrated to new interpretationRequestId field
         self.assertEqual(migrated_object.interpretationRequestId, test_ir_id)
 
+        # Check genomic feature is migrated correctly
+        old_variants = old_interpretation_request_rd.TieredVariants
+        new_variants = migrated_object.tieredVariants
+        for old_variant, new_variant in zip(old_variants, new_variants):
+            old_events = old_variant.reportEvents
+            new_events = new_variant.reportEvents
+            for old_event, new_event in zip(old_events, new_events):
+
+                self.assertIsInstance(new_event.genomicFeature, self.new_model.GenomicFeature)
+
+                self.assertEqual(old_event.genomicFeature.featureType, new_event.genomicFeature.featureType)
+                self.assertEqual(old_event.genomicFeature.ensemblId, new_event.genomicFeature.ensemblId)
+                self.assertEqual(old_event.genomicFeature.HGNC, new_event.genomicFeature.hgnc)
+                self.assertEqual(old_event.genomicFeature.other_ids, new_event.genomicFeature.otherIds)
+
     def test_migrate_interpreted_genome_rd(self):
 
         old_interpreted_genome_rd = util.get_valid_interpreted_genome_rd_3_0_0()

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -17,6 +17,9 @@ class TestMigrateReports3To420SNAPSHOT(TestCase):
 
         test_ir_id = 'CHF-2003'
         old_interpretation_request_rd.InterpretationRequestID = test_ir_id
+        old_interpretation_request_rd.additionalInfo = {"additional": "info"}
+        old_interpretation_request_rd.analysisVersion = '234'
+        old_interpretation_request_rd.complexGeneticPhenomena = self.old_model.ComplexGeneticPhenomena.other_aneuploidy
 
         # Check old_interpretation_request_rd is a valid reports_3_0_0 InterpretationRequestRD object
         self.assertTrue(isinstance(old_interpretation_request_rd, self.old_model.InterpretationRequestRD))
@@ -51,6 +54,95 @@ class TestMigrateReports3To420SNAPSHOT(TestCase):
                 self.assertEqual(old_event.genomicFeature.ensemblId, new_event.genomicFeature.ensemblId)
                 self.assertEqual(old_event.genomicFeature.HGNC, new_event.genomicFeature.hgnc)
                 self.assertEqual(old_event.genomicFeature.other_ids, new_event.genomicFeature.otherIds)
+
+        self.assertIsNotNone(migrated_object.genomeAssemblyVersion)
+        self.assertEqual(migrated_object.genomeAssemblyVersion, old_interpretation_request_rd.genomeAssemblyVersion)
+
+        self.assertIsNotNone(migrated_object.cellbaseVersion)
+        self.assertEqual(migrated_object.cellbaseVersion, old_interpretation_request_rd.cellbaseVersion)
+
+        self.assertIsNotNone(migrated_object.interpretationRequestVersion)
+        self.assertEqual(migrated_object.interpretationRequestVersion, old_interpretation_request_rd.InterpretationRequestVersion)
+
+        self.assertIsNotNone(migrated_object.interpretGenome)
+        self.assertEqual(migrated_object.interpretGenome, old_interpretation_request_rd.interpretGenome)
+
+        self.assertIsNotNone(migrated_object.workspace)
+        self.assertEqual(migrated_object.workspace, old_interpretation_request_rd.workspace)
+
+        self.assertIsNotNone(migrated_object.tieringVersion)
+        self.assertEqual(migrated_object.tieringVersion, old_interpretation_request_rd.TieringVersion)
+
+        self.assertIsNotNone(migrated_object.analysisVersion)
+        self.assertEqual(migrated_object.analysisReturnUri, old_interpretation_request_rd.analysisReturnURI)
+
+        self.assertIsNotNone(migrated_object.analysisVersion)
+        self.assertEqual(migrated_object.analysisVersion, old_interpretation_request_rd.analysisVersion)
+
+        self.assertIsNotNone(migrated_object.additionalInfo)
+        self.assertEqual(migrated_object.additionalInfo, old_interpretation_request_rd.additionalInfo)
+
+        self.assertIsNotNone(migrated_object.complexGeneticPhenomena)
+        self.assertEqual(migrated_object.complexGeneticPhenomena, old_interpretation_request_rd.complexGeneticPhenomena)
+
+        self.assertIsInstance(migrated_object.otherFamilyHistory, self.new_model.OtherFamilyHistory)
+        self.assertEqual(migrated_object.otherFamilyHistory.maternalFamilyHistory, old_interpretation_request_rd.otherFamilyHistory.maternalFamilyHistory)
+        self.assertEqual(migrated_object.otherFamilyHistory.paternalFamilyHistory, old_interpretation_request_rd.otherFamilyHistory.paternalFamilyHistory)
+
+        # Check BAM locations are migrated correctly
+        old_bams = old_interpretation_request_rd.BAMs
+        new_bams = migrated_object.bams
+        for old_bam, new_bam in zip(old_bams, new_bams):
+            self.assertIsInstance(new_bam, self.new_model.File)
+
+            self.assertEqual(new_bam.sampleId, old_bam.SampleId)
+            self.assertEqual(new_bam.uriFile, old_bam.URIFile)
+            self.assertEqual(new_bam.fileType, old_bam.fileType)
+            self.assertEqual(new_bam.md5Sum, old_bam.md5Sum)
+
+        # Check VCF locations are migrated correctly
+        old_vcfs = old_interpretation_request_rd.VCFs
+        new_vcfs = migrated_object.vcfs
+        for old_vcf, new_vcf in zip(old_vcfs, new_vcfs):
+            self.assertIsInstance(new_vcf, self.new_model.File)
+
+            self.assertEqual(new_vcf.sampleId, old_vcf.SampleId)
+            self.assertEqual(new_vcf.uriFile, old_vcf.URIFile)
+            self.assertEqual(new_vcf.fileType, old_vcf.fileType)
+            self.assertEqual(new_vcf.md5Sum, old_vcf.md5Sum)
+
+        # Check BigWig locations are migrated correctly
+        old_big_wigs = old_interpretation_request_rd.bigWigs
+        new_big_wigs = migrated_object.bigWigs
+        for old_big_wig, new_big_wig in zip(old_big_wigs, new_big_wigs):
+            self.assertIsInstance(new_big_wig, self.new_model.File)
+
+            self.assertEqual(new_big_wig.sampleId, old_big_wig.SampleId)
+            self.assertEqual(new_big_wig.uriFile, old_big_wig.URIFile)
+            self.assertEqual(new_big_wig.fileType, old_big_wig.fileType)
+            self.assertEqual(new_big_wig.md5Sum, old_big_wig.md5Sum)
+
+        # Check Pedigree Diagram file is migrated correctly
+        old_pedigree_diagram = old_interpretation_request_rd.pedigreeDiagram
+        new_pedigree_diagram = migrated_object.pedigreeDiagram
+
+        self.assertIsInstance(new_pedigree_diagram, self.new_model.File)
+
+        self.assertEqual(new_pedigree_diagram.sampleId, old_pedigree_diagram.SampleId)
+        self.assertEqual(new_pedigree_diagram.uriFile, old_pedigree_diagram.URIFile)
+        self.assertEqual(new_pedigree_diagram.fileType, old_pedigree_diagram.fileType)
+        self.assertEqual(new_pedigree_diagram.md5Sum, old_pedigree_diagram.md5Sum)
+
+        # Check Annotation File file is migrated correctly
+        old_annotation_file = old_interpretation_request_rd.annotationFile
+        new_annotation_file = migrated_object.annotationFile
+
+        self.assertIsInstance(new_annotation_file, self.new_model.File)
+
+        self.assertEqual(new_annotation_file.sampleId, old_annotation_file.SampleId)
+        self.assertEqual(new_annotation_file.uriFile, old_annotation_file.URIFile)
+        self.assertEqual(new_annotation_file.fileType, old_annotation_file.fileType)
+        self.assertEqual(new_annotation_file.md5Sum, old_annotation_file.md5Sum)
 
     def test_migrate_interpreted_genome_rd(self):
 

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -15,6 +15,9 @@ class TestMigrateReports3To420SNAPSHOT(TestCase):
 
         old_interpretation_request_rd = util.get_valid_interpretation_request_rd_3_0_0()
 
+        test_ir_id = 'CHF-2003'
+        old_interpretation_request_rd.InterpretationRequestID = test_ir_id
+
         # Check old_interpretation_request_rd is a valid reports_3_0_0 InterpretationRequestRD object
         self.assertTrue(isinstance(old_interpretation_request_rd, self.old_model.InterpretationRequestRD))
         self.assertTrue(old_interpretation_request_rd.validate(jsonDict=old_interpretation_request_rd.toJsonDict()))
@@ -30,6 +33,9 @@ class TestMigrateReports3To420SNAPSHOT(TestCase):
         # Check version control field is now a ReportVersionControl object and has the correct details
         self.assertTrue(isinstance(migrated_object.versionControl, self.new_model.ReportVersionControl))
         self.assertDictEqual(migrated_object.versionControl.toJsonDict(), {u'gitVersionControl': '4.2.0'})
+
+        # Check old InterpretationRequestID is migrated to new interpretationRequestId field
+        self.assertEqual(migrated_object.interpretationRequestId, test_ir_id)
 
     def test_migrate_interpreted_genome_rd(self):
 


### PR DESCRIPTION
[IP-346 - Migrate InterpretedGenomeRD](https://jira.extge.co.uk/browse/IP-346)
=========================
Migrate InterpretedGenomeRD from 3.0.0 to 4.2.0-SNAPSHOT as required by the CIP API to send Reported Variants to CVA 

Summary of Changes
==================
* Add `migrate_interpreted_genome_rd` to `MigrateReports3To420SNAPSHOT`
* Add `test_migrate_interpreted_genome_rd` to `TestMigrateReports3To420SNAPSHOT`
```
(.env) $ python -m unittest discover
..............................................
----------------------------------------------------------------------
Ran 46 tests in 2.550s

OK
(.env) $ 
```