### PR TITLE
IP-75 - Adding annotations and annotator version to VariantRepresentation model 

### DIFF
--- a/build.py
+++ b/build.py
@@ -255,8 +255,7 @@ def main():
             logging.error('Please provide the version and the name of the package in the following format: package::version')
             sys.exit(-1)
         if model not in MODEL_SHORT_NAME:
-
-            logging.error(str(model) + ' is not a valid package name')
+            logging.error("Model: [{model}] is not a valid package name".format(model=str(model)))
             sys.exit(-1)
 
         list_of_models.append((model, version))

--- a/build.py
+++ b/build.py
@@ -244,6 +244,7 @@ def main():
         help='List of models packages and versions to generated, in the following format package::version'
     )
     parser.add_argument('--skip_doc', default=False, action='store_true', help='Documentation will be skipped')
+    parser.add_argument('--build_only_snapshots', default=False, action='store_true', help='Documentation will be skipped')
     args = parser.parse_args()
 
     list_of_models = []
@@ -255,10 +256,21 @@ def main():
             sys.exit(-1)
         if model not in MODEL_SHORT_NAME:
 
-            logging.error(str(model) + 'is not a valid package name')
+            logging.error(str(model) + ' is not a valid package name')
             sys.exit(-1)
 
         list_of_models.append((model, version))
+
+    if args.build_only_snapshots:
+        list_of_models = [
+            ("org.gel.models.participant.avro", "1.0.4-SNAPSHOT"),
+            ("org.gel.models.metrics.avro", "1.1.0-SNAPSHOT"),
+            ("org.ga4gh.models", "3.1.0-SNAPSHOT"),
+            ("org.gel.models.report.avro", "4.2.0-SNAPSHOT"),
+            ("org.gel.models.cva.avro", "0.4.0-SNAPSHOT"),
+            ("org.opencb.biodata.models", "1.2.0")
+        ]
+
 
     build(models=list_of_models, skip_doc=args.skip_doc)
 

--- a/pom.xml
+++ b/pom.xml
@@ -254,6 +254,7 @@
                             <workingDirectory>${basedir}</workingDirectory>
                             <arguments>
                                 <argument>build.py</argument>
+                                <argument>--build_only_snapshots</argument>
                                 <!--
                                 <argument>- -models</argument>
                                 <argument>${report.models.package}::${report.models.version}</argument>

--- a/schemas/IDLs/org.gel.models.cva.avro/0.4.0-SNAPSHOT/Variant.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/0.4.0-SNAPSHOT/Variant.avdl
@@ -18,6 +18,8 @@ protocol VariantProtocol {
     */
     record VariantRepresentation {
         SupportedAssembly assembly;
+        union {null, string} annotatorVersion;
+        union {null, string} annotationsVersion;
         org.opencb.biodata.models.variant.avro.VariantAvro variant;
     }
 


### PR DESCRIPTION
* Annotator and annotations version added to CVA variant model
* Optionally building only snapshots by running `build.py --build_only_snapshots`. Maven build will only build snapshots... May change in the future