### PR TITLE
Fix - get_valid_cancer_participant_1_0_3

### DIFF
--- a/protocols/tests/test_util/test_generate_mock_objects.py
+++ b/protocols/tests/test_util/test_generate_mock_objects.py
@@ -7,6 +7,7 @@ from protocols import reports_4_0_0
 from protocols import reports_4_2_0_SNAPSHOT
 from protocols import cva_0_3_1
 from protocols import cva_0_4_0_SNAPSHOT
+from protocols import participant_1_0_3
 from protocols.util import generate_mock_objects
 
 
@@ -412,3 +413,17 @@ class TestGenerateMockObjectsCVA040(TestCase):
         test_tvi_rd = generate_mock_objects.get_valid_candidate_variant_inject_cancer_0_4_0()
         self.assertTrue(isinstance(test_tvi_rd, self.model.CandidateVariantInjectCancer))
         self.assertTrue(test_tvi_rd.validate(test_tvi_rd.toJsonDict()))
+
+
+class TestGenerateMockObjectsParticipant103(TestCase):
+
+    model = participant_1_0_3
+
+    def test_tiered_variant_inject_rd(self):
+        """
+        Ensure generate_mock_objects.get_valid_cancer_participant_1_0_3 returns a valid
+        participant_1_0_3.CancerParticipant object
+        """
+        test_participant = generate_mock_objects.get_valid_cancer_participant_1_0_3()
+        self.assertTrue(isinstance(test_participant, self.model.CancerParticipant))
+        self.assertTrue(test_participant.validate(test_participant.toJsonDict()))

--- a/protocols/util/generate_mock_objects.py
+++ b/protocols/util/generate_mock_objects.py
@@ -210,10 +210,11 @@ def get_valid_cancer_participant_1_0_3():
     new_participant = MockModelObject(object_type=object_type).get_valid_empty_object()
     new_participant.sex = 'M'
     new_participant.germlineSamples.labSampleId = 1
-    new_participant.tumourSamples.tumourId = 1
+    new_participant.tumourSamples.tumourId = '1'
     new_participant.tumourSamples.labSampleId = 1
     new_participant.readyForAnalysis = True
     new_participant.sex = 'UNKNOWN'
+    new_participant.yearOfBirth = 1969
 
     matchedSample = new_participant.matchedSamples
     new_participant.matchedSamples = [matchedSample]


### PR DESCRIPTION
Summary of Changes
================
* Reflect changes in `participant_1_0_3.CancerParticipant` when generating valid empty object
* Add test for `get_valid_cancer_participant_1_0_3`

- [x] Tests Passing Locally:
```
(.env) $ python -m unittest discover
.........................................................
----------------------------------------------------------------------
Ran 57 tests in 3.201s

OK
(.env) $ 
```