### PR TITLE
Feature - Generate Valid Exit Questionnaire v4.2.0

### DIFF
--- a/protocols/migration/migration_reports_4_0_0_to_reports_4_2_0_SNAPSHOT.py
+++ b/protocols/migration/migration_reports_4_0_0_to_reports_4_2_0_SNAPSHOT.py
@@ -1,0 +1,28 @@
+from protocols import reports_4_0_0
+from protocols import reports_4_2_0_SNAPSHOT
+from protocols.migration import BaseMigration
+from protocols.migration.participants import MigrationParticipants100To104SNAPSHOT
+
+
+class MigrateReports400To420SNAPSHOT(BaseMigration):
+
+    old_model = reports_4_0_0
+    new_model = reports_4_2_0_SNAPSHOT
+
+    def migrate_cancer_interpretation_request(self, cancer_interpretation_request):
+        """
+        :type cancer_interpretation_request: reports_4_2_0_SNAPSHOT.CancerInterpretationRequest
+        :rtype: reports_4_0_0.CancerInterpretationRequest
+        """
+        new_cancer_interpretation_request = self.new_model.CancerInterpretationRequest.fromJsonDict(
+            jsonDict=cancer_interpretation_request.toJsonDict()
+        )
+
+        new_cancer_participant = MigrationParticipants100To104SNAPSHOT().migrate_cancer_participant(
+            cancer_participant=cancer_interpretation_request.cancerParticipant
+        )
+        new_cancer_interpretation_request.cancerParticipant = new_cancer_participant
+
+        return self.validate_object(
+            object_to_validate=new_cancer_interpretation_request, object_type=self.new_model.CancerInterpretationRequest
+        )

--- a/protocols/tests/test_util/test_generate_mock_objects.py
+++ b/protocols/tests/test_util/test_generate_mock_objects.py
@@ -36,6 +36,15 @@ class TestGenerateMockObjects420(TestCase):
         self.assertTrue(isinstance(test_ir_rd, self.model.CancerInterpretationRequest))
         self.assertTrue(test_ir_rd.validate(test_ir_rd.toJsonDict()))
 
+    def test_rd_exit_questionnaire(self):
+        """
+        Ensure generate_mock_objects.get_valid_rd_exit_questionnaire_4_2_0 returns a valid
+        reports_4_2_0_SNAPSHOT.RareDiseaseExitQuestionnaire object
+        """
+        test_eq = generate_mock_objects.get_valid_rd_exit_questionnaire_4_2_0()
+        self.assertTrue(isinstance(test_eq, self.model.RareDiseaseExitQuestionnaire))
+        self.assertTrue(test_eq.validate(test_eq.toJsonDict()))
+
 
 class TestGenerateMockObjects4(TestCase):
 

--- a/protocols/util/__init__.py
+++ b/protocols/util/__init__.py
@@ -31,6 +31,7 @@ from .generate_mock_objects import get_valid_interpreted_genome_rd_4_2_0
 from .generate_mock_objects import get_valid_rd_exit_questionnaire_3_0_0
 from .generate_mock_objects import get_valid_rd_exit_questionnaire_3_1_0
 from .generate_mock_objects import get_valid_rd_exit_questionnaire_4_0_0
+from .generate_mock_objects import get_valid_rd_exit_questionnaire_4_2_0
 
 from .generate_mock_objects import get_valid_clinical_report_cancer_2_1_0
 from .generate_mock_objects import get_valid_clinical_report_cancer_3_0_0

--- a/protocols/util/generate_mock_objects.py
+++ b/protocols/util/generate_mock_objects.py
@@ -11,6 +11,8 @@ from protocols import participant_1_0_4
 from protocols import cva_0_3_1
 from protocols import cva_0_4_0
 from protocols import system_0_1_0
+from protocols.util.dependency_manager import VERSION_430
+from protocols.util.factories.avro_factory import GenericFactoryAvro
 
 
 class MockModelObject(object):
@@ -716,6 +718,16 @@ def get_valid_rd_exit_questionnaire_4_0_0():
     return validate_object(object_to_validate=new_rd_eq, object_type=object_type)
 
 
+def get_valid_rd_exit_questionnaire_4_2_0():
+    object_type = reports_4_2_0.RareDiseaseExitQuestionnaire
+    rare_disease_exit_questionnaire = GenericFactoryAvro.get_factory_avro(
+        clazz=object_type,
+        version=VERSION_430
+    )
+    new_rd_eq = rare_disease_exit_questionnaire()
+    return validate_object(object_to_validate=new_rd_eq, object_type=object_type)
+
+
 def get_valid_reported_somatic_structural_variant_3_0_0():
     object_type = reports_3_0_0.ReportedSomaticStructuralVariants
     new_variant = MockModelObject(object_type=object_type).get_valid_empty_object()
@@ -967,8 +979,11 @@ def get_valid_clinical_report_cancer_4_2_0():
 
 def get_valid_called_genotype_2_1_0():
     object_type = reports_2_1_0.CalledGenotype
-    new_cg = MockModelObject(object_type=object_type).get_valid_empty_object()
-    new_cg.genotype = ''
+    called_genotype = GenericFactoryAvro.get_factory_avro(
+        clazz=object_type,
+        version="2.1.0"
+    )
+    new_cg = called_genotype()
 
     return validate_object(object_to_validate=new_cg, object_type=object_type)
 


### PR DESCRIPTION
Feature - Generate Valid Exit Questionnaire v4.2.0
==================================

Summary of Changes
=================
* Add `get_valid_rd_exit_questionnaire_4_2_0_SNAPSHOT`
* Add `test_rd_exit_questionnaire`

Tests and Build
================
- [x]  All tests passing locally
- [ ]  Building locally 
```
(.env) $ python -m unittest discover
........................................................................
----------------------------------------------------------------------
Ran 72 tests in 2.740s

OK
(.env) greg@greg-Latitude-E7470:~/gel/GelReportModels$ 

(.env) $
```
```
Build
```


