### PR TITLE
Feature - Generic mock factory for Avro objects

### DIFF
--- a/build2.py
+++ b/build2.py
@@ -8,6 +8,7 @@ import distutils.dir_util
 sys.path.append(os.path.dirname(os.path.join(os.path.dirname(__file__), 'resources', 'GelModelsTools')))
 from GelModelsTools import utils
 from GelModelsTools.gel_models_tools import GelModelsTools
+from protocols.util.dependency_manager import DependencyManager
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -163,9 +164,9 @@ def run_build(build, skip_docs=False):
         __idl2json(build_folder, json_build_folder)
 
         # generate python source code
-        class_name = "{}_{}.py".format(
-            package["python_package"],
-            package["version"].replace("-SNAPSHOT", "").replace(".", "_").replace("-", "_")
+        package_name = DependencyManager.get_python_package_name(package)
+        class_name = "{}.py".format(
+            package_name
         )
         __json2python(json_build_folder, os.path.join(PYTHON_FOLDER, class_name), package["version"])
 

--- a/builds.json
+++ b/builds.json
@@ -56,6 +56,37 @@
       ]
     },
     {
+      "version": "4.1.0",
+      "packages": [
+        {
+          "package": "org.gel.models.participant.avro",
+          "python_package": "participant",
+          "version": "1.0.0",
+          "dependencies": []
+        },
+        {
+          "package": "org.gel.models.report.avro",
+          "python_package": "reports",
+          "version": "4.1.0",
+          "dependencies": [
+            "org.gel.models.participant.avro"
+          ]
+        },
+        {
+          "package": "org.gel.models.metrics.avro",
+          "python_package": "metrics",
+          "version": "1.0.1",
+          "dependencies": []
+        },
+        {
+          "package": "org.ga4gh.models",
+          "python_package": "ga4gh",
+          "version": "3.0.0",
+          "dependencies": []
+        }
+      ]
+    },
+    {
       "version": "4.0.0",
       "packages": [
         {

--- a/protocols/tests/test_util/test_dependency_manager.py
+++ b/protocols/tests/test_util/test_dependency_manager.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+from protocols.util.dependency_manager import DependencyManager
+import protocols.reports_4_2_0
+import protocols.reports_4_0_0
+
+
+class TestDependencyManager(TestCase):
+
+    def testDependencyManager(self):
+        dependency_manager = DependencyManager()
+        assert dependency_manager is not None
+        latest_dependencies = dependency_manager.get_latest_version_dependencies()
+        assert isinstance(latest_dependencies, dict)
+        assert latest_dependencies["org.gel.models.report.avro"] == protocols.reports_4_2_0
+        dependencies_400 = dependency_manager.get_version_dependencies("4.0.0")
+        assert isinstance(dependencies_400, dict)
+        assert dependencies_400["org.gel.models.report.avro"] == protocols.reports_4_0_0
+        assert dependencies_400["org.gel.models.report.avro"] != protocols.reports_4_2_0

--- a/protocols/tests/test_util/test_factories.py
+++ b/protocols/tests/test_util/test_factories.py
@@ -6,6 +6,12 @@ from protocols.ga4gh_3_0_0 import Variant
 from protocols.reports_4_1_0 import CancerExitQuestionnaire
 from protocols.util.factories.ga4gh_factories import GA4GHVariantFactory, CallFactory
 from protocols.util.factories.reports_4_1_0_factories import CancerExitQuestionnaireFactory
+from protocols.util.factories.avro_factory import GenericFactoryAvro
+from protocols.cva_0_4_0 import TieredVariantInjectRD, TieredVariantInjectCancer
+import protocols.reports_4_2_0
+import protocols.reports_4_1_0
+import protocols.reports_3_0_0
+from protocols.util.dependency_manager import VERSION_430, VERSION_410, VERSION_300
 
 
 class TestGA4GHVariantFactory(TestCase):
@@ -70,3 +76,39 @@ class TestGA4GHVariantFactory(TestCase):
         batch = CancerExitQuestionnaireFactory.create_batch(1000)
         validation_results = map(lambda x: CancerExitQuestionnaire.validate(x.toJsonDict()), batch)
         self.assertNotIn(False, validation_results)
+
+
+class TestGenericFactory(TestCase):
+
+    def test_tiered_variant_inject_rd_factory(self):
+        tiered_variant_inject_factory = GenericFactoryAvro.get_factory_avro(TieredVariantInjectRD)
+        instance = tiered_variant_inject_factory()
+        self.assertTrue(instance.validate(instance.toJsonDict()))
+
+    def test_tiered_variant_inject_cancer_factory(self):
+        tiered_variant_inject_factory = GenericFactoryAvro.get_factory_avro(TieredVariantInjectCancer)
+        instance = tiered_variant_inject_factory()
+        self.assertTrue(instance.validate(instance.toJsonDict()))
+
+    def test_interpretation_request(self):
+        # get an interpretation request RD for reports 4.2.0
+        interpretation_request_factory = GenericFactoryAvro.get_factory_avro(
+            protocols.reports_4_2_0.InterpretationRequestRD,
+            version = VERSION_430
+        )
+        instance = interpretation_request_factory()
+        self.assertTrue(instance.validate(instance.toJsonDict()))
+        # get an interpretation request RD for reports 4.1.0
+        interpretation_request_factory = GenericFactoryAvro.get_factory_avro(
+            protocols.reports_4_1_0.InterpretationRequestRD,
+            version=VERSION_410
+        )
+        instance = interpretation_request_factory()
+        self.assertTrue(instance.validate(instance.toJsonDict()))
+        # get an interpretation request RD for reports 3.1.0
+        interpretation_request_factory = GenericFactoryAvro.get_factory_avro(
+            protocols.reports_3_0_0.InterpretationRequestRD,
+            version=VERSION_300
+        )
+        instance = interpretation_request_factory()
+        self.assertTrue(instance.validate(instance.toJsonDict()))

--- a/protocols/util/dependency_manager.py
+++ b/protocols/util/dependency_manager.py
@@ -1,0 +1,75 @@
+import ujson
+import importlib
+import os.path
+import inspect
+
+
+VERSION_430 = "4.3.0-SNAPSHOT"
+VERSION_300 = "3.0.0"
+VERSION_410 = "4.1.0"
+
+class DependencyManager:
+    """
+    Singleton class that reads builds.json file at the root of the project
+    and provides utils for dependency management.
+    """
+
+    class __DependencyManager:
+
+        def __init__(self):
+            filename = inspect.getframeinfo(inspect.currentframe()).filename
+            path = os.path.dirname(os.path.abspath(filename))
+            dependencies_json = "{}/../../builds.json".format(path)
+            self.builds = ujson.load(open(dependencies_json))["builds"]
+
+            # prepares resource: version -> namespace -> python package
+            self.versions = {}
+            for build in self.builds:
+                self.versions[build["version"]] = {}
+                for package in build["packages"]:
+                    namespace = package["package"]
+                    _module = DependencyManager.get_python_module(package)
+                    self.versions[build["version"]][namespace] = _module
+
+        def get_version_dependencies(self, version):
+            if version not in self.versions:
+                raise ValueError("Version {} not available in builds.json!".format(version))
+            return self.versions[version]
+
+        def get_latest_version_dependencies(self):
+            latest_version = max(self.versions.keys())
+            return self.versions[latest_version]
+
+        def get_latest_version(self):
+            latest_version = max(self.versions.keys())
+            return latest_version
+
+    instance = None
+
+    def __init__(self):
+        if not DependencyManager.instance:
+            DependencyManager.instance = DependencyManager.__DependencyManager()
+
+    def __getattr__(self, name):
+        return getattr(self.instance, name)
+
+    @staticmethod
+    def get_python_package_name(package):
+        """
+        Returns the python package name built from a Gel package definition.
+        :param package: the package dict
+        :return: the python package name
+        """
+        package_base = package["python_package"]
+        package_version = package["version"]
+        package_name = "{}_{}".format(
+            package_base,
+            package_version.replace(".", "_").replace("-SNAPSHOT", "")
+        )
+        return package_name
+
+    @staticmethod
+    def get_python_module(package):
+        package_name = DependencyManager.get_python_package_name(package)
+        _module = importlib.import_module("protocols.{}".format(package_name))
+        return _module

--- a/protocols/util/factories/avro_factory.py
+++ b/protocols/util/factories/avro_factory.py
@@ -2,69 +2,211 @@ import sys
 
 import factory.fuzzy
 from factory.base import FactoryMetaClass, BaseFactory, BaseMeta
+from protocols.util.dependency_manager import DependencyManager
 
 
-def mock_schema(protocol):
+BASIC_TYPES = ['null', 'boolean', 'string', 'bytes', 'int', 'long', 'float', 'double', 'enum']
+COMPLEX_TYPES = ['record', 'array', 'map']
+UNION_TYPE = 'union'
+DEFAULT_ELEMENTS_ARRAY = 5
+DEFAULT_ELEMENTS_MAP = 5
+INT_MIN_VALUE = -(1 << 31)
+INT_MAX_VALUE = (1 << 31) - 1
+LONG_MIN_VALUE = -(1 << 63)
+LONG_MAX_VALUE = (1 << 63) - 1
+
+
+def mock_schema(protocol, version):
     """
     :type protocol: Protocol
+    :param version: the package version as registered in the dependency manager
+    :type version: str
+    :return: a dictionary following the schema of the protocol containing mocked values
+    :rtype: dict
     """
     expected_schema = protocol.schema
-    basics = ['null', 'boolean', 'string', 'bytes', 'int', 'long', 'float', 'double', 'enum']
+    dependency_manager = DependencyManager()
+    if version is not None:
+        dependencies = dependency_manager.get_version_dependencies(version)
+    else:
+        dependencies = dependency_manager.get_latest_version_dependencies()
+
     mock_result = {}
     for field in expected_schema.fields:
-        schema_type = field.type.type
-        name = field.name
-        if schema_type in basics:
-            basic_types(field, mock_result, name, schema_type)
-        elif schema_type == 'union':
-            basic_types(field.type.schemas[1], mock_result, name, field.type.schemas[1].type)
+        field_type = field.type.type
+        field_name = field.name
+        mock_result[field_name] = mock_field(field, field_type, dependencies, version)
     return mock_result
 
 
-def basic_types(field, mock_result, name, schema_type):
-    INT_MIN_VALUE = -(1 << 31)
-    INT_MAX_VALUE = (1 << 31) - 1
-    LONG_MIN_VALUE = -(1 << 63)
-    LONG_MAX_VALUE = (1 << 63) - 1
-    if schema_type == 'null':
-        mock_result[name] = None
-    elif schema_type == 'boolean':
-        mock_result[name] = factory.fuzzy.FuzzyChoice([True, False])
-    elif schema_type == 'string':
-        mock_result[name] = factory.fuzzy.FuzzyText()
-    elif schema_type == 'bytes':
-        mock_result[name] = b'a'
-    elif schema_type == 'int':
-        mock_result[name] = factory.fuzzy.FuzzyInteger(INT_MIN_VALUE, INT_MAX_VALUE)
-    elif schema_type == 'long':
-        mock_result[name] = factory.fuzzy.FuzzyInteger(LONG_MIN_VALUE, LONG_MAX_VALUE)
-    elif schema_type in ['float', 'double']:
-        mock_result[name] = factory.fuzzy.FuzzyFloat(sys.float_info.min)
-    elif schema_type == 'enum':
+def mock_field(field, field_type, dependencies, version):
+    """
+    :param field:
+    :param field_type:
+    :param dependencies: the list of dependencies as provided by the dependency manager
+    :type dependencies: dict
+    :param version: the package version as registered in the dependency manager
+    :type version: str
+    :return: the mocked value for a field
+    :rtype: object
+    """
+    value = None
+    if field_type in BASIC_TYPES:
+        value = mock_basic_type(field, field_type)
+    # by convention we expect that nullable fields are defined as "union {null, RelevantType}"
+    # we get the first type of union expecting that it is the null type
+    elif field_type == UNION_TYPE:
+        value = mock_basic_type(field.type.schemas[0], field.type.schemas[0].type)
+    elif field_type in COMPLEX_TYPES:
+        value = mock_complex_type(field, field_type, dependencies, version)
+    return value
+
+
+def mock_basic_type(field, field_type):
+    """
+    :param field:
+    :param field_type:
+    :return: the mocked value for the basic type
+    :rtype: object
+    """
+    value = None
+    if field_type == 'null':
+        value =  None
+    elif field_type == 'boolean':
+        value = factory.fuzzy.FuzzyChoice([True, False]).fuzz()
+    elif field_type == 'string':
+        value = factory.fuzzy.FuzzyText().fuzz()
+    elif field_type == 'bytes':
+        value = b'a'
+    elif field_type == 'int':
+        value = factory.fuzzy.FuzzyInteger(INT_MIN_VALUE, INT_MAX_VALUE).fuzz()
+    elif field_type == 'long':
+        value = factory.fuzzy.FuzzyInteger(LONG_MIN_VALUE, LONG_MAX_VALUE).fuzz()
+    elif field_type in ['float', 'double']:
+        value = factory.fuzzy.FuzzyFloat(sys.float_info.min).fuzz()
+    elif field_type == 'enum':
         if hasattr(field, 'symbols'):
             symbols = field.symbols
         else:
             symbols = field.type.symbols
-        mock_result[name] = factory.fuzzy.FuzzyChoice(symbols)
+        value = factory.fuzzy.FuzzyChoice(symbols).fuzz()
+    return value
+
+
+def mock_complex_type(field, field_type, dependencies, version):
+    """
+    :param field:
+    :param field_type:
+    :param dependencies:
+    :param version:
+    :return: the mocked value for a complex type
+    :rtype: object
+    """
+    value = None
+    if field_type == 'record':
+        if isinstance(field.type, unicode):
+            # in some cases field types are just a string
+            class_name = field.name
+            namespace = field.namespace
+        else:
+            class_name = field.type.name
+            namespace = field.type.namespace
+        clazz = getattr(dependencies[namespace], class_name)
+        clazz_factory = GenericFactoryAvro.get_factory_avro(clazz, version)
+        value = clazz_factory()
+    elif field_type == 'array':
+        value = []
+        for _ in xrange(DEFAULT_ELEMENTS_ARRAY):
+            if isinstance(field.type, str):
+                value.append(mock_field(field.items, field.items.type, dependencies, version))
+            else:
+                value.append(mock_field(field.type.items, field.type.items.type, dependencies, version))
+    elif field_type == 'map':
+        value = {}
+        for _ in xrange(DEFAULT_ELEMENTS_MAP):
+            if isinstance(field.type, str):
+                value[factory.fuzzy.FuzzyText().fuzz()] = \
+                    mock_field(field.values, field.values.type, dependencies, version)
+            else:
+                value[factory.fuzzy.FuzzyText().fuzz()] = \
+                    mock_field(field.type.values, field.type.values.type, dependencies, version)
+    return value
 
 
 class FactoryAvroMetaClass(FactoryMetaClass):
-    def __new__(mcs, *args):
-        attrs = args[2]
+    def __new__(mcs, name, bases, attrs):
         if hasattr(attrs['Meta'], 'model'):
-            fuzzy_attributes = mock_schema(attrs['Meta'].model)
-            for parent in args[1]:
+            version = attrs.get('_version', None)
+            fuzzy_attributes = mock_schema(attrs['Meta'].model, version)
+            for parent in bases:
                 fuzzy_attributes.update(parent._meta.pre_declarations.declarations)
             fuzzy_attributes.update(attrs)
             attrs = fuzzy_attributes
 
-        return super(FactoryAvroMetaClass, mcs).__new__(mcs, args[0], args[1], attrs)
+        return super(FactoryAvroMetaClass, mcs).__new__(mcs, name, bases, attrs)
 
-FactoryAvro = FactoryAvroMetaClass(str('Factory'), (BaseFactory,), {
-    'Meta': BaseMeta,
-    '__doc__': """Factory base with build and create support.
 
-    This class has the ability to support multiple ORMs by using custom creation
-    functions.
-    """,
-})
+FactoryAvro = FactoryAvroMetaClass(
+    str('Factory'),
+    (BaseFactory,),
+    {
+        'Meta': BaseMeta,
+        '__doc__': """Factory base with build and create support.
+
+        This class has the ability to support multiple ORMs by using custom creation
+        functions.
+        """,
+    }
+)
+
+
+class GenericFactoryAvro():
+
+    def __init__(self):
+        pass
+
+    factory_avro_cache = {}
+
+    @staticmethod
+    def register_factory(clazz, factory, version=None):
+        """
+
+        :param clazz:
+        :param factory:
+        :param version:
+        :return:
+        """
+        if version is None:
+            dependency_manager = DependencyManager()
+            version = dependency_manager.get_latest_version()
+        # checks if the factory is already in the cache
+        GenericFactoryAvro.factory_avro_cache[(clazz, version)] = factory
+
+    @staticmethod
+    def get_factory_avro(clazz, version=None):
+        """
+        Returns a generic factory avro to create mock objects
+        :param clazz:
+        :type clazz: ProtocolElement
+        :param version: the package version as of the dependency manager to which the clazz corresponds
+        :type version: str
+        :return:
+        """
+        if version is None:
+            dependency_manager = DependencyManager()
+            version = dependency_manager.get_latest_version()
+        # checks if the factory is already in the cache
+        if (clazz, version) in GenericFactoryAvro.factory_avro_cache:
+            return GenericFactoryAvro.factory_avro_cache[(clazz, version)]
+
+        class ClazzFactory(FactoryAvro):
+            def __init__(self, *args, **kwargs):
+                ClazzFactory.super(self).__init__(*args, **kwargs)
+
+            class Meta:
+                model = clazz
+
+            _version = version
+
+        GenericFactoryAvro.factory_avro_cache[(clazz, version)] = ClazzFactory
+        return ClazzFactory

--- a/protocols/util/factories/ga4gh_factories.py
+++ b/protocols/util/factories/ga4gh_factories.py
@@ -3,7 +3,8 @@ import itertools
 import factory.fuzzy
 
 from protocols.ga4gh_3_0_0 import Variant, Call
-from .avro_factory import FactoryAvro
+from protocols.util.dependency_manager import VERSION_430
+from protocols.util.factories.avro_factory import FactoryAvro, GenericFactoryAvro
 
 
 class GA4GHVariantFactory(FactoryAvro):
@@ -12,6 +13,9 @@ class GA4GHVariantFactory(FactoryAvro):
 
     class Meta:
         model = Variant
+
+    _version = VERSION_430
+
     start = factory.fuzzy.FuzzyInteger(1, 10000000)
     referenceBases = factory.fuzzy.FuzzyChoice(['A', 'T', 'C', 'G'])
     alternateBases = factory.LazyAttribute(lambda x: [factory.fuzzy.FuzzyChoice(['A', 'T', 'C', 'G']).fuzz()])
@@ -40,6 +44,8 @@ class CallFactory(FactoryAvro):
 
     class Meta:
         model = Call
+
+    _version = VERSION_430
 
     callSetName = factory.Sequence(lambda n: 'Sample%d' % n)
     callSetId = factory.Sequence(lambda n: '%d' % n)

--- a/protocols/util/factories/reports_3_0_0_factories.py
+++ b/protocols/util/factories/reports_3_0_0_factories.py
@@ -1,8 +1,5 @@
-import itertools
-import json
-
 import factory.fuzzy
-
+from protocols.util.dependency_manager import VERSION_300
 from protocols.reports_3_0_0 import (
     CancerParticipant,
     CancerSample,
@@ -11,8 +8,15 @@ from protocols.reports_3_0_0 import (
     Actions,
     CancerInterpretationRequest,
     VersionControl,
-    CancerDemographics, ConsentStatus, File, MatchedSamples, GenomicFeatureCancer, ReportedSomaticVariants)
-from avro_factory import FactoryAvro
+    CancerDemographics,
+    ConsentStatus,
+    File,
+    MatchedSamples,
+    GenomicFeatureCancer,
+    ReportedSomaticVariants
+)
+from protocols.util.factories.avro_factory import FactoryAvro
+
 
 class ConsentStatusFactory(FactoryAvro):
     def __init__(self, *args, **kwargs):
@@ -21,6 +25,8 @@ class ConsentStatusFactory(FactoryAvro):
     class Meta:
         model = ConsentStatus
 
+    _version = VERSION_300
+
 
 class CancerDemographicsFactory(FactoryAvro):
     def __init__(self, *args, **kwargs):
@@ -28,6 +34,8 @@ class CancerDemographicsFactory(FactoryAvro):
 
     class Meta:
         model = CancerDemographics
+
+    _version = VERSION_300
 
 
     consentStatus = factory.SubFactory(ConsentStatusFactory)
@@ -38,6 +46,9 @@ class CancerSampleFactory(FactoryAvro):
 
     class Meta:
         model = CancerSample
+
+    _version = VERSION_300
+
     labId = '1'
     preservationMethod = factory.fuzzy.FuzzyChoice(["FF", "FFPE"])
     phase = factory.fuzzy.FuzzyChoice(["PRIMARY"])
@@ -50,6 +61,8 @@ class CancerParticipantFactory(FactoryAvro):
 
     class Meta:
         model = CancerParticipant
+
+    _version = VERSION_300
 
     cancerDemographics = factory.SubFactory(CancerDemographicsFactory)
     versionControl = VersionControl()
@@ -83,6 +96,8 @@ class FileFactory(FactoryAvro):
     class Meta:
         model = File
 
+    _version = VERSION_300
+
 
 class ActionsFactory(FactoryAvro):
     def __init__(self, *args, **kwargs):
@@ -91,12 +106,16 @@ class ActionsFactory(FactoryAvro):
     class Meta:
         model = Actions
 
+    _version = VERSION_300
+
 class GenomicFeatureCancerFactory(FactoryAvro):
     def __init__(self, *args, **kwargs):
         super(GenomicFeatureCancerFactory, self).__init__(*args, **kwargs)
 
     class Meta:
         model = GenomicFeatureCancer
+
+    _version = VERSION_300
 
 
 class ReportEventCancerFactory(FactoryAvro):
@@ -105,6 +124,8 @@ class ReportEventCancerFactory(FactoryAvro):
 
     class Meta:
         model = ReportEventCancer
+
+    _version = VERSION_300
 
     genomicFeatureCancer = factory.SubFactory(GenomicFeatureCancerFactory)
     soTerms = [str(factory.fuzzy.FuzzyText('SO:', length=7).fuzz()) for _ in range(0, 2)]
@@ -132,6 +153,8 @@ class CancerReportedVariantsFactory(FactoryAvro):
 
     class Meta:
         model = ReportedVariantCancer
+
+    _version = VERSION_300
 
     chromosome = factory.fuzzy.FuzzyChoice(list(map(str, range(1, 23)) + ['X', 'Y', 'MT']))
     position = factory.fuzzy.FuzzyInteger(1, 10000000)
@@ -169,6 +192,8 @@ class ReportedSomaticVariantsFactory(FactoryAvro):
     class Meta:
         model = ReportedSomaticVariants
 
+    _version = VERSION_300
+
     reportedVariantCancer = factory.SubFactory(CancerReportedVariantsFactory)
     somaticOrGermline = 'somatic'
 
@@ -179,6 +204,8 @@ class CancerInterpretationRequestFactory(FactoryAvro):
 
     class Meta:
         model = CancerInterpretationRequest
+
+    _version = VERSION_300
 
     reportVersion = 1
     reportRequestId = factory.Sequence(lambda n: 'CIPID-{}-1'.format(n))

--- a/protocols/util/factories/reports_4_1_0_factories.py
+++ b/protocols/util/factories/reports_4_1_0_factories.py
@@ -1,16 +1,13 @@
-import itertools
-import json
 from random import randint
 import factory.fuzzy
-
+from protocols.util.dependency_manager import VERSION_410
 from protocols.reports_4_1_0 import (
     CancerExitQuestionnaire,
     CancerSomaticVariantLevelQuestions,
     CancerGermlineVariantLevelQuestions,
     CancerCaseLevelQuestions
 )
-
-from avro_factory import FactoryAvro
+from protocols.util.factories.avro_factory import FactoryAvro
 
 
 def aux_ramdom_variant_method():
@@ -28,6 +25,8 @@ class CancerCaseLevelQuestionsFactory(FactoryAvro):
     class Meta:
         model = CancerCaseLevelQuestions
 
+    _version = VERSION_410
+
     total_review_time = factory.fuzzy.FuzzyFloat(1.0, 10.0)
     mdt1_time = factory.fuzzy.FuzzyFloat(1.0, 10.0,)
     mdt2_time = factory.fuzzy.FuzzyChoice([None, factory.fuzzy.FuzzyFloat(1.0, 10.0).fuzz()])
@@ -44,18 +43,26 @@ class CancerCaseLevelQuestionsFactory(FactoryAvro):
 class CancerSomaticVariantLevelQuestionsFactory(FactoryAvro):
     class Meta:
         model = CancerSomaticVariantLevelQuestions
+
+    _version = VERSION_410
+
     variantDetails = factory.LazyAttribute(lambda x: aux_ramdom_variant_method())
 
 
 class CancerGermlineVariantLevelQuestionsFactory(FactoryAvro):
     class Meta:
         model = CancerGermlineVariantLevelQuestions
+
+    _version = VERSION_410
+
     variantDetails = factory.LazyAttribute(lambda x: aux_ramdom_variant_method())
 
 
 class CancerExitQuestionnaireFactory(FactoryAvro):
     class Meta:
         model = CancerExitQuestionnaire
+
+    _version = VERSION_410
 
     caseLevelQuestions = factory.SubFactory(CancerCaseLevelQuestionsFactory)
     somaticVariantLevelQuestions = factory.LazyAttribute(lambda x: [i for i in CancerSomaticVariantLevelQuestionsFactory.create_batch(randint(0, 10))])


### PR DESCRIPTION
Created a generic mock factory based on factory-boy.
Now you can create any valid mock object for any model version as follows:
```
interpretation_request_factory = GenericFactoryAvro.get_factory_avro(
    protocols.reports_4_2_0.InterpretationRequestRD,
    version = VERSION_430
)
instance = interpretation_request_factory()
self.assertTrue(instance.validate(instance.toJsonDict()))
```
There is also a dependency manager that reads `builds.json` and exposes useful information about versions and dependencies.

- [x] Tests passing locally:
```
(.env) $ python -m unittest discover
...........................................................................
----------------------------------------------------------------------
Ran 75 tests in 2.568s

OK
(.env) $ 
```
