### PR TITLE
Feature - Migrations use mocked data factories

### DIFF
--- a/protocols/migration/base_migration.py
+++ b/protocols/migration/base_migration.py
@@ -9,6 +9,7 @@ class BaseMigration(object):
             from protocols.util import handle_avro_errors
             from pprint import pprint
             pprint(handle_avro_errors(object_to_validate.validate_parts()))
+            print object_to_validate.validate(object_to_validate.toJsonDict(), verbose=True).messages
             raise Exception("New {object_type} object is not valid".format(object_type=object_type))
 
     @staticmethod

--- a/protocols/migration/base_migration.py
+++ b/protocols/migration/base_migration.py
@@ -9,7 +9,11 @@ class BaseMigration(object):
             from protocols.util import handle_avro_errors
             from pprint import pprint
             pprint(handle_avro_errors(object_to_validate.validate_parts()))
-            print object_to_validate.validate(object_to_validate.toJsonDict(), verbose=True).messages
+
+            for message in object_to_validate.validate(object_to_validate.toJsonDict(), verbose=True).messages:
+                print "---------------"
+                print message
+
             raise Exception("New {object_type} object is not valid".format(object_type=object_type))
 
     @staticmethod

--- a/protocols/migration/base_migration.py
+++ b/protocols/migration/base_migration.py
@@ -10,3 +10,12 @@ class BaseMigration(object):
             from pprint import pprint
             pprint(handle_avro_errors(object_to_validate.validate_parts()))
             raise Exception("New {object_type} object is not valid".format(object_type=object_type))
+
+    @staticmethod
+    def convert_string_to_integer(string):
+        if string is None:
+            return None
+        try:
+            return int(string)
+        except ValueError:
+            raise Exception("Value: {string} is not an integer contained in a string !".format(string=string))

--- a/protocols/migration/migration.py
+++ b/protocols/migration/migration.py
@@ -7,7 +7,6 @@ class Migration3_0_0To3_1_0(object):
 
     def migrate_interpretation_request_rd(self, interpretation_request):
         """
-
         :type interpretation_request: reports_3_0_0.InterpretationRequestRD
         :rtype: reports_3_1_0.InterpretationRequestRD
         """

--- a/protocols/migration/migration_reports_3_0_0_to_participant_1_0_0.py
+++ b/protocols/migration/migration_reports_3_0_0_to_participant_1_0_0.py
@@ -30,21 +30,19 @@ class MigrateReports3ToParticipant1(BaseMigration):
         new_cancer_participant.readyForAnalysis = True
 
         germline_samples = [
-            sample for sample in old_cancer_participant.cancerSamples if sample.sampleType == 'germline'
+            sample for sample in old_cancer_participant.cancerSamples if sample.sampleType == self.old_model.SampleType.germline
         ]
         new_cancer_participant.germlineSamples = [self.migrate_germline_sample(sample) for sample in germline_samples]
 
         tumor_samples = [
-            sample for sample in old_cancer_participant.cancerSamples if sample.sampleType == 'tumor'
+            sample for sample in old_cancer_participant.cancerSamples if sample.sampleType == self.old_model.SampleType.tumor
         ]
 
         new_cancer_participant.tumourSamples = [self.migrate_tumor_sample(sample) for sample in tumor_samples]
 
-        if new_cancer_participant.validate(new_cancer_participant.toJsonDict()):
-            return new_cancer_participant
-        else:
-            # TODO(Greg): Improve these error messages
-            raise Exception('This model can not be converted: ', new_cancer_participant.validate_parts())
+        return self.validate_object(
+            object_to_validate=new_cancer_participant, object_type=self.new_model.CancerParticipant
+        )
 
     def migrate_tumor_sample(self, old_cancer_sample):
 
@@ -74,11 +72,9 @@ class MigrateReports3ToParticipant1(BaseMigration):
 
         new_tumour_sample.tumourId = 1
 
-        if new_tumour_sample.validate(new_tumour_sample.toJsonDict()):
-            return new_tumour_sample
-        else:
-            # TODO(Greg): Improve these error messages
-            raise Exception('This model can not be converted: ', handle_avro_errors(new_tumour_sample.validate_parts()))
+        return self.validate_object(
+            object_to_validate=new_tumour_sample, object_type=self.new_model.TumourSample
+        )
 
     def migrate_germline_sample(self, old_cancer_sample):
 

--- a/protocols/migration/migration_reports_3_0_0_to_participant_1_0_0.py
+++ b/protocols/migration/migration_reports_3_0_0_to_participant_1_0_0.py
@@ -1,9 +1,13 @@
 from protocols import participant_1_0_0
 from protocols import reports_3_0_0
 from protocols.util import handle_avro_errors
+from protocols.migration.base_migration import BaseMigration
 
 
-class MigrateReports3ToParticipant1(object):
+class MigrateReports3ToParticipant1(BaseMigration):
+    """
+    Any participant with empty labId in tumour or germline sample will fail to validate.
+    """
     old_model = reports_3_0_0
     new_model = participant_1_0_0
 
@@ -105,10 +109,3 @@ class MigrateReports3ToParticipant1(object):
             self.old_model.Sex.undetermined: self.new_model.Sex.UNKNOWN,
         }
         return sex_map.get(old_sex, self.new_model.Sex.UNKNOWN)
-
-    @staticmethod
-    def convert_string_to_integer(string):
-        try:
-            return int(string)
-        except ValueError:
-            raise Exception("Value: {string} is not an integer contained in a string !".format(string=string))

--- a/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0.py
+++ b/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0.py
@@ -84,9 +84,12 @@ class MigrateReports3To420(BaseMigration):
 
         new_clinical_report_rd.interpretationRequestId = old_clinical_report_rd.interpretationRequestID
 
-        new_clinical_report_rd.candidateVariants = self.migrate_reported_variants(
-            old_reported_variants=old_clinical_report_rd.candidateVariants
-        )
+        if old_clinical_report_rd.candidateVariants is not None:
+            new_clinical_report_rd.candidateVariants = self.migrate_reported_variants(
+                old_reported_variants=old_clinical_report_rd.candidateVariants
+            )
+        else:
+            new_clinical_report_rd.candidateVariants = None
 
         new_clinical_report_rd.candidateStructuralVariants = self.migrate_reported_structural_variants(
             old_reported_structural_variants=old_clinical_report_rd.candidateStructuralVariants

--- a/protocols/migration/migration_reports_3_1_0_to_participant_1_0_0.py
+++ b/protocols/migration/migration_reports_3_1_0_to_participant_1_0_0.py
@@ -1,8 +1,12 @@
 from protocols import reports_3_1_0
 from protocols import participant_1_0_0
+from protocols.migration.base_migration import BaseMigration
 
 
-class MigrateReports3ToParticipant1(object):
+class MigrateReports3ToParticipant1(BaseMigration):
+    """
+    Any participant with empty labId in tumour or germline sample will fail to validate.
+    """
     old_model = reports_3_1_0
     new_model = participant_1_0_0
 
@@ -90,10 +94,3 @@ class MigrateReports3ToParticipant1(object):
             self.old_model.Sex.undetermined: self.new_model.Sex.UNKNOWN,
         }
         return sex_map.get(old_sex, self.new_model.Sex.UNKNOWN)
-
-    @staticmethod
-    def convert_string_to_integer(string):
-        try:
-            return int(string)
-        except ValueError:
-            raise Exception("Value: {string} is not an integer contained in a string !".format(string=string))

--- a/protocols/migration/migration_reports_4_0_0_to_reports_4_2_0.py
+++ b/protocols/migration/migration_reports_4_0_0_to_reports_4_2_0.py
@@ -161,9 +161,6 @@ class MigrateReports400To420(BaseMigration):
                     action=action
                 ))
             new_report_event.actions = new_actions
-        new_report_event.actions = self.new_model.Action()
-
-
 
         return self.validate_object(
             object_to_validate=new_report_event, object_type=self.new_model.ReportEventCancer
@@ -179,10 +176,10 @@ class MigrateReports400To420(BaseMigration):
         )
 
         action_types_map = {
-            "therapy": self.new_model.ActionType.therapy,
-            "therapeutic": self.new_model.ActionType.therapeutic,
-            "diagnosis": self.new_model.ActionType.diagnosis,
-            "prognosis": self.new_model.ActionType.prognosis
+            self.old_model.ActionType.therapy: self.new_model.ActionType.therapy,
+            self.old_model.ActionType.therapeutic: self.new_model.ActionType.therapeutic,
+            self.old_model.ActionType.diagnosis: self.new_model.ActionType.diagnosis,
+            self.old_model.ActionType.prognosis: self.new_model.ActionType.prognosis
         }
 
         action_status_map = {

--- a/protocols/migration/migration_reports_4_0_0_to_reports_4_2_0.py
+++ b/protocols/migration/migration_reports_4_0_0_to_reports_4_2_0.py
@@ -155,11 +155,15 @@ class MigrateReports400To420(BaseMigration):
         )
 
         new_actions = []
-        for action in report_event.actions:
-            new_actions.append(self.migrate_action(
-                action=action
-            ))
-        new_report_event.actions = new_actions
+        if report_event.actions is not None:
+            for action in report_event.actions:
+                new_actions.append(self.migrate_action(
+                    action=action
+                ))
+            new_report_event.actions = new_actions
+        new_report_event.actions = self.new_model.Action()
+
+
 
         return self.validate_object(
             object_to_validate=new_report_event, object_type=self.new_model.ReportEventCancer

--- a/protocols/migration/migration_reports_4_2_0_to_reports_4_0_0.py
+++ b/protocols/migration/migration_reports_4_2_0_to_reports_4_0_0.py
@@ -9,6 +9,12 @@ class MigrateReports420To400(BaseMigration):
     We only need migration from 4.2.0 to 4.0.0 to send cancer cases to Illumina.
     Illumina will be returning ClinicalReports in version 4.0.0.
     We don't need to migrate any rare disease case.
+
+    This target schema is missing the attribute `groupOfVariants`, this means we will lose the information related
+    to composite heterozygous variants.
+    The target schema is missing the list of `VariantCall` that includes the important attribute `sampleId`. This means
+    we will lose the ability to represent multiple variant calls for the same ReportEvent and furthermore we lose the
+    reference to the sampleId in the ReportedVariant.
     """
     old_model = reports_4_2_0
     new_model = reports_4_0_0
@@ -97,7 +103,8 @@ class MigrateReports420To400(BaseMigration):
 
     def migrate_report_event_cancer(self, report_event_cancer):
         """
-        This migration is missing the attribute `groupOfVariants`, this will stop
+        This migration is missing the attribute `groupOfVariants`, this means we will lose the information related
+        to composite heterozygous variants.
         :type report_event_cancer: reports_4_2_0.ReportEventCancer
         :rtype: reports_4_0_0.ReportEventCancer
         """

--- a/protocols/migration/participants.py
+++ b/protocols/migration/participants.py
@@ -219,7 +219,11 @@ class MigrationReportsToParticipants1(BaseMigration):
         new_pedigree = self.new_model.Pedigree.fromJsonDict(pedigree.toJsonDict())
         new_pedigree.versionControl = self.new_model.VersionControl()
         new_pedigree.members = [self.migrate_pedigree_member(member=member) for member in pedigree.participants]
-        new_pedigree.analysisPanels = [self.migrate_analysis_panel(analysis_panel=panel) for panel in pedigree.analysisPanels]
+        analysis_panels = []
+        if pedigree.analysisPanels is not None:
+            for analysis_panel in pedigree.analysisPanels:
+                analysis_panels.append(self.migrate_analysis_panel(analysis_panel=analysis_panel))
+        new_pedigree.analysisPanels = analysis_panels
         new_pedigree.readyForAnalysis = ready_for_analysis
         new_pedigree.familyId = pedigree.gelFamilyId
         if new_pedigree.validate(new_pedigree.toJsonDict()):

--- a/protocols/migration/participants.py
+++ b/protocols/migration/participants.py
@@ -5,6 +5,7 @@ from protocols import participant_1_0_3
 from protocols import participant_1_0_4
 from protocols.util import handle_avro_errors
 from protocols.migration import BaseMigration
+from protocols.reports_4_0_0 import MatchedSamples
 
 
 class MigrationParticipants100To104(BaseMigration):
@@ -33,10 +34,22 @@ class MigrationParticipants100To104(BaseMigration):
         migrated_participant.germlineSamples = self.migrate_germline_samples(
             germline_samples=cancer_participant.germlineSamples, LDPCode=cancer_participant.LDPCode
         )
+        migrated_participant.matchedSamples = self.migrate_matched_samples(
+            matched_samples=cancer_participant.matchedSamples
+        )
 
         return self.validate_object(
             object_to_validate=migrated_participant, object_type=self.new_model.CancerParticipant
         )
+
+    def migrate_matched_samples(self, matched_samples):
+        if matched_samples is None:
+            ms = MatchedSamples()
+            return [ms]
+        return [self.migrate_matched_sample(matched_sample=matched_sample) for matched_sample in matched_samples]
+
+    def migrate_matched_sample(self, matched_sample):
+        return MatchedSamples().fromJsonDict(jsonDict=matched_sample.toJsonDict())
 
     def migrate_tumour_sample(self, tumour_sample, LDPCode):
         migrated_tumour_sample = self.new_model.TumourSample.fromJsonDict(tumour_sample.toJsonDict())

--- a/protocols/migration/participants.py
+++ b/protocols/migration/participants.py
@@ -5,7 +5,6 @@ from protocols import participant_1_0_3
 from protocols import participant_1_0_4
 from protocols.util import handle_avro_errors
 from protocols.migration import BaseMigration
-from protocols.reports_4_0_0 import MatchedSamples
 
 
 class MigrationParticipants100To104(BaseMigration):
@@ -44,12 +43,12 @@ class MigrationParticipants100To104(BaseMigration):
 
     def migrate_matched_samples(self, matched_samples):
         if matched_samples is None:
-            ms = MatchedSamples()
+            ms = self.new_model.MatchedSamples()
             return [ms]
         return [self.migrate_matched_sample(matched_sample=matched_sample) for matched_sample in matched_samples]
 
     def migrate_matched_sample(self, matched_sample):
-        return MatchedSamples().fromJsonDict(jsonDict=matched_sample.toJsonDict())
+        return self.new_model.MatchedSamples().fromJsonDict(jsonDict=matched_sample.toJsonDict())
 
     def migrate_tumour_sample(self, tumour_sample, LDPCode):
         migrated_tumour_sample = self.new_model.TumourSample.fromJsonDict(tumour_sample.toJsonDict())

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_participant_1_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_participant_1_0_0.py
@@ -5,9 +5,12 @@ from protocols.participant_1_0_0 import CancerParticipant as CancerParticipant_n
 from protocols.migration.migration_reports_3_0_0_to_participant_1_0_0 import MigrateReports3ToParticipant1
 from protocols.util.factories.avro_factory import GenericFactoryAvro
 from protocols.util.dependency_manager import VERSION_400, VERSION_300
+from protocols import reports_3_0_0
 
 
 class TestMigrateReports3ToParticipant1(TestCase):
+
+    old_model = reports_3_0_0
 
     def test_migrate_cancer_participant(self):
 
@@ -19,6 +22,7 @@ class TestMigrateReports3ToParticipant1(TestCase):
             cancer_sample.tumorSubType = 'mock_subtype'
             cancer_sample.tumorContent = 'High'
             cancer_sample.labId = "1"
+        old_participant.cancerSamples[0].sampleType = self.old_model.SampleType.tumor
 
         # Check old_participant is a valid reports_3_0_0 CancerParticipant object
         self.assertTrue(isinstance(old_participant, CancerParticipant_old))

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_participant_1_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_participant_1_0_0.py
@@ -1,22 +1,24 @@
 from unittest import TestCase
 
-from protocols.util import get_valid_cancer_participant_3_0_0
-from protocols.util import get_valid_cancer_participant_1_0_0
 from protocols.reports_3_0_0 import CancerParticipant as CancerParticipant_old
 from protocols.participant_1_0_0 import CancerParticipant as CancerParticipant_new
 from protocols.migration.migration_reports_3_0_0_to_participant_1_0_0 import MigrateReports3ToParticipant1
+from protocols.util.factories.avro_factory import GenericFactoryAvro
+from protocols.util.dependency_manager import VERSION_400, VERSION_300
 
 
 class TestMigrateReports3ToParticipant1(TestCase):
 
     def test_migrate_cancer_participant(self):
 
-        old_participant = get_valid_cancer_participant_3_0_0()
-        new_participant = get_valid_cancer_participant_1_0_0()
+        old_participant = GenericFactoryAvro.get_factory_avro(CancerParticipant_old, VERSION_300)()
+        new_participant = GenericFactoryAvro.get_factory_avro(CancerParticipant_new, VERSION_400)()
 
-        old_participant.cancerSamples[0].tumorType = 'lung'
-        old_participant.cancerSamples[0].tumorSubType = 'mock_subtype'
-        old_participant.cancerSamples[0].tumorContent = 'High'
+        for cancer_sample in old_participant.cancerSamples:
+            cancer_sample.tumorType = 'lung'
+            cancer_sample.tumorSubType = 'mock_subtype'
+            cancer_sample.tumorContent = 'High'
+            cancer_sample.labId = "1"
 
         # Check old_participant is a valid reports_3_0_0 CancerParticipant object
         self.assertTrue(isinstance(old_participant, CancerParticipant_old))

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_0_0.py
@@ -5,22 +5,21 @@ from protocols.reports_3_0_0 import ReportEventCancer as ReportEventCancer_old
 from protocols.reports_3_0_0 import ReportedSomaticVariants as ReportedSomaticVariants_old
 from protocols.reports_4_0_0 import ReportEventCancer as ReportEventCancer_new
 from protocols.reports_4_0_0 import ReportedSomaticVariants as ReportedSomaticVariants_new
-from protocols.util import get_valid_reported_somatic_variant_3_0_0
-from protocols.util import get_valid_reported_somatic_variant_4_0_0
-from protocols.util.generate_mock_objects import get_valid_report_event_cancer_3_0_0
+from protocols.util.dependency_manager import VERSION_300, VERSION_400
+from protocols.util.factories.avro_factory import GenericFactoryAvro
 
 
 class TestMigrateReports3To4(TestCase):
 
     def test_migrate_reported_somatic_variants(self):
 
-        old_variants = get_valid_reported_somatic_variant_3_0_0()
+        old_variants = GenericFactoryAvro.get_factory_avro(ReportedSomaticVariants_old, VERSION_300)()
 
         # Check old_variants is a valid reports_3_0_0 ReportedSomaticVariants object
         self.assertTrue(isinstance(old_variants, ReportedSomaticVariants_old))
         self.assertTrue(old_variants.validate(jsonDict=old_variants.toJsonDict()))
 
-        new_variants = get_valid_reported_somatic_variant_4_0_0()
+        new_variants = GenericFactoryAvro.get_factory_avro(ReportedSomaticVariants_new, VERSION_400)()
 
         # Check new_variants is a valid participant_1_0_0 ReportedSomaticVariants object
         self.assertTrue(isinstance(new_variants, ReportedSomaticVariants_new))
@@ -34,7 +33,7 @@ class TestMigrateReports3To4(TestCase):
 
     def test_migrate_report_event_cancer(self):
 
-        old_report_event_cancer = get_valid_report_event_cancer_3_0_0()
+        old_report_event_cancer = GenericFactoryAvro.get_factory_avro(ReportEventCancer_old, VERSION_300)()
 
         # Check old_report_event_cancer is a valid reports_3_0_0.ReportEventCancer object
         self.assertTrue(isinstance(old_report_event_cancer, ReportEventCancer_old))
@@ -53,7 +52,7 @@ class TestMigrateReports3To4(TestCase):
         """
 
         for valid_cancer_role in ['oncogene', 'TSG', 'both']:
-            old_report_event_cancer = get_valid_report_event_cancer_3_0_0()
+            old_report_event_cancer = GenericFactoryAvro.get_factory_avro(ReportEventCancer_old, VERSION_300)()
             old_report_event_cancer.genomicFeatureCancer.roleInCancer = valid_cancer_role
 
             migrated_report_event_cancer = MigrateReports3To4().migrate_report_event_cancer(old_report_event_cancer)
@@ -63,7 +62,7 @@ class TestMigrateReports3To4(TestCase):
                 old_report_event_cancer.genomicFeatureCancer.roleInCancer,
                 migrated_report_event_cancer.genomicFeatureCancer.roleInCancer,
             )
-        old_report_event_cancer = get_valid_report_event_cancer_3_0_0()
+        old_report_event_cancer = GenericFactoryAvro.get_factory_avro(ReportEventCancer_old, VERSION_300)()
         old_report_event_cancer.genomicFeatureCancer.roleInCancer = 'not an included cancer role'
 
         migrated_report_event_cancer = MigrateReports3To4().migrate_report_event_cancer(old_report_event_cancer)

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_0_0.py
@@ -1,34 +1,39 @@
 from unittest import TestCase
 
-from protocols.migration.migration_reports_3_0_0_to_reports_4_0_0 import MigrateReports3To4
-from protocols.reports_3_0_0 import ReportEventCancer as ReportEventCancer_old
-from protocols.reports_3_0_0 import ReportedSomaticVariants as ReportedSomaticVariants_old
-from protocols.reports_4_0_0 import ReportEventCancer as ReportEventCancer_new
-from protocols.reports_4_0_0 import ReportedSomaticVariants as ReportedSomaticVariants_new
-from protocols.util.dependency_manager import VERSION_300, VERSION_400
+from protocols import reports_3_0_0
+from protocols import reports_4_0_0
+from protocols.util.dependency_manager import VERSION_300
+from protocols.util.dependency_manager import VERSION_400
 from protocols.util.factories.avro_factory import GenericFactoryAvro
+from protocols.reports_3_0_0 import ReportEventCancer as ReportEventCancer_old
+from protocols.reports_4_0_0 import ReportEventCancer as ReportEventCancer_new
+from protocols.migration.migration_reports_3_0_0_to_reports_4_0_0 import MigrateReports3To4
 
 
 class TestMigrateReports3To4(TestCase):
 
+    old_model = reports_3_0_0
+    new_model = reports_4_0_0
+
     def test_migrate_reported_somatic_variants(self):
 
-        old_variants = GenericFactoryAvro.get_factory_avro(ReportedSomaticVariants_old, VERSION_300)()
+        old_variants = GenericFactoryAvro.get_factory_avro(self.old_model.ReportedSomaticVariants, VERSION_300)()
+        old_variants.somaticOrGermline = self.old_model.SomaticOrGermline.somatic
 
         # Check old_variants is a valid reports_3_0_0 ReportedSomaticVariants object
-        self.assertTrue(isinstance(old_variants, ReportedSomaticVariants_old))
+        self.assertTrue(isinstance(old_variants, self.old_model.ReportedSomaticVariants))
         self.assertTrue(old_variants.validate(jsonDict=old_variants.toJsonDict()))
 
-        new_variants = GenericFactoryAvro.get_factory_avro(ReportedSomaticVariants_new, VERSION_400)()
+        new_variants = GenericFactoryAvro.get_factory_avro(self.new_model.ReportedSomaticVariants, VERSION_400)()
 
         # Check new_variants is a valid participant_1_0_0 ReportedSomaticVariants object
-        self.assertTrue(isinstance(new_variants, ReportedSomaticVariants_new))
+        self.assertTrue(isinstance(new_variants, self.new_model.ReportedSomaticVariants))
         self.assertTrue(new_variants.validate(jsonDict=new_variants.toJsonDict()))
 
         migrated_object = MigrateReports3To4().migrate_reported_somatic_variants(old_variants)
 
         # Check migrated_object is a valid participant_1_0_0 ReportedSomaticVariants object
-        self.assertTrue(isinstance(migrated_object, ReportedSomaticVariants_new))
+        self.assertTrue(isinstance(migrated_object, self.new_model.ReportedSomaticVariants))
         self.assertTrue(migrated_object.validate(jsonDict=migrated_object.toJsonDict()))
 
     def test_migrate_report_event_cancer(self):

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 from protocols.migration import MigrateReports3To420
 from protocols import reports_4_2_0
 from protocols import reports_3_0_0
-from protocols import util
+from protocols.util.dependency_manager import VERSION_300
+from protocols.util.factories.avro_factory import GenericFactoryAvro
 
 
 class TestMigrateReports3To420(TestCase):
@@ -13,15 +14,17 @@ class TestMigrateReports3To420(TestCase):
 
     def test_migrate_interpretation_request_rd(self):
 
-        old_interpretation_request_rd = util.get_valid_interpretation_request_rd_3_0_0()
+        old_interpretation_request_rd = GenericFactoryAvro.get_factory_avro(
+            reports_3_0_0.InterpretationRequestRD, VERSION_300
+        )()
 
         test_ir_id = 'CHF-2003'
         old_interpretation_request_rd.InterpretationRequestID = test_ir_id
         old_interpretation_request_rd.additionalInfo = {"additional": "info"}
         old_interpretation_request_rd.analysisVersion = '234'
         old_interpretation_request_rd.complexGeneticPhenomena = self.old_model.ComplexGeneticPhenomena.other_aneuploidy
-
-        old_interpretation_request_rd.pedigree.participants[0].affectionStatus = self.old_model.AffectionStatus.unknown
+        for participant in old_interpretation_request_rd.pedigree.participants:
+            participant.affectionStatus = self.old_model.AffectionStatus.unknown
 
         # Check old_interpretation_request_rd is a valid reports_3_0_0 InterpretationRequestRD object
         self.assertTrue(isinstance(old_interpretation_request_rd, self.old_model.InterpretationRequestRD))
@@ -87,9 +90,12 @@ class TestMigrateReports3To420(TestCase):
         self.assertIsNotNone(migrated_object.complexGeneticPhenomena)
         self.assertEqual(migrated_object.complexGeneticPhenomena, old_interpretation_request_rd.complexGeneticPhenomena)
 
-        self.assertIsInstance(migrated_object.otherFamilyHistory, self.new_model.OtherFamilyHistory)
-        self.assertEqual(migrated_object.otherFamilyHistory.maternalFamilyHistory, old_interpretation_request_rd.otherFamilyHistory.maternalFamilyHistory)
-        self.assertEqual(migrated_object.otherFamilyHistory.paternalFamilyHistory, old_interpretation_request_rd.otherFamilyHistory.paternalFamilyHistory)
+        if migrated_object.otherFamilyHistory is not None:
+            self.assertIsInstance(migrated_object.otherFamilyHistory, self.new_model.OtherFamilyHistory)
+            if migrated_object.otherFamilyHistory.maternalFamilyHistory is not None:
+                self.assertEqual(migrated_object.otherFamilyHistory.maternalFamilyHistory, old_interpretation_request_rd.otherFamilyHistory.maternalFamilyHistory)
+            if migrated_object.otherFamilyHistory.paternalFamilyHistory is not None:
+                self.assertEqual(migrated_object.otherFamilyHistory.paternalFamilyHistory, old_interpretation_request_rd.otherFamilyHistory.paternalFamilyHistory)
 
         # Check BAM locations are migrated correctly
         old_bams = old_interpretation_request_rd.BAMs
@@ -116,39 +122,46 @@ class TestMigrateReports3To420(TestCase):
         # Check BigWig locations are migrated correctly
         old_big_wigs = old_interpretation_request_rd.bigWigs
         new_big_wigs = migrated_object.bigWigs
-        for old_big_wig, new_big_wig in zip(old_big_wigs, new_big_wigs):
-            self.assertIsInstance(new_big_wig, self.new_model.File)
+        if old_big_wigs is not None:
+            for old_big_wig, new_big_wig in zip(old_big_wigs, new_big_wigs):
+                self.assertIsInstance(new_big_wig, self.new_model.File)
 
-            self.assertEqual(new_big_wig.sampleId, old_big_wig.SampleId)
-            self.assertEqual(new_big_wig.uriFile, old_big_wig.URIFile)
-            self.assertEqual(new_big_wig.fileType, old_big_wig.fileType)
-            self.assertEqual(new_big_wig.md5Sum, old_big_wig.md5Sum)
+                self.assertEqual(new_big_wig.sampleId, old_big_wig.SampleId)
+                self.assertEqual(new_big_wig.uriFile, old_big_wig.URIFile)
+                self.assertEqual(new_big_wig.fileType, old_big_wig.fileType)
+                self.assertEqual(new_big_wig.md5Sum, old_big_wig.md5Sum)
+        else:
+            self.assertTrue(new_big_wigs is None)
 
         # Check Pedigree Diagram file is migrated correctly
         old_pedigree_diagram = old_interpretation_request_rd.pedigreeDiagram
         new_pedigree_diagram = migrated_object.pedigreeDiagram
-
-        self.assertIsInstance(new_pedigree_diagram, self.new_model.File)
-
-        self.assertEqual(new_pedigree_diagram.sampleId, old_pedigree_diagram.SampleId)
-        self.assertEqual(new_pedigree_diagram.uriFile, old_pedigree_diagram.URIFile)
-        self.assertEqual(new_pedigree_diagram.fileType, old_pedigree_diagram.fileType)
-        self.assertEqual(new_pedigree_diagram.md5Sum, old_pedigree_diagram.md5Sum)
+        if old_pedigree_diagram is not None:
+            self.assertIsInstance(new_pedigree_diagram, self.new_model.File)
+            self.assertEqual(new_pedigree_diagram.sampleId, old_pedigree_diagram.SampleId)
+            self.assertEqual(new_pedigree_diagram.uriFile, old_pedigree_diagram.URIFile)
+            self.assertEqual(new_pedigree_diagram.fileType, old_pedigree_diagram.fileType)
+            self.assertEqual(new_pedigree_diagram.md5Sum, old_pedigree_diagram.md5Sum)
+        else:
+            self.assertTrue(new_pedigree_diagram is None)
 
         # Check Annotation File file is migrated correctly
         old_annotation_file = old_interpretation_request_rd.annotationFile
         new_annotation_file = migrated_object.annotationFile
-
-        self.assertIsInstance(new_annotation_file, self.new_model.File)
-
-        self.assertEqual(new_annotation_file.sampleId, old_annotation_file.SampleId)
-        self.assertEqual(new_annotation_file.uriFile, old_annotation_file.URIFile)
-        self.assertEqual(new_annotation_file.fileType, old_annotation_file.fileType)
-        self.assertEqual(new_annotation_file.md5Sum, old_annotation_file.md5Sum)
+        if old_annotation_file is not None:
+            self.assertIsInstance(new_annotation_file, self.new_model.File)
+            self.assertEqual(new_annotation_file.sampleId, old_annotation_file.SampleId)
+            self.assertEqual(new_annotation_file.uriFile, old_annotation_file.URIFile)
+            self.assertEqual(new_annotation_file.fileType, old_annotation_file.fileType)
+            self.assertEqual(new_annotation_file.md5Sum, old_annotation_file.md5Sum)
+        else:
+            self.assertTrue(new_annotation_file is None)
 
     def test_migrate_interpreted_genome_rd(self):
 
-        old_interpreted_genome_rd = util.get_valid_interpreted_genome_rd_3_0_0()
+        old_interpreted_genome_rd = GenericFactoryAvro.get_factory_avro(
+            reports_3_0_0.InterpretedGenomeRD, VERSION_300
+        )()
 
         # Check old_interpretation_request_rd is a valid reports_3_0_0 InterpretedGenomeRD object
         self.assertTrue(isinstance(old_interpreted_genome_rd, self.old_model.InterpretedGenomeRD))
@@ -164,7 +177,9 @@ class TestMigrateReports3To420(TestCase):
 
     def test_migrate_reported_structural_variant(self):
 
-        old_reported_structural_variant = util.get_valid_reported_structural_variant_3_0_0()
+        old_reported_structural_variant = GenericFactoryAvro.get_factory_avro(
+            reports_3_0_0.ReportedStructuralVariant, VERSION_300
+        )()
 
         # Check old_reported_structural_variant is a valid reports_3_0_0 ReportedStructuralVariant object
         self.assertTrue(isinstance(old_reported_structural_variant, self.old_model.ReportedStructuralVariant))
@@ -180,7 +195,9 @@ class TestMigrateReports3To420(TestCase):
 
     def test_migrate_clinical_report_rd(self):
 
-        old_clinical_report_rd = util.get_valid_clinical_report_rd_3_0_0()
+        old_clinical_report_rd = GenericFactoryAvro.get_factory_avro(
+            reports_3_0_0.ClinicalReportRD, VERSION_300
+        )()
 
         # Check old_clinical_report_rd is a valid reports_3_0_0 ClinicalReportRD object
         self.assertTrue(isinstance(old_clinical_report_rd, self.old_model.ClinicalReportRD))

--- a/protocols/tests/test_migration/test_migration_reports_3_1_0_to_participant_1_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_1_0_to_participant_1_0_0.py
@@ -2,21 +2,37 @@ from unittest import TestCase
 
 from protocols.migration.migration_reports_3_1_0_to_participant_1_0_0 import MigrateReports3ToParticipant1
 from protocols.participant_1_0_0 import CancerParticipant as CancerParticipant_new
-from protocols.reports_3_1_0 import CancerParticipant as CancerParticipant_old
-from protocols.util import get_valid_cancer_participant_3_1_0
-from protocols.util import get_valid_cancer_participant_1_0_0
+from protocols.reports_3_1_0 import CancerParticipant as CancerParticipant_old, MatchedSamples as MatchedSamples
+from protocols.util.dependency_manager import VERSION_310, VERSION_400
+from protocols.util.factories.avro_factory import GenericFactoryAvro
 
 
 class TestMigrateReports3ToParticipant1(TestCase):
 
     def test_migrate_cancer_participant(self):
 
-        old_participant = get_valid_cancer_participant_3_1_0()
+        old_participant = GenericFactoryAvro.get_factory_avro(
+            CancerParticipant_old, VERSION_310
+        )()
+        for cancer_sample in old_participant.cancerSamples:
+            cancer_sample.tumorType = 'lung'
+            cancer_sample.tumorSubType = 'mock_subtype'
+            cancer_sample.tumorContent = 'High'
+            cancer_sample.labId = "1"
+        matched_samples = GenericFactoryAvro.get_factory_avro(
+            MatchedSamples, VERSION_310
+        ).create_batch(5)
+        old_participant.matchedSamples = matched_samples
+
+
         # Check old_participant is a valid reports_3_1_0 CancerParticipant object
         self.assertTrue(isinstance(old_participant, CancerParticipant_old))
         self.assertTrue(old_participant.validate(old_participant.toJsonDict()))
 
-        new_participant = get_valid_cancer_participant_1_0_0()
+        new_participant = GenericFactoryAvro.get_factory_avro(
+            CancerParticipant_new, VERSION_400
+        )()
+
         # Check new_participant is a valid participant_1_0_0 CancerParticipant object
         self.assertTrue(isinstance(new_participant, CancerParticipant_new))
         self.assertTrue(new_participant.validate(jsonDict=new_participant.toJsonDict()))

--- a/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_4_2_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_4_2_0.py
@@ -4,6 +4,8 @@ from protocols import reports_4_0_0
 from protocols import reports_4_2_0
 from protocols.migration import MigrateReports400To420
 from protocols.util import get_valid_cancer_interpretation_request_4_0_0
+from protocols.util.dependency_manager import VERSION_310, VERSION_400
+from protocols.util.factories.avro_factory import GenericFactoryAvro
 
 
 class TestMigrateReports420To4(TestCase):
@@ -13,7 +15,10 @@ class TestMigrateReports420To4(TestCase):
 
     def test_migrate_cir_400_to_420(self):
 
-        cir_400 = get_valid_cancer_interpretation_request_4_0_0()
+        #cir_400 = get_valid_cancer_interpretation_request_4_0_0()
+        cir_400 = GenericFactoryAvro.get_factory_avro(
+            self.old_model.CancerInterpretationRequest, VERSION_400
+        )()
 
         cir_400.cancerParticipant.LDPCode = 'test_LDP_code_migrate_cir_400_to_420'
 

--- a/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_4_2_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_4_2_0.py
@@ -7,7 +7,7 @@ from protocols.util.dependency_manager import VERSION_400
 from protocols.util.factories.avro_factory import GenericFactoryAvro
 
 
-class TestMigrateReports420To4(TestCase):
+class TestMigrateReports4To420(TestCase):
 
     old_model = reports_4_0_0
     new_model = reports_4_2_0
@@ -19,6 +19,9 @@ class TestMigrateReports420To4(TestCase):
         )()
 
         cir_400.cancerParticipant.LDPCode = 'test_LDP_code_migrate_cir_400_to_420'
+        cir_400.tieredVariants[0].reportedVariantCancer.reportEvents[0].actions = [self.old_model.Actions()]
+        cir_400.tieredVariants[0].reportedVariantCancer.reportEvents[0].actions[0].actionType = self.old_model.ActionType.diagnosis
+        cir_400.tieredVariants[0].reportedVariantCancer.reportEvents[0].actions[0].variantActionable = False
 
         self.assertIsInstance(cir_400, self.old_model.CancerInterpretationRequest)
         self.assertTrue(cir_400.validate(cir_400.toJsonDict()))

--- a/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_4_2_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_4_2_0.py
@@ -3,8 +3,7 @@ from unittest import TestCase
 from protocols import reports_4_0_0
 from protocols import reports_4_2_0
 from protocols.migration import MigrateReports400To420
-from protocols.util import get_valid_cancer_interpretation_request_4_0_0
-from protocols.util.dependency_manager import VERSION_310, VERSION_400
+from protocols.util.dependency_manager import VERSION_400
 from protocols.util.factories.avro_factory import GenericFactoryAvro
 
 
@@ -15,7 +14,6 @@ class TestMigrateReports420To4(TestCase):
 
     def test_migrate_cir_400_to_420(self):
 
-        #cir_400 = get_valid_cancer_interpretation_request_4_0_0()
         cir_400 = GenericFactoryAvro.get_factory_avro(
             self.old_model.CancerInterpretationRequest, VERSION_400
         )()

--- a/protocols/util/dependency_manager.py
+++ b/protocols/util/dependency_manager.py
@@ -2,56 +2,54 @@ import ujson
 import importlib
 import os.path
 import inspect
+from protocols.util.singleton import Singleton
 
 
 VERSION_430 = "4.3.0-SNAPSHOT"
-VERSION_300 = "3.0.0"
 VERSION_410 = "4.1.0"
+VERSION_400 = "4.0.0"
+VERSION_310 = "3.1.0"
+VERSION_300 = "3.0.0"
+VERSION_210 = "2.1.0"
 
-class DependencyManager:
+
+class DependencyManager():
     """
     Singleton class that reads builds.json file at the root of the project
     and provides utils for dependency management.
     """
-
-    class __DependencyManager:
-
-        def __init__(self):
-            filename = inspect.getframeinfo(inspect.currentframe()).filename
-            path = os.path.dirname(os.path.abspath(filename))
-            dependencies_json = "{}/../../builds.json".format(path)
-            self.builds = ujson.load(open(dependencies_json))["builds"]
-
-            # prepares resource: version -> namespace -> python package
-            self.versions = {}
-            for build in self.builds:
-                self.versions[build["version"]] = {}
-                for package in build["packages"]:
-                    namespace = package["package"]
-                    _module = DependencyManager.get_python_module(package)
-                    self.versions[build["version"]][namespace] = _module
-
-        def get_version_dependencies(self, version):
-            if version not in self.versions:
-                raise ValueError("Version {} not available in builds.json!".format(version))
-            return self.versions[version]
-
-        def get_latest_version_dependencies(self):
-            latest_version = max(self.versions.keys())
-            return self.versions[latest_version]
-
-        def get_latest_version(self):
-            latest_version = max(self.versions.keys())
-            return latest_version
-
-    instance = None
+    __metaclass__ = Singleton
 
     def __init__(self):
-        if not DependencyManager.instance:
-            DependencyManager.instance = DependencyManager.__DependencyManager()
+        filename = inspect.getframeinfo(inspect.currentframe()).filename
+        path = os.path.dirname(os.path.abspath(filename))
+        dependencies_json = "{}/../../builds.json".format(path)
+        builds = ujson.load(open(dependencies_json))["builds"]
 
-    def __getattr__(self, name):
-        return getattr(self.instance, name)
+        # prepares resource: version -> namespace -> python package
+        self.builds = {}
+        for build in builds:
+            self.builds[build["version"]] = {}
+            for package in build["packages"]:
+                namespace = package["package"]
+                _module = DependencyManager.get_python_module(package)
+                self.builds[build["version"]][namespace] = _module
+
+    def get_version_dependencies(self, version):
+        if version not in self.builds:
+            raise ValueError("Version {} not available in builds.json!".format(version))
+        return self.builds[version]
+
+    def get_latest_version_dependencies(self):
+        latest_version = max(self.builds.keys())
+        return self.builds[latest_version]
+
+    def get_latest_version(self):
+        latest_version = max(self.builds.keys())
+        return latest_version
+
+    def get_package_version(self, package, build_version):
+        return self.builds[build_version][package]
 
     @staticmethod
     def get_python_package_name(package):

--- a/protocols/util/singleton.py
+++ b/protocols/util/singleton.py
@@ -1,0 +1,10 @@
+class Singleton(type):
+    """
+    Use this class as a metaclass to have a singleton.
+    """
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+        return cls._instances[cls]

--- a/schemas/IDLs/org.gel.models.report.avro/4.2.0-SNAPSHOT/ExitQuestionnaire.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/4.2.0-SNAPSHOT/ExitQuestionnaire.avdl
@@ -90,9 +90,209 @@ protocol ExitQuestionnaires {
         string reporter;
         FamilyLevelQuestions familyLevelQuestions;
         array<VariantGroupLevelQuestions> variantGroupLevelQuestions;
+    }
+
+    /**
+    -------------------------------------------------
+    CANCER EXITQUESTIONNAIRE
+    -------------------------------------------------
+    */
+
+    /**
+    An enumeration for Which parts of the WGA were reviewed?:
+        * `domain_1`: Domain 1 only
+        * `domain_1_and_2`: Domains 1 and 2
+        * `domain_1_2_and_suplementary`: Domains 1, 2 and supplementary analysis
+    */
+    enum ReviewedParts {domain_1, domain_1_and_2, domain_1_2_and_suplementary}
+
+    /**
+     * `yes`: yes
+     * `no`: no
+    */
+    enum CancerActionableVariants {yes, no}
+
+    /**
+    An enumeration Variant Actionability:
+        * `predicts_therapeutic_response`: Predicts therapeutic response
+        * `prognostic`: Prognostic
+        * `defines_diagnosis_group`: Defines diagnosis group
+        * `eligibility_for_trial`: Eligibility for trial
+        * `other`:  Other (please specify)
+    */
+    enum CancerActionability {predicts_therapeutic_response, prognostic, defines_diagnosis_group, eligibility_for_trial, other}
+
+    /**
+    An enumeration Variant Usability:
+        * `already_actioned`: Already actioned (i.e. prior to receiving this WGA)
+        * `actioned_result_of_this_wga`: actioned as a result of receiving this WGA
+        * `not_yet_actioned`: not yet actioned, but potentially actionable in the future
+    */
+    enum CancerUsabilitySomatic {already_actioned, actioned_result_of_this_wga, not_yet_actioned}
+
+    /**
+    An enumeration Variant Usability:
+        * `already_actioned`: Already actioned (i.e. prior to receiving this WGA)
+        * `actioned_result_of_this_wga`: actioned as a result of receiving this WGA
+    */
+    enum CancerUsabilityGermline {already_actioned, actioned_result_of_this_wga}
+
+    /**
+    An enumeration Variant tested:
+        * `not_indicated_for_patient_care`: No: not indicated for patient care at this time
+        * `no_orthologous_test_available`: No: no orthologous test available
+        * `test_performed_prior_to_wga`: Yes: test performed prior to receiving WGA (eg using standard-of-care assay such as panel testing, or sanger sequencing)
+        * `technical_validation_following_WGA`: Yes: technical validation performed/planned following receiving this WGA
+    */
+    enum CancerTested {not_indicated_for_patient_care, no_orthologous_test_available, test_performed_prior_to_wga, technical_validation_following_wga}
+
+    record CancerCaseLevelQuestions{
+
+    /**
+    Total time taken to review/collate evidence for variants (hours).
+    Include all literature review time, consultation with relevant experts etc.
+    */
+    double total_review_time;
+
+    /**
+    Time taken to discuss case at MDT (hours).
+    */
+    double mdt1_time;
+
+    /**
+    If the case is discussed at a 2nd MDT please enter time here (hours).
+    */
+    union {null, double} mdt2_time;
+
+    /**
+    Total time to design ALL validation assay(s) for case (hours).
+    Only applicable if it is necessary to design a new assay to validate the variant.
+    */
+    union {null, double} validation_assay_time;
+
+    /**
+    Technical Laboratory Validation. Total time for validation test wet work for all variants (hours).
+    */
+    union {null, double} wet_validation_time;
+
+    /**
+    Analytical Laboratory Validation. Total time for analysis of validation results for all variants (hours).
+    */
+    union {null, double} analytical_validation_time;
+
+    /**
+    Primary Reporting. Time taken to complete primary reporting stage (hours).
+    */
+    double primary_reporting_time;
+
+    /**
+    Report Authorisation. Time taken to check and authorise report (hours).
+    */
+    double primary_authorisation_time;
+
+    /**
+    Report Distribution.
+    Please enter, where possible/accessible how long it takes for the result to be conveyed to the patient.
+    E.g. via letter from the clinician (days).
+    */
+    double report_distribution_time;
+
+    /**
+    Total time from result to report.
+    The total time taken from when the analysis of the WGS results started  to a report being received
+    by the patient include any 'waiting' time (days).
+    */
+    double total_time;
+
+    /**
+    Which parts of the WGA were reviewed?
+    */
+    ReviewedParts reviewedInMdtWga;
+
+    /**
+    Were potentially actionable variants detected?
+    */
+    CancerActionableVariants actionableVariants;
+
+    }
 
 
+    record CancerGermlineVariantLevelQuestions{
+    /**
+    Chr: Pos Ref > Alt
+    */
+    string variantDetails;
 
+    /**
+    How has/will this potentially actionable variant been/be used?
+    */
+    CancerUsabilityGermline variantUsability;
+
+    /**
+    Has this variant been tested by another method (either prior to or following receipt of this WGA)?
+    */
+    CancerTested variantTested;
+
+    /**
+    Please enter validation assay type e.g Pyrosequencing, NGS panel, COBAS, Sanger sequencing. If not applicable enter NA;
+    */
+    string validationAssayType;
+
+    }
+
+    record CancerSomaticVariantLevelQuestions{
+    /**
+    Chr: Pos Ref > Alt
+    */
+    string variantDetails;
+    /**
+    Type of potential actionability:
+    */
+    CancerActionability variantActionability;
+    union {null, string} otherVariantActionability;
+
+    /**
+    How has/will this potentially actionable variant been/be used?
+    */
+    CancerUsabilitySomatic variantUsability;
+
+    /**
+    Has this variant been tested by another method (either prior to or following receipt of this WGA)?
+    */
+    CancerTested variantTested;
+
+    /**
+    Please enter validation assay type e.g Pyrosequencing, NGS panel, COBAS, Sanger sequencing. If not applicable enter NA;
+    */
+    string validationAssayType;
+    }
+
+    record CancerExitQuestionnaire{
+        string eventDate;
+        string reporter;
+        CancerCaseLevelQuestions caseLevelQuestions;
+
+        /**
+        Somatic variants
+        */
+        union {null, array<CancerSomaticVariantLevelQuestions>} somaticVariantLevelQuestions;
+
+        /**
+        Pathogenic germline cancer susceptability variants
+        */
+        union {null, array<CancerGermlineVariantLevelQuestions>} germlineVariantLevelQuestions;
+
+        /**
+        Please enter any additional comments you may have about the case here.
+        */
+        union {null, string} additionalComments;
+
+        /**
+        Other actionable variants or entities.
+        Please provide other (potentially) actionable entities: e.g domain 3 small variants,
+        SV/CNV, mutational signatures, mutational burden
+        */
+        union {null, string} otherActionableVariants;
     }
 
 }


### PR DESCRIPTION
* All migrations are now using the mocked data factories
* Many issues on migration scripts arised when using this mocked data. Some of them due to nullable fields being null in the current mocked data and some others due to not having empty strings on non nullable fields.

Also several glitches migrating between different versions were identified I will report those separately.

@Antonior26 
@greglever 