### PR TITLE
Feature - Remove system check object generation

### DIFF
--- a/protocols/tests/test_util/test_generate_mock_objects.py
+++ b/protocols/tests/test_util/test_generate_mock_objects.py
@@ -457,15 +457,6 @@ class TestGenerateMockObjectsSystem010(TestCase):
         self.assertTrue(isinstance(test_dependencies, self.model.Dependencies))
         self.assertTrue(test_dependencies.validate(test_dependencies.toJsonDict()))
 
-    def test_servicehealth(self):
-        """
-        Ensure generate_mock_objects.get_valid_servicehealth_0_1_0 returns a valid
-        system_0_1_0.ServiceHealth object
-        """
-        test_servicehealth = generate_mock_objects.get_valid_servicehealth_0_1_0()
-        self.assertTrue(isinstance(test_servicehealth, self.model.ServiceHealth))
-        self.assertTrue(test_servicehealth.validate(test_servicehealth.toJsonDict()))
-
 
 class TestGenerateMockObjectsParticipant103(TestCase):
 

--- a/protocols/util/generate_mock_objects.py
+++ b/protocols/util/generate_mock_objects.py
@@ -1757,12 +1757,3 @@ def get_valid_dependencies_0_1_0():
 
     return validate_object(object_to_validate=new_api, object_type=object_type)
 
-
-def get_valid_servicehealth_0_1_0():
-    object_type = system_0_1_0.ServiceHealth
-    new_api = object_type()
-
-    new_api.dependencies = get_valid_dependencies_0_1_0()
-    new_api.status = system_0_1_0.Status.OK
-
-    return validate_object(object_to_validate=new_api, object_type=object_type)


### PR DESCRIPTION
Feature - Remove system check object generation
==========================

Summary of Changes
================
* Remove `get_valid_servicehealth_0_1_0` and `test_servicehealth`

- [x] Tests passing locally:
```
----------------------------------------------------------------------
Ran 75 tests in 3.594s

OK
```