### PR TITLE
Fix - Adding builds.json as a resource to the protocols package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,20 @@
                             </target>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>copy builds.json to python package</id>
+                        <phase>initialize</phase>
+                        <goals><goal>run</goal></goals>
+                        <configuration>
+                            <target>
+                                <copy todir="protocols/resources">
+                                    <fileset dir="">
+                                        <include name="builds.json"/>
+                                    </fileset>
+                                </copy>
+                            </target>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <!--

--- a/protocols/util/dependency_manager.py
+++ b/protocols/util/dependency_manager.py
@@ -23,7 +23,9 @@ class DependencyManager():
     def __init__(self):
         filename = inspect.getframeinfo(inspect.currentframe()).filename
         path = os.path.dirname(os.path.abspath(filename))
-        dependencies_json = "{}/../../builds.json".format(path)
+        dependencies_json = "{}/../resources/builds.json".format(path)
+        if not os.path.exists(dependencies_json):
+            raise ValueError("Not found config file '{}'. Try running 'mvn initialize'".format(dependencies_json))
         builds = ujson.load(open(dependencies_json))["builds"]
 
         # prepares resource: version -> namespace -> python package


### PR DESCRIPTION
builds.json is now copied into the protocols package when we run `mvn initialize`

@greglever 