### PR TITLE
Feature - Remove Maven from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,4 @@ RUN cd ./GelReportModels && \
     pip install --upgrade pip && \
     pip install -r requirements.txt && \
     pip install --upgrade pysam && \
-    mvn clean package -DskipTests && \
-    mvn package -Dp.type=war
-
+    python build2.py --skip-docs


### PR DESCRIPTION
Feature - Remove Maven from Dockerfile
==================================

Summary of Changes
=================
* Replace `mvn` commands with `python build2.py --skip-docs`

Tests and Build
================
- [x]  All tests passing locally
- [x]  Building locally 
```
(.env) $ python -m unittest discover
...............................
----------------------------------------------------------------------
Ran 31 tests in 4.009s

OK

(.env) $ 

```
```
$ sudo ./build_models

...

 ---> 03c943fb28e4
Removing intermediate container 486a0d73e025
Successfully built 03c943fb28e4
Successfully tagged gel:latest

```
