### PR TITLE
IP-428 - Modify md5sum and migration

### DIFF
--- a/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0.py
+++ b/protocols/migration/migration_reports_3_0_0_to_reports_4_2_0.py
@@ -185,7 +185,7 @@ class MigrateReports3To420(BaseMigration):
                 fileType=old_file.fileType,
                 uriFile=old_file.URIFile,
                 sampleId=sampleId,
-                md5Sum=old_file.md5Sum,
+                md5Sum=None,
             )
         if new_file.validate(new_file.toJsonDict()):
             return new_file

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_2_0.py
@@ -15,8 +15,10 @@ class TestMigrateReports3To420(TestCase):
     def test_migrate_interpretation_request_rd(self):
 
         old_interpretation_request_rd = GenericFactoryAvro.get_factory_avro(
-            reports_3_0_0.InterpretationRequestRD, VERSION_300
+            reports_3_0_0.InterpretationRequestRD, VERSION_300, fill_nullables=False
         )()
+
+        old_interpretation_request_rd.BAMs[0].md5Sum = old_interpretation_request_rd.BAMs[1]
 
         test_ir_id = 'CHF-2003'
         old_interpretation_request_rd.InterpretationRequestID = test_ir_id
@@ -106,7 +108,7 @@ class TestMigrateReports3To420(TestCase):
             self.assertEqual(new_bam.sampleId, old_bam.SampleId)
             self.assertEqual(new_bam.uriFile, old_bam.URIFile)
             self.assertEqual(new_bam.fileType, old_bam.fileType)
-            self.assertEqual(new_bam.md5Sum, old_bam.md5Sum)
+            self.assertEqual(new_bam.md5Sum, None)
 
         # Check VCF locations are migrated correctly
         old_vcfs = old_interpretation_request_rd.VCFs
@@ -117,7 +119,7 @@ class TestMigrateReports3To420(TestCase):
             self.assertEqual(new_vcf.sampleId, old_vcf.SampleId)
             self.assertEqual(new_vcf.uriFile, old_vcf.URIFile)
             self.assertEqual(new_vcf.fileType, old_vcf.fileType)
-            self.assertEqual(new_vcf.md5Sum, old_vcf.md5Sum)
+            self.assertEqual(new_vcf.md5Sum, None)
 
         # Check BigWig locations are migrated correctly
         old_big_wigs = old_interpretation_request_rd.bigWigs
@@ -129,7 +131,7 @@ class TestMigrateReports3To420(TestCase):
                 self.assertEqual(new_big_wig.sampleId, old_big_wig.SampleId)
                 self.assertEqual(new_big_wig.uriFile, old_big_wig.URIFile)
                 self.assertEqual(new_big_wig.fileType, old_big_wig.fileType)
-                self.assertEqual(new_big_wig.md5Sum, old_big_wig.md5Sum)
+                self.assertEqual(new_big_wig.md5Sum, None)
         else:
             self.assertTrue(new_big_wigs is None)
 
@@ -141,7 +143,7 @@ class TestMigrateReports3To420(TestCase):
             self.assertEqual(new_pedigree_diagram.sampleId, old_pedigree_diagram.SampleId)
             self.assertEqual(new_pedigree_diagram.uriFile, old_pedigree_diagram.URIFile)
             self.assertEqual(new_pedigree_diagram.fileType, old_pedigree_diagram.fileType)
-            self.assertEqual(new_pedigree_diagram.md5Sum, old_pedigree_diagram.md5Sum)
+            self.assertEqual(new_pedigree_diagram.md5Sum, None)
         else:
             self.assertTrue(new_pedigree_diagram is None)
 
@@ -153,7 +155,7 @@ class TestMigrateReports3To420(TestCase):
             self.assertEqual(new_annotation_file.sampleId, old_annotation_file.SampleId)
             self.assertEqual(new_annotation_file.uriFile, old_annotation_file.URIFile)
             self.assertEqual(new_annotation_file.fileType, old_annotation_file.fileType)
-            self.assertEqual(new_annotation_file.md5Sum, old_annotation_file.md5Sum)
+            self.assertEqual(new_annotation_file.md5Sum, None)
         else:
             self.assertTrue(new_annotation_file is None)
 

--- a/schemas/IDLs/org.gel.models.report.avro/4.0.0/CommonRequest.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/4.0.0/CommonRequest.avdl
@@ -60,7 +60,7 @@ Types:
 
         FileType fileType;
 
-        union {null, File} md5Sum;
+        union {null, string} md5Sum;
 
     }
 

--- a/schemas/IDLs/org.gel.models.report.avro/4.2.0-SNAPSHOT/CommonRequest.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/4.2.0-SNAPSHOT/CommonRequest.avdl
@@ -60,7 +60,7 @@ Types:
 
         FileType fileType;
 
-        union {null, File} md5Sum;
+        union {null, string} md5Sum;
 
     }
 


### PR DESCRIPTION
[IP-428 - Modify md5sum and migration](https://jira.extge.co.uk/browse/IP-428)
======================

Summary of changes
===================
* Change `md5Sum` to be `string` instead of `File` for models v4.0.0 and v4.2.0
* Modify migrations to account for this
* Modify migration tests to make the `md5Sum` a valid `File` object for 3.0.0 and then check it is `None` following the migration.

- [x] Building locally
- [x] Tests passing locally
```
[INFO] Webapp assembled in [7540 msecs]
[INFO] Building war: /gel/GelReportModels/target/gel-models-docs-4.3.0-SNAPSHOT.war
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 03:26 min
[INFO] Finished at: 2017-10-27T12:42:13+00:00
[INFO] Final Memory: 44M/732M
[INFO] ------------------------------------------------------------------------
 ---> b6c645578747
Removing intermediate container a3006903d87b
Successfully built b6c645578747
Successfully tagged gel:latest
```
```
(.env) root@5ddab29e0b4c:/gel/GelReportModels# python -m unittest discover
...............................
----------------------------------------------------------------------
Ran 31 tests in 2.303s

OK
(.env) root@5ddab29e0b4c:/gel/GelReportModels# 
```