### PR TITLE
IP-428 - Modify md5Sum

### DIFF
--- a/protocols/util/generate_mock_objects.py
+++ b/protocols/util/generate_mock_objects.py
@@ -187,7 +187,7 @@ def get_valid_file_4_0_0(file_type=None):
     new_file = MockModelObject(object_type=reports_4_0_0.File).get_valid_empty_object()
     new_file.fileType = file_type
     new_file.SampleId = ['']
-    new_file.md5Sum.fileType = reports_4_0_0.FileType.OTHER
+    new_file.md5Sum = None
 
     return validate_object(object_to_validate=new_file, object_type=reports_4_0_0.File)
 

--- a/schemas/IDLs/org.gel.models.report.avro/3.0.0/CommonRequest.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/3.0.0/CommonRequest.avdl
@@ -59,7 +59,7 @@ record File {
 
     FileType fileType;
 
-    union {null, File} md5Sum;
+    union {null, string} md5Sum;
 
 }
 

--- a/schemas/IDLs/org.gel.models.report.avro/4.0.0/CommonRequest.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/4.0.0/CommonRequest.avdl
@@ -60,7 +60,7 @@ Types:
 
         FileType fileType;
 
-        union {null, File} md5Sum;
+        union {null, string} md5Sum;
 
     }
 


### PR DESCRIPTION
[IP-428 - Modify md5sum and migration](https://jira.extge.co.uk/browse/IP-428)
======================

Summary of changes
===================
* Change `md5Sum` to be `string` instead of `File` for models v4.0.0 and v4.2.0
* Modify `generate_mock_objects` (deprecated in `develop`) to account for this

- [x] Building locally
- [x] Tests passing locally
```
[INFO] Webapp assembled in [7106 msecs]
[INFO] Building war: /gel/GelReportModels/target/gel-models-docs-4.3.1.war
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 08:27 min
[INFO] Finished at: 2017-10-27T14:34:30+00:00
[INFO] Final Memory: 46M/691M
[INFO] ------------------------------------------------------------------------
 ---> 8dec43969680
Removing intermediate container da58909e61cc
Successfully built 8dec43969680
Successfully tagged gel:latest
root@b006490a7848:/gel# 
```
```
[INFO] --- exec-maven-plugin:1.6.0:exec (Run Python unit tests) @ gel-models ---
..........................................
----------------------------------------------------------------------
Ran 42 tests in 3.247s

OK
[INFO] 
```