### PR TITLE
IP-429 - OtherFile addition

### DIFF
--- a/schemas/IDLs/org.gel.models.report.avro/4.0.0/CommonRequest.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/4.0.0/CommonRequest.avdl
@@ -39,7 +39,10 @@ Types:
         BigWig,
         MD5Sum,
         ROH,
-        OTHER
+        OTHER,
+        partition,
+        VFResults,
+        coverage
         }
 
     /**

--- a/schemas/IDLs/org.gel.models.report.avro/4.0.0/InterpretationRequestCancer.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/4.0.0/InterpretationRequestCancer.avdl
@@ -106,6 +106,12 @@ protocol CancerInterpretationRequests {
         */
         union {null, map<string>} additionalInfo;
 
+        /**
+        Other files that may be vendor specific
+        map of key: type of file, value: record of type File
+        */
+        union {null, map<File>} otherFiles;
+
     }
 
 


### PR DESCRIPTION
[IP-429 - Add otherFile to CancerInterpretationRequest](https://jira.extge.co.uk/browse/IP-429)
======================

Summary of changes
===================
* Add `otherFiles` to `InterpretationRequestCancer` versions 4.0.0 and 4.2.0
* Extend `FileType` enum as per spec in ticket

- [x] Building locally
- [x] Tests passing locally
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 09:32 min
[INFO] Finished at: 2017-10-27T16:02:59+00:00
[INFO] Final Memory: 46M/786M
[INFO] ------------------------------------------------------------------------
 ---> 3ca09a2b9ddd
Removing intermediate container 194983f490ba
Successfully built 3ca09a2b9ddd
Successfully tagged gel:latest

```
```
(.env) root@6c008c902bfa:/gel/GelReportModels# python -m unittest discover
..........................................
----------------------------------------------------------------------
Ran 42 tests in 2.872s

OK
(.env) root@6c008c902bfa:/gel/GelReportModels# 
```