### PR TITLE
IP-450 - Fix Migration of Cancer Clinical Report from 4.0.0 to 4.2.0

### DIFF
--- a/protocols/migration/migration_reports_4_0_0_to_reports_4_2_0.py
+++ b/protocols/migration/migration_reports_4_0_0_to_reports_4_2_0.py
@@ -89,19 +89,19 @@ class MigrateReports400To420(BaseMigration):
         )
 
         # FIXME: we are using the individual identifier in the cancer participant to set the sample id
-        candidate_variants = []
-        for candidate_variant in cancer_clinical_report.candidateVariants:
-            candidate_variants.append(self.migrate_reported_variant_cancer(
-                candidate_variant,
-                sample_id
-            ))
-        new_cancer_clinical_report.reportedVariants = candidate_variants
+        new_cancer_clinical_report.candidateVariants = [
+            self.migrate_reported_variant_cancer(
+                reported_somatic_variants=candidate_variant,
+                sample_id=sample_id
+            ) for candidate_variant in cancer_clinical_report.candidateVariants
+        ]
 
         # FIXME: we have no sample id field in the structural variant
-        structural_candidate_variants = []
-        for candidate_structural_variant in cancer_clinical_report.candidateStructuralVariants:
-            structural_candidate_variants.append(self.migrate_reported_structural_variant_cancer(candidate_structural_variant))
-        new_cancer_clinical_report.reportedStructuralVariants = structural_candidate_variants
+        new_cancer_clinical_report.candidateStructuralVariants = [
+            self.migrate_reported_structural_variant_cancer(
+                reported_somatic_structural_variants=candidate_structural_variant
+            ) for candidate_structural_variant in cancer_clinical_report.candidateStructuralVariants
+        ]
 
         return self.validate_object(
             object_to_validate=new_cancer_clinical_report, object_type=self.new_model.ClinicalReportCancer

--- a/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_4_2_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_4_2_0.py
@@ -4,6 +4,7 @@ from protocols import reports_4_0_0
 from protocols import reports_4_2_0
 from protocols.migration import MigrateReports400To420
 from protocols.util.dependency_manager import VERSION_400
+from protocols.util.dependency_manager import VERSION_500
 from protocols.util.factories.avro_factory import GenericFactoryAvro
 
 
@@ -11,6 +12,28 @@ class TestMigrateReports4To420(TestCase):
 
     old_model = reports_4_0_0
     new_model = reports_4_2_0
+
+    def test_migrate_cancer_clinical_report(self):
+        cr_c_400 = GenericFactoryAvro.get_factory_avro(
+            self.old_model.ClinicalReportCancer, VERSION_400, fill_nullables=True
+        ).create()
+        self.assertTrue(cr_c_400.validate(cr_c_400.toJsonDict()))
+
+        cr_c_420 = GenericFactoryAvro.get_factory_avro(
+            self.new_model.ClinicalReportCancer, VERSION_500
+        ).create()
+        self.assertTrue(cr_c_420.validate(cr_c_420.toJsonDict()))
+
+        migrated_cir_420 = MigrateReports400To420().migrate_cancer_clinical_report(
+            cancer_clinical_report=cr_c_400, sample_id='test_sample_id'
+        )
+
+        self.assertTrue(migrated_cir_420.validate(migrated_cir_420.toJsonDict()))
+
+        for cv_400, cv_420 in zip(cr_c_400.candidateVariants, migrated_cir_420.candidateVariants):
+            self.assertEqual(cv_400.reportedVariantCancer.reference, cv_420.reference)
+            self.assertEqual(cv_400.reportedVariantCancer.alternate, cv_420.alternate)
+            self.assertEqual(cv_400.reportedVariantCancer.position, cv_420.position)
 
     def test_migrate_cir_400_to_420(self):
 


### PR DESCRIPTION
[IP-450 - Fix Migration of Cancer Clinical Report from 4.0.0 to 4.2.0](https://jira.extge.co.uk/browse/IP-450)
=============================
This currently blocks [IP-449 - Store Cancer IR, IG and CR as 4.2.0](https://jira.extge.co.uk/browse/IP-449)

Summary of Changes:
=================
* Migrate to `new_cancer_clinical_report.candidateVariants` instead of `new_cancer_clinical_report.reportedVariants` and refactor to a list comprehension
* Migrate to `new_cancer_clinical_report.candidateStructuralVariants` instead of `new_cancer_clinical_report.reportedStructuralVariants` and refactor to a list comprehension
* Add `test_migrate_cancer_clinical_report` to test_migration_reports_4_0_0_to_reports_4_2_0.py to make sure it works

- [x] Tests passing locally:
```
(.env) $ python -m unittest discover
.............................
----------------------------------------------------------------------
Ran 29 tests in 3.105s

OK
```