### PR TITLE
Feature/ip 451

### DIFF
--- a/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/DataIntakeCancer.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/DataIntakeCancer.avdl
@@ -68,13 +68,13 @@ protocol DataIntakeCancerProtocol {
         */
         array<string> workspace;
         /**
-        The assembly to which the variant refers
+        The assembly to which the variants refer
         */
         SupportedAssembly assembly;
         /**
-        Basic information about the InterpretationRequest
+        Rare disease Interpreted Genome
         */
-        org.gel.models.report.avro.CancerInterpretationRequest interpretationRequest;
+        org.gel.models.report.avro.CancerInterpretedGenome interpretedGenome;
     }
 
     /**
@@ -123,7 +123,7 @@ protocol DataIntakeCancerProtocol {
         */
         array<string> workspace;
         /**
-        The assembly to which the variant refers
+        The assembly to which the variants refer
         */
         SupportedAssembly assembly;
         /**
@@ -178,7 +178,7 @@ protocol DataIntakeCancerProtocol {
         */
         array<string> workspace;
         /**
-        The assembly to which the variant refers
+        The assembly to which the variants refer
         */
         SupportedAssembly assembly;
         /**
@@ -188,7 +188,7 @@ protocol DataIntakeCancerProtocol {
     }
 
     /**
-    A record holding the somatic variant level questions for a single variant together with its coordinates
+    A record holding the somatic variant level questions for a single variant together with its normalized variant coordinates
     */
     record CancerSomaticVariantLevelQuestionnaire {
         /**
@@ -202,7 +202,7 @@ protocol DataIntakeCancerProtocol {
     }
 
     /**
-    A record holding the germline variant level questions for a single variant together with its coordinates
+    A record holding the germline variant level questions for a single variant together with its normalized variant coordinates
     */
     record CancerGermlineVariantLevelQuestionnaire {
         /**
@@ -260,6 +260,10 @@ protocol DataIntakeCancerProtocol {
         The genome shall be assigned to the workspaces(projects or domains with a predefined set of users) to control user access
         */
         array<string> workspace;
+        /**
+        The assembly to which the variants refer
+        */
+        SupportedAssembly assembly;
         /**
         Cancer somatic exit questionnaire
         */

--- a/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/DataIntakeRD.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/DataIntakeRD.avdl
@@ -68,13 +68,13 @@ protocol DataIntakeRDProtocol {
         */
         array<string> workspace;
         /**
-        The assembly to which the variant refers
+        The assembly to which the variants refer
         */
         SupportedAssembly assembly;
         /**
-        Basic information about the InterpretationRequest
+        Rare disease Interpreted Genome
         */
-        org.gel.models.report.avro.InterpretationRequestRD interpretationRequest;
+        org.gel.models.report.avro.InterpretedGenomeRD interpretedGenome;
     }
 
     /**
@@ -123,7 +123,7 @@ protocol DataIntakeRDProtocol {
         */
         array<string> workspace;
         /**
-        The assembly to which the variant refers
+        The assembly to which the variants refer
         */
         SupportedAssembly assembly;
         /**
@@ -178,7 +178,7 @@ protocol DataIntakeRDProtocol {
         */
         array<string> workspace;
         /**
-        The assembly to which the variant refers
+        The assembly to which the variants refer
         */
         SupportedAssembly assembly;
         /**
@@ -188,32 +188,33 @@ protocol DataIntakeRDProtocol {
     }
 
     /**
-    A record holding the variant level questions for a single variant together with its coordinates
+    This object holds the variant group level questions together with normalized variant coordinates.
     */
-    record VariantLevelQuestionnaire {
+    record VariantGroupLevelQuestionsWithCoordinates {
         /**
-        The coordinates of a given variant: assembly, chromosome, position, reference and alternate
+        The list of variant coordinates
+        (ASSUMPTION: the order of this list is the same as the order of variants in VariantLevelQuestions)
         */
-        VariantCoordinates variantCoordinates;
+        array<VariantCoordinates> variantsCoordinates;
         /**
-        The questions at variant level
+        The variant group level questions containing also the variant level questions
         */
-        org.gel.models.report.avro.VariantLevelQuestions variantLevelQuestions;
+        org.gel.models.report.avro.VariantGroupLevelQuestions variantGroupLevelQuestions;
     }
 
     /**
-    A record holding the variant group level questions for a group of variants
-    (the variant level questions inside the VariantGroupLevelQuestions will be ignored)
+    This is an entity to hold the information in org.gel.models.report.avro.RareDiseaseExitQuestionnaire in
+    a form compatible with CVA.
     */
-    record VariantGroupLevelQuestionnaire {
+    record ExitQuestionnaireRD {
         /**
-        The coordinates of a given variant: assembly, chromosome, position, reference and alternate
+        The family level questions
         */
-        array<VariantCoordinates> variantCoordinates;
+        org.gel.models.report.avro.FamilyLevelQuestions familyLevelQuestions;
         /**
-        The questions at variant level
+        The list variant group level questions (this list will be unwinded during ingestion)
         */
-        org.gel.models.report.avro.VariantGroupLevelQuestions variantGroupLevelQuestions;
+        array<VariantGroupLevelQuestionsWithCoordinates> variantGroupLevelQuestions;
     }
 
     /**
@@ -262,12 +263,12 @@ protocol DataIntakeRDProtocol {
         */
         array<string> workspace;
         /**
-        Exit questionnaires at variant level for a set of variants
+        The assembly to which the variants refer
         */
-        array<VariantLevelQuestionnaire> variantLevelQuestionnaires;
+        SupportedAssembly assembly;
         /**
-        Exit questionnaires at variant group level for a set of variants
+        Exit questionnaire, having reliable variant coordinates
         */
-        array<VariantGroupLevelQuestionnaire> variantGroupLevelQuestionnaires;
+        ExitQuestionnaireRD exitQuestionnaireRd;
     }
 }

--- a/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/ReportEvent.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/ReportEvent.avdl
@@ -39,6 +39,28 @@ protocol ReportEventProtocol {
     }
 
     /**
+    The report event for a questionnaire in RD.
+    */
+    record ReportEventQuestionnaireRd {
+        /**
+        The identifier used to group variants together
+        */
+        union {null, int} groupOfVariants;
+        /**
+        The variant level questions
+        */
+        org.gel.models.report.avro.VariantLevelQuestions variantLevelQuestions;
+        /**
+        The variant group level questions
+        */
+        org.gel.models.report.avro.VariantGroupLevelQuestions variantGroupLevelQuestions;
+        /**
+        The family level questions
+        */
+        org.gel.models.report.avro.FamilyLevelQuestions familyLevelQuestions;
+    }
+
+    /**
 A variant or variants (i.e.: composite heterozygous) reported by any manual or automated means.
 The information about the report is contained within a ReportEvent, it is linked to one or more
 ObservedVariant.
@@ -122,23 +144,19 @@ Duplication of the prior fields is not be supported.
         */
         union {null, org.gel.models.report.avro.ReportEvent} reportEvent;
         /**
-        The variant level questions
+        The report event for the questionnaire reports in the rare disease program
         */
-        union {null, org.gel.models.report.avro.VariantLevelQuestions} variantLevelQuestions;
-        /**
-        The variant group level questions
-        */
-        union {null, array<org.gel.models.report.avro.VariantGroupLevelQuestions>} variantGroupLevelQuestions;
+        union {null, ReportEventQuestionnaireRd} reportEventQuestionnaire;
         /**
         The report event for the cancer program
         */
         union {null, org.gel.models.report.avro.ReportEventCancer} reportEventCancer;
         /**
-        The somatic variant level questions
+        The somatic variant level questions for the cancer program
         */
         union {null, org.gel.models.report.avro.CancerSomaticVariantLevelQuestions} cancerSomaticVariantLevelQuestions;
         /**
-        The variant group level questions
+        The variant group level questions for the cancer program
         */
         union {null, org.gel.models.report.avro.CancerGermlineVariantLevelQuestions} cancerGermlineVariantLevelQuestions;
         /**

--- a/schemas/IDLs/org.gel.models.report.avro/5.0.0-SNAPSHOT/ClinicalReportCancer.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/5.0.0-SNAPSHOT/ClinicalReportCancer.avdl
@@ -35,12 +35,12 @@ protocol ClinicalReportsCancer {
         /**
         Candidate Variants - as defined in CommonInterpreted
         */
-        union {null, array<ReportedVariantCancer>} candidateVariants;
+        union {null, array<ReportedVariantCancer>} variants;
 
         /**
         Candidate Structural Variants - as defined in CommonInterpreted
         */
-        union {null, array<ReportedStructuralVariantCancer>} candidateStructuralVariants;
+        union {null, array<ReportedStructuralVariantCancer>} structuralVariants;
 
         /**
         Summary of the interpretation, this should reflects the positive conclusions of this interpretation

--- a/schemas/IDLs/org.gel.models.report.avro/5.0.0-SNAPSHOT/ExitQuestionnaire.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/5.0.0-SNAPSHOT/ExitQuestionnaire.avdl
@@ -83,8 +83,6 @@ protocol ExitQuestionnaires {
 
     }
 
-
-
     record RareDiseaseExitQuestionnaire{
         string eventDate;
         string reporter;

--- a/schemas/IDLs/org.gel.models.report.avro/5.0.0-SNAPSHOT/InterpretationRequestCancer.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/5.0.0-SNAPSHOT/InterpretationRequestCancer.avdl
@@ -69,7 +69,10 @@ protocol CancerInterpretationRequests {
         */
         union{null, File} annotationFile;
 
-        org.gel.models.participant.avro.CancerParticipant cancerParticipant;
+        /**
+        The participant to which this corresponds
+        */
+        org.gel.models.participant.avro.CancerParticipant participant;
 
         /**
         Location (URI) where the data can be found
@@ -84,12 +87,12 @@ protocol CancerInterpretationRequests {
         /**
         Tiered Variants
         */
-        array<ReportedVariantCancer> tieredVariants;
+        array<ReportedVariantCancer> variants;
 
         /**
         Structural Tiered Variants
         */
-        array<ReportedStructuralVariantCancer> structuralTieredVariants;
+        array<ReportedStructuralVariantCancer> structuralVariants;
 
         /**
         Tiering Version

--- a/schemas/IDLs/org.gel.models.report.avro/5.0.0-SNAPSHOT/InterpretedGenomesCancer.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/5.0.0-SNAPSHOT/InterpretedGenomesCancer.avdl
@@ -51,12 +51,12 @@ protocol CancerInterpretedGenomes {
         /**
         The reported small variants for cancer
         */
-        array<ReportedVariantCancer> reportedVariants;
+        array<ReportedVariantCancer> variants;
 
         /**
         The reported structural variants for cancer
         */
-        array<ReportedStructuralVariantCancer> reportedStructuralVariants;
+        array<ReportedStructuralVariantCancer> structuralVariants;
 
         /**
         Comments about the report


### PR DESCRIPTION
* CVA models now receive an interpreted genome with the tiered variants
* Exit questionnaires report events for CVA have been refactored
* Suffix to "variants" fields have been removed (e.g.: `tieredVariants` is now just `variants`)