### PR TITLE
Feature - Refactor build of report events from questionnaires

### DIFF
--- a/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/DataIntakeCancer.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/DataIntakeCancer.avdl
@@ -265,6 +265,10 @@ protocol DataIntakeCancerProtocol {
         */
         SupportedAssembly assembly;
         /**
+        Case level questions
+        */
+        org.gel.models.report.avro.CancerCaseLevelQuestions cancercaseLevelQuestions;
+        /**
         Cancer somatic exit questionnaire
         */
         array<CancerSomaticVariantLevelQuestionnaire> cancerSomaticExitQuestionnaires;
@@ -272,5 +276,15 @@ protocol DataIntakeCancerProtocol {
         Germline somatic exit questionnaire
         */
         array<CancerGermlineVariantLevelQuestionnaire> cancerGermlineExitQuestionnaires;
+        /**
+        Please enter any additional comments you may have about the case here.
+        */
+        union {null, string} additionalComments;
+        /**
+        Other actionable variants or entities.
+        Please provide other (potentially) actionable entities: e.g domain 3 small variants,
+        SV/CNV, mutational signatures, mutational burden
+        */
+        union {null, string} otherActionableVariants;
     }
 }

--- a/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/DataIntakeRD.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/DataIntakeRD.avdl
@@ -188,33 +188,14 @@ protocol DataIntakeRDProtocol {
     }
 
     /**
-    This object holds the variant group level questions together with normalized variant coordinates.
-    */
-    record VariantGroupLevelQuestionsWithCoordinates {
-        /**
-        The list of variant coordinates
-        (ASSUMPTION: the order of this list is the same as the order of variants in VariantLevelQuestions)
-        */
-        array<VariantCoordinates> variantsCoordinates;
-        /**
-        The variant group level questions containing also the variant level questions
-        */
-        org.gel.models.report.avro.VariantGroupLevelQuestions variantGroupLevelQuestions;
-    }
-
-    /**
     This is an entity to hold the information in org.gel.models.report.avro.RareDiseaseExitQuestionnaire in
     a form compatible with CVA.
     */
     record ExitQuestionnaireRD {
         /**
-        The family level questions
-        */
-        org.gel.models.report.avro.FamilyLevelQuestions familyLevelQuestions;
-        /**
         The list variant group level questions (this list will be unwinded during ingestion)
         */
-        array<VariantGroupLevelQuestionsWithCoordinates> variantGroupLevelQuestions;
+        array<ReportedVariantQuestionnaireRd> variants;
     }
 
     /**

--- a/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/DataIntakeRD.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/DataIntakeRD.avdl
@@ -195,7 +195,7 @@ protocol DataIntakeRDProtocol {
         /**
         The list variant group level questions (this list will be unwinded during ingestion)
         */
-        array<ReportedVariantQuestionnaireRd> variants;
+        array<ReportedVariantQuestionnaireRD> variants;
     }
 
     /**

--- a/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/EvidenceSet.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/EvidenceSet.avdl
@@ -183,24 +183,6 @@ Duplication of the prior fields is not be supported.
     }
 
     /**
-    Variant coordinates
-    */
-    record VariantCoordinates {
-        SupportedAssembly assembly;
-        string chromosome;
-        int position;
-        string reference;
-        string alternate;
-    }
-
-    /**
-    Variants coordinates
-    */
-    record VariantsCoordinates {
-        array<VariantCoordinates> variants = [];
-    }
-
-    /**
     A curation and the variants coordinates to which it corresponds
     */
     record CurationAndVariants {

--- a/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/ReportEvent.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/ReportEvent.avdl
@@ -41,7 +41,7 @@ protocol ReportEventProtocol {
     /**
     The report event for a questionnaire in RD.
     */
-    record ReportEventQuestionnaireRd {
+    record ReportEventQuestionnaireRD {
         /**
         The identifier used to group variants together
         */
@@ -81,7 +81,7 @@ protocol ReportEventProtocol {
     /**
     This object holds all questionnaire questions together with normalized variant coordinates.
     */
-    record ReportedVariantQuestionnaireRd {
+    record ReportedVariantQuestionnaireRD {
         /**
         The normalized representation of variants coordinates
         */
@@ -89,7 +89,7 @@ protocol ReportEventProtocol {
         /**
         The questionnaire report event
         */
-        ReportEventQuestionnaireRd reportEvent;
+        ReportEventQuestionnaireRD reportEvent;
     }
 
     record ReportEventQuestionnaireCancer {
@@ -203,7 +203,7 @@ Duplication of the prior fields is not be supported.
         /**
         The report event for the questionnaire reports in the rare disease program
         */
-        union {null, ReportEventQuestionnaireRd} reportEventQuestionnaire;
+        union {null, ReportEventQuestionnaireRD} reportEventQuestionnaire;
         /**
         The report event for the cancer program
         */

--- a/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/ReportEvent.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/ReportEvent.avdl
@@ -92,6 +92,31 @@ protocol ReportEventProtocol {
         ReportEventQuestionnaireRd reportEvent;
     }
 
+    record ReportEventQuestionnaireCancer {
+        /**
+        The somatic variant level questions for the cancer program
+        */
+        union {null, org.gel.models.report.avro.CancerSomaticVariantLevelQuestions} cancerSomaticVariantLevelQuestions;
+        /**
+        The variant group level questions for the cancer program
+        */
+        union {null, org.gel.models.report.avro.CancerGermlineVariantLevelQuestions} cancerGermlineVariantLevelQuestions;
+        /**
+        Cancer case level questions
+        */
+        org.gel.models.report.avro.CancerCaseLevelQuestions cancercaseLevelQuestions;
+        /**
+        Please enter any additional comments you may have about the case here.
+        */
+        union {null, string} additionalComments;
+        /**
+        Other actionable variants or entities.
+        Please provide other (potentially) actionable entities: e.g domain 3 small variants,
+        SV/CNV, mutational signatures, mutational burden
+        */
+        union {null, string} otherActionableVariants;
+    }
+
     /**
 A variant or variants (i.e.: composite heterozygous) reported by any manual or automated means.
 The information about the report is contained within a ReportEvent, it is linked to one or more
@@ -184,13 +209,9 @@ Duplication of the prior fields is not be supported.
         */
         union {null, org.gel.models.report.avro.ReportEventCancer} reportEventCancer;
         /**
-        The somatic variant level questions for the cancer program
+        The report event for the questionnaire reports in the cancer program
         */
-        union {null, org.gel.models.report.avro.CancerSomaticVariantLevelQuestions} cancerSomaticVariantLevelQuestions;
-        /**
-        The variant group level questions for the cancer program
-        */
-        union {null, org.gel.models.report.avro.CancerGermlineVariantLevelQuestions} cancerGermlineVariantLevelQuestions;
+        union {null, ReportEventQuestionnaireCancer} reportEventQuestionnaireCancer;
         /**
         The observed variants
         */

--- a/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/ReportEvent.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.0.0-SNAPSHOT/ReportEvent.avdl
@@ -61,6 +61,38 @@ protocol ReportEventProtocol {
     }
 
     /**
+    Variant coordinates
+    */
+    record VariantCoordinates {
+        SupportedAssembly assembly;
+        string chromosome;
+        int position;
+        string reference;
+        string alternate;
+    }
+
+    /**
+    A list of variant coordinates
+    */
+    record VariantsCoordinates {
+        array<VariantCoordinates> variants = [];
+    }
+
+    /**
+    This object holds all questionnaire questions together with normalized variant coordinates.
+    */
+    record ReportedVariantQuestionnaireRd {
+        /**
+        The normalized representation of variants coordinates
+        */
+        VariantCoordinates variantCoordinates;
+        /**
+        The questionnaire report event
+        */
+        ReportEventQuestionnaireRd reportEvent;
+    }
+
+    /**
 A variant or variants (i.e.: composite heterozygous) reported by any manual or automated means.
 The information about the report is contained within a ReportEvent, it is linked to one or more
 ObservedVariant.


### PR DESCRIPTION
The data intake for RD exit questionnaires has been refactored so we assume that exit questionnaires need to be disaggregated as follows:
* For each variant reported in a rare disease questionnaire a `ReportedVariantQuestionnaireRd` will be created.
* Family level questions will be repeated for every variant in the questionnaire
* Variant group level questions will be repeated for every variant in a group of variants
* Groups of variants will be defined in the field `ReportEventQuestionnaireRd.groupOfVariants` being the values of the group of variants only relevant within the same questionnaire.

The above format is very repetitive, but this aligns with how other report events are stored and facilitates data querying.