### PR TITLE
IP-916: hotfix 6.0.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+Version 6.0.3 (22nd March 2018)
+--------------------------------
+
+#### Minor Changes
+
+* Fixed `MigrateReports400To500().migrate_cancer_interpretation_request` and `MigrateReports400To500().migrate_interpretation_request_rd` that were failing when tested with nullable fields being null. Tests are improved
+* Refactored migration tests to use `_validate`
+
 Version 6.0.2 (21st March 2018)
 --------------------------------
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Version 6.0.3 (22nd March 2018)
 --------------------------------
 
+### Major changes
+
+* Remove hotfix version numbering from build version from 6.0 onwards. To generate any mock data from build 6.0 onwards, the string `6.0` is expected instead of `6.0.0`
+
+
 #### Minor Changes
 
 * Fixed `MigrateReports400To500().migrate_cancer_interpretation_request` and `MigrateReports400To500().migrate_interpretation_request_rd` that were failing when tested with nullable fields being null. Tests are improved

--- a/builds.json
+++ b/builds.json
@@ -2,7 +2,7 @@
   "builds" :
   [
     {
-      "version": "6.0.2",
+      "version": "6.0.3",
       "packages": [
         {
           "package": "org.ga4gh.models",

--- a/builds.json
+++ b/builds.json
@@ -2,7 +2,7 @@
   "builds" :
   [
     {
-      "version": "6.0.3",
+      "version": "6.0",
       "packages": [
         {
           "package": "org.ga4gh.models",

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <packaging>${p.type}</packaging>
 
     <properties>
-        <models.version>6.0.2</models.version>
+        <models.version>6.0.3</models.version>
         <opencb.models.version>1.3.0</opencb.models.version>
         <opencb.models.package>org.opencb.biodata.models.variant.avro</opencb.models.package>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/protocols/tests/test_migration/base_test_migration.py
+++ b/protocols/tests/test_migration/base_test_migration.py
@@ -27,3 +27,6 @@ class TestCaseMigration(TestCase):
                             self._check_non_empty_fields(element, exclusions)
                     else:
                         self._check_non_empty_fields(attribute, exclusions)
+
+    def _validate(self, instance):
+        self.assertTrue(instance.validate(instance.toJsonDict()))

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_participant_1_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_participant_1_0_0.py
@@ -24,11 +24,11 @@ class TestMigrateReports3ToParticipant1(TestCaseMigration):
         old_instance.cancerSamples[0].sampleType = self.old_model.SampleType.germline
         old_instance.cancerSamples[1].sampleType = self.old_model.SampleType.tumor
 
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
         self._check_non_empty_fields(old_instance)
 
         new_instance = MigrateReports3ToParticipant1().migrate_cancer_participant(old_instance)
-        self.assertTrue(new_instance.validate(new_instance.toJsonDict()))
+        self._validate(new_instance)
         self._check_non_empty_fields(
             new_instance,
             exclusions=["clinicalSampleDateTime", "preparationMethod", "product", "primaryDiagnosisSubDisease",
@@ -46,18 +46,18 @@ class TestMigrateReports3ToParticipant1(TestCaseMigration):
 
         # Check old_participant is a valid reports_3_0_0 CancerParticipant object
         self.assertTrue(isinstance(old_participant, CancerParticipant_old))
-        self.assertTrue(old_participant.validate(jsonDict=old_participant.toJsonDict()))
+        self._validate(old_participant)
 
         # Check new_participant is a valid participant_1_0_0 CancerParticipant object
         self.assertTrue(isinstance(new_participant, CancerParticipant_new))
-        self.assertTrue(new_participant.validate(jsonDict=new_participant.toJsonDict()))
+        self._validate(new_participant)
 
         # Perform the migration of old_participant from reports_3_0_0 to participant_1_0_0
         migrated_participant = MigrateReports3ToParticipant1().migrate_cancer_participant(old_participant)
 
         # Check migrated_participant is a valid participant_1_0_0 CancerParticipant object
         self.assertTrue(isinstance(migrated_participant, CancerParticipant_new))
-        self.assertTrue(migrated_participant.validate(jsonDict=migrated_participant.toJsonDict()))
+        self._validate(migrated_participant)
 
         self.assertEqual(
             migrated_participant.tumourSamples[0].tumourType,

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_participant_1_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_participant_1_0_0.py
@@ -1,4 +1,4 @@
-from protocols.tests.test_migration.test_migration import TestCaseMigration
+from protocols.tests.test_migration.base_test_migration import TestCaseMigration
 from protocols.reports_3_0_0 import CancerParticipant as CancerParticipant_old
 from protocols.participant_1_0_0 import CancerParticipant as CancerParticipant_new
 from protocols.migration.migration_reports_3_0_0_to_participant_1_0_0 import MigrateReports3ToParticipant1

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_0_0.py
@@ -1,4 +1,4 @@
-from protocols.tests.test_migration.test_migration import TestCaseMigration
+from protocols.tests.test_migration.base_test_migration import TestCaseMigration
 from protocols import reports_3_0_0
 from protocols import reports_4_0_0
 from protocols.util.dependency_manager import VERSION_300

--- a/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_3_0_0_to_reports_4_0_0.py
@@ -21,19 +21,19 @@ class TestMigrateReports3To4(TestCaseMigration):
 
         # Check old_variants is a valid reports_3_0_0 ReportedSomaticVariants object
         self.assertTrue(isinstance(old_variants, self.old_model.ReportedSomaticVariants))
-        self.assertTrue(old_variants.validate(jsonDict=old_variants.toJsonDict()))
+        self._validate(old_variants)
 
         new_variants = GenericFactoryAvro.get_factory_avro(self.new_model.ReportedSomaticVariants, VERSION_400)()
 
         # Check new_variants is a valid participant_1_0_0 ReportedSomaticVariants object
         self.assertTrue(isinstance(new_variants, self.new_model.ReportedSomaticVariants))
-        self.assertTrue(new_variants.validate(jsonDict=new_variants.toJsonDict()))
+        self._validate(new_variants)
 
         migrated_object = MigrateReports3To4().migrate_reported_somatic_variants(old_variants)
 
         # Check migrated_object is a valid participant_1_0_0 ReportedSomaticVariants object
         self.assertTrue(isinstance(migrated_object, self.new_model.ReportedSomaticVariants))
-        self.assertTrue(migrated_object.validate(jsonDict=migrated_object.toJsonDict()))
+        self._validate(migrated_object)
 
     def test_migrate_report_event_cancer(self):
 
@@ -41,13 +41,13 @@ class TestMigrateReports3To4(TestCaseMigration):
 
         # Check old_report_event_cancer is a valid reports_3_0_0.ReportEventCancer object
         self.assertTrue(isinstance(old_report_event_cancer, ReportEventCancer_old))
-        self.assertTrue(old_report_event_cancer.validate(old_report_event_cancer.toJsonDict()))
+        self._validate(old_report_event_cancer)
 
         migrated_report_event_cancer = MigrateReports3To4().migrate_report_event_cancer(old_report_event_cancer)
 
         # Check migrated_report_event_cancer is a valid reports_4_0_0.ReportEventCancer object
         self.assertTrue(isinstance(migrated_report_event_cancer, ReportEventCancer_new))
-        self.assertTrue(migrated_report_event_cancer.validate(migrated_report_event_cancer.toJsonDict()))
+        self._validate(migrated_report_event_cancer)
 
     def test_migrate_report_event_cancer_specific_cancer_role(self):
         """
@@ -78,25 +78,25 @@ class TestMigrateReports3To4(TestCaseMigration):
         old_instance = GenericFactoryAvro.get_factory_avro(
             self.old_model.ClinicalReportRD, VERSION_300, fill_nullables=True
         ).create()
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
         migrated_instance = MigrateReports3To4().migrate_clinical_report_rd(old_clinical_report_rd=old_instance)
-        self.assertTrue(migrated_instance.validate(migrated_instance.toJsonDict()))
+        self._validate(migrated_instance)
 
     def test_migrate_interpreted_genome_rd(self):
         """ Test passing on 3000 real cases"""
         old_instance = GenericFactoryAvro.get_factory_avro(self.old_model.InterpretedGenomeRD, VERSION_300).create()
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
         migrated_instance = MigrateReports3To4().migrate_interpreted_genome_rd(old_instance=old_instance)
-        self.assertTrue(migrated_instance.validate(migrated_instance.toJsonDict()))
+        self._validate(migrated_instance)
 
     def test_migrate_interpretation_request_rd(self):
         """Also tested with real data"""
         old_instance = GenericFactoryAvro.get_factory_avro(
             self.old_model.InterpretationRequestRD, VERSION_300, fill_nullables=False
         ).create()  # reports_3_0_0.InterpretationRequestRD
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
         migrated_instance = MigrateReports3To4().migrate_interpretation_request_rd(old_instance=old_instance)
-        self.assertTrue(migrated_instance.validate(migrated_instance.toJsonDict()))
+        self._validate(migrated_instance)
 
         old_big_wigs = old_instance.bigWigs
         new_big_wigs = migrated_instance.bigWigs

--- a/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_5_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_5_0_0.py
@@ -4,7 +4,6 @@ from protocols import reports_4_0_0
 from protocols import reports_5_0_0
 from protocols.migration.migration_reports_4_0_0_to_reports_5_0_0 import MigrateReports400To500
 from protocols.util.dependency_manager import VERSION_400
-from protocols.util.dependency_manager import VERSION_500
 from protocols.util.factories.avro_factory import GenericFactoryAvro
 from protocols.util.factories.avro_factory import FactoryAvro
 
@@ -49,7 +48,7 @@ class TestMigrateReports4To500(TestCaseMigration):
         cr_c_400 = GenericFactoryAvro.get_factory_avro(
             self.old_model.ClinicalReportCancer, VERSION_400, fill_nullables=True
         ).create(interpretationRequestVersion='1')  # we need to enforce that it can be cast to int
-        self.assertTrue(cr_c_400.validate(cr_c_400.toJsonDict()))
+        self._validate(cr_c_400)
         self._check_non_empty_fields(cr_c_400)
 
         assembly = 'grch38'
@@ -58,7 +57,7 @@ class TestMigrateReports4To500(TestCaseMigration):
         migrated_cir_500 = MigrateReports400To500().migrate_cancer_clinical_report(
             cr_c_400, assembly=assembly, participant_id=participant_id, sample_id=sample_id
         )
-        self.assertTrue(migrated_cir_500.validate(migrated_cir_500.toJsonDict()))
+        self._validate(migrated_cir_500)
         self._check_non_empty_fields(migrated_cir_500,
                                      exclusions=["genomicChanges", "references", "actionType", "otherIds",
                                                  "groupOfVariants", "score", "vendorSpecificScores",
@@ -75,7 +74,7 @@ class TestMigrateReports4To500(TestCaseMigration):
         cr_c_400 = GenericFactoryAvro.get_factory_avro(
             self.old_model.ClinicalReportCancer, VERSION_400, fill_nullables=False
         ).create(interpretationRequestVersion='1')
-        self.assertTrue(cr_c_400.validate(cr_c_400.toJsonDict()))
+        self._validate(cr_c_400)
 
         assembly = 'hg19'
         participant_id = "no_one"
@@ -83,7 +82,7 @@ class TestMigrateReports4To500(TestCaseMigration):
         migrated_cir_500 = MigrateReports400To500().migrate_cancer_clinical_report(
             cr_c_400, assembly=assembly, participant_id=participant_id, sample_id=sample_id
         )
-        self.assertTrue(migrated_cir_500.validate(migrated_cir_500.toJsonDict()))
+        self._validate(migrated_cir_500)
 
         self.assertTrue(cr_c_400.candidateVariants is None)
         self.assertTrue(migrated_cir_500.variants is None)
@@ -94,7 +93,7 @@ class TestMigrateReports4To500(TestCaseMigration):
         old_instance = GenericFactoryAvro.get_factory_avro(
             self.old_model.CancerInterpretedGenome, VERSION_400, fill_nullables=True
         ).create()
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
         self._check_non_empty_fields(old_instance)
 
         assembly = 'grch38'
@@ -107,7 +106,7 @@ class TestMigrateReports4To500(TestCaseMigration):
             interpretation_request_version=interpretation_request_version,
             interpretation_service=interpretation_service
         )
-        self.assertTrue(new_instance.validate(new_instance.toJsonDict()))
+        self._validate(new_instance)
         self._check_non_empty_fields(new_instance,
                                      exclusions=["genomicChanges", "references", "actionType", "otherIds",
                                                  "groupOfVariants", "score", "vendorSpecificScores",
@@ -124,7 +123,7 @@ class TestMigrateReports4To500(TestCaseMigration):
         old_instance = GenericFactoryAvro.get_factory_avro(
             self.old_model.CancerInterpretedGenome, VERSION_400, fill_nullables=False
         ).create()
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
 
         assembly = 'hg19'
         participant_id = "no_one"
@@ -136,7 +135,7 @@ class TestMigrateReports4To500(TestCaseMigration):
             interpretation_request_version=interpretation_request_version,
             interpretation_service=interpretation_service
         )
-        self.assertTrue(new_instance.validate(new_instance.toJsonDict()))
+        self._validate(new_instance)
         self._check_variant_coordinates(
             [variant.reportedVariantCancer for variant in old_instance.reportedVariants],
             new_instance.variants,
@@ -150,7 +149,7 @@ class TestMigrateReports4To500(TestCaseMigration):
             self.old_model.CancerInterpretationRequest, VERSION_400, fill_nullables=True
         ).create()
         old_instance.cancerParticipant.tumourSamples = [old_instance.cancerParticipant.tumourSamples[0]]
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
         self._check_non_empty_fields(old_instance)
 
         assembly = 'grch38'
@@ -163,7 +162,7 @@ class TestMigrateReports4To500(TestCaseMigration):
             report_url="blablabla.blah",
             comments=["bla", "bla!", "bla?"]
         )
-        self.assertTrue(new_instance.validate(new_instance.toJsonDict()))
+        self._validate(new_instance)
         self._check_non_empty_fields(new_instance,
                                      exclusions=["genomicChanges", "references", "actionType", "otherIds",
                                                  "groupOfVariants", "score", "vendorSpecificScores",
@@ -181,7 +180,7 @@ class TestMigrateReports4To500(TestCaseMigration):
             self.old_model.CancerInterpretationRequest, VERSION_400, fill_nullables=False
         ).create()
         old_instance.cancerParticipant.tumourSamples = [old_instance.cancerParticipant.tumourSamples[0]]
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
 
         assembly = 'grCH37'
         interpretation_service = 'testing'
@@ -191,7 +190,7 @@ class TestMigrateReports4To500(TestCaseMigration):
             reference_database_versions={},
             software_versions={}
         )
-        self.assertTrue(new_instance.validate(new_instance.toJsonDict()))
+        self._validate(new_instance)
         self._check_variant_coordinates(
             [variant.reportedVariantCancer for variant in old_instance.tieredVariants],
             new_instance.variants,
@@ -204,14 +203,14 @@ class TestMigrateReports4To500(TestCaseMigration):
         old_instance = GenericFactoryAvro.get_factory_avro(
             self.old_model.ClinicalReportRD, VERSION_400, fill_nullables=True
         ).create(interpretationRequestVersion='1')  # we need to enforce that it can be cast to int
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
         self._check_non_empty_fields(old_instance)
 
         assembly = 'grch38'
         new_instance = MigrateReports400To500().migrate_clinical_report_rd(
             old_instance, assembly=assembly
         )
-        self.assertTrue(new_instance.validate(new_instance.toJsonDict()))
+        self._validate(new_instance)
         self._check_non_empty_fields(new_instance,
                                      exclusions=["alleleFrequencies", "genomicChanges", "proteinChanges",
                                                  "cdnaChanges", "dbSnpId", "cosmicIds", "clinVarIds",
@@ -228,13 +227,13 @@ class TestMigrateReports4To500(TestCaseMigration):
         cr_c_400 = GenericFactoryAvro.get_factory_avro(
             self.old_model.ClinicalReportRD, VERSION_400, fill_nullables=False
         ).create(interpretationRequestVersion='1')
-        self.assertTrue(cr_c_400.validate(cr_c_400.toJsonDict()))
+        self._validate(cr_c_400)
 
         assembly = 'hg19'
         new_instance = MigrateReports400To500().migrate_clinical_report_rd(
             cr_c_400, assembly=assembly
         )
-        self.assertTrue(new_instance.validate(new_instance.toJsonDict()))
+        self._validate(new_instance)
 
         self.assertTrue(cr_c_400.candidateVariants is None)
         self.assertTrue(new_instance.variants is None)
@@ -245,14 +244,14 @@ class TestMigrateReports4To500(TestCaseMigration):
         old_instance = GenericFactoryAvro.get_factory_avro(
             self.old_model.InterpretedGenomeRD, VERSION_400, fill_nullables=True
         ).create()  # we need to enforce that it can be cast to int
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
         self._check_non_empty_fields(old_instance)
 
         assembly = 'grch38'
         new_instance = MigrateReports400To500().migrate_interpreted_genome_rd(
             old_instance, assembly=assembly, interpretation_request_version=1
         )
-        self.assertTrue(new_instance.validate(new_instance.toJsonDict()))
+        self._validate(new_instance)
         self._check_non_empty_fields(new_instance,
                                      exclusions=["alleleFrequencies", "genomicChanges", "proteinChanges",
                                                  "cdnaChanges", "dbSnpId", "cosmicIds", "clinVarIds",
@@ -269,13 +268,13 @@ class TestMigrateReports4To500(TestCaseMigration):
         old_instance = GenericFactoryAvro.get_factory_avro(
             self.old_model.InterpretedGenomeRD, VERSION_400, fill_nullables=False
         ).create()
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
 
         assembly = 'hg19'
         new_instance = MigrateReports400To500().migrate_interpreted_genome_rd(
             old_instance, assembly=assembly, interpretation_request_version=1
         )
-        self.assertTrue(new_instance.validate(new_instance.toJsonDict()))
+        self._validate(new_instance)
 
         self._check_variant_coordinates(
             old_instance.reportedVariants,
@@ -289,7 +288,7 @@ class TestMigrateReports4To500(TestCaseMigration):
         old_instance = GenericFactoryAvro.get_factory_avro(
             self.old_model.InterpretationRequestRD, VERSION_400, fill_nullables=True
         ).create()  # we need to enforce that it can be cast to int
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
         self._check_non_empty_fields(old_instance)
 
         assembly = 'grch38'
@@ -301,7 +300,7 @@ class TestMigrateReports4To500(TestCaseMigration):
             report_url="blablabla.blah",
             comments=["bla", "bla!", "bla?"]
         )
-        self.assertTrue(new_instance.validate(new_instance.toJsonDict()))
+        self._validate(new_instance)
         self._check_non_empty_fields(new_instance,
                                      exclusions=["alleleFrequencies", "genomicChanges", "proteinChanges",
                                                  "cdnaChanges", "dbSnpId", "cosmicIds", "clinVarIds",
@@ -318,7 +317,7 @@ class TestMigrateReports4To500(TestCaseMigration):
         old_instance = GenericFactoryAvro.get_factory_avro(
             self.old_model.InterpretationRequestRD, VERSION_400, fill_nullables=False
         ).create()
-        self.assertTrue(old_instance.validate(old_instance.toJsonDict()))
+        self._validate(old_instance)
 
         assembly = 'hg19'
         new_instance = MigrateReports400To500().migrate_interpretation_request_rd_to_interpreted_genome_rd(
@@ -328,7 +327,7 @@ class TestMigrateReports4To500(TestCaseMigration):
             report_url="blablabla.blah",
             comments=["bla", "bla!", "bla?"]
         )
-        self.assertTrue(new_instance.validate(new_instance.toJsonDict()))
+        self._validate(new_instance)
 
         self._check_variant_coordinates(
             old_instance.tieredVariants,

--- a/protocols/tests/test_migration/test_participants.py
+++ b/protocols/tests/test_migration/test_participants.py
@@ -1,4 +1,4 @@
-from protocols.tests.test_migration.test_migration import TestCaseMigration
+from protocols.tests.test_migration.base_test_migration import TestCaseMigration
 from protocols import participant_1_0_0
 from protocols import participant_1_0_3
 from protocols.util.dependency_manager import VERSION_500

--- a/protocols/tests/test_migration/test_participants.py
+++ b/protocols/tests/test_migration/test_participants.py
@@ -25,14 +25,14 @@ class TestMigrationParticipants100To103(TestCaseMigration):
         old_participant.LDPCode = 'test_LDP_code'
 
         self.assertIsInstance(old_participant, self.old_model.CancerParticipant)
-        self.assertTrue(old_participant.validate(old_participant.toJsonDict()))
+        self._validate(old_participant)
 
         migrated_participant = MigrationParticipants100To103().migrate_cancer_participant(
             cancer_participant=old_participant
         )
 
         self.assertIsInstance(migrated_participant, self.new_model.CancerParticipant)
-        self.assertTrue(migrated_participant.validate(migrated_participant.toJsonDict()))
+        self._validate(migrated_participant)
 
         self.assertIsInstance(migrated_participant.versionControl, self.new_model.VersionControl)
         self.assertDictEqual(migrated_participant.versionControl.toJsonDict(), {"GitVersionControl": "1.0.3"})
@@ -84,14 +84,14 @@ class TestMigrationParticipants100To103(TestCaseMigration):
         )
 
         self.assertIsInstance(old_tumour_sample, self.old_model.TumourSample)
-        self.assertTrue(old_tumour_sample.validate(old_tumour_sample.toJsonDict()))
+        self._validate(old_tumour_sample)
 
         migrated_sample = MigrationParticipants100To103().migrate_tumour_sample(
             tumour_sample=old_tumour_sample, LDPCode='test_ldp_code'
         )
 
         self.assertIsInstance(migrated_sample, self.new_model.TumourSample)
-        self.assertTrue(migrated_sample.validate(migrated_sample.toJsonDict()))
+        self._validate(migrated_sample)
 
         self.assertEqual(migrated_sample.sampleId, test_sample_id)
         self.assertEqual(migrated_sample.labSampleId, test_lab_sample_id)
@@ -148,14 +148,14 @@ class TestMigrationParticipants103To100(TestCaseMigration):
         )
 
         self.assertIsInstance(old_tumour_sample, self.old_model.TumourSample)
-        self.assertTrue(old_tumour_sample.validate(old_tumour_sample.toJsonDict()))
+        self._validate(old_tumour_sample)
 
         migrated_sample = MigrationParticipants103To100().migrate_tumour_sample(
             tumour_sample=old_tumour_sample
         )
 
         self.assertIsInstance(migrated_sample, self.new_model.TumourSample)
-        self.assertTrue(migrated_sample.validate(migrated_sample.toJsonDict()))
+        self._validate(migrated_sample)
 
         self.assertEqual(migrated_sample.sampleId, test_sample_id)
         self.assertEqual(migrated_sample.labSampleId, test_lab_sample_id)
@@ -178,14 +178,14 @@ class TestMigrationParticipants103To100(TestCaseMigration):
 
         # Check old_participant is a valid participants_1_0_4 CancerParticipant object
         self.assertTrue(isinstance(old_participant, self.old_model.CancerParticipant))
-        self.assertTrue(old_participant.validate(jsonDict=old_participant.toJsonDict()))
+        self._validate(old_participant)
 
         # # Perform the migration of old_participant from participants_1_0_4 to participants_1_0_0
         migrated_participant = MigrationParticipants103To100().migrate_cancer_participant(old_participant)
 
         # # Check migrated_participant is a valid participant_1_0_0 CancerParticipant object
         self.assertTrue(isinstance(migrated_participant, self.new_model.CancerParticipant))
-        self.assertTrue(migrated_participant.validate(jsonDict=migrated_participant.toJsonDict()))
+        self._validate(migrated_participant)
 
 
 class TestMigrationParticipants103To100(TestCaseMigration):
@@ -200,11 +200,11 @@ class TestMigrationParticipants103To100(TestCaseMigration):
 
         # Check old_participant is a valid participants_1_0_3 CancerParticipant object
         self.assertTrue(isinstance(old_participant, self.old_model.CancerParticipant))
-        self.assertTrue(old_participant.validate(jsonDict=old_participant.toJsonDict()))
+        self._validate(old_participant)
 
         # # Perform the migration of old_participant from participants_1_0_3 to participants_1_0_0
         migrated_participant = MigrationParticipants103To100().migrate_cancer_participant(old_participant)
 
         # # Check migrated_participant is a valid participant_1_0_0 CancerParticipant object
         self.assertTrue(isinstance(migrated_participant, self.new_model.CancerParticipant))
-        self.assertTrue(migrated_participant.validate(jsonDict=migrated_participant.toJsonDict()))
+        self._validate(migrated_participant)

--- a/protocols/util/dependency_manager.py
+++ b/protocols/util/dependency_manager.py
@@ -4,7 +4,7 @@ import os.path
 import inspect
 from protocols.util.singleton import Singleton
 
-VERSION_600 = "6.0.0"
+VERSION_60 = "6.0"
 VERSION_500 = "5.0.0"
 VERSION_400 = "4.0.0"
 VERSION_300 = "3.0.0"

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ reqs = [
     "PyYAML==3.12",
 ]
 
-VERSION = "6.0.2"
+VERSION = "6.0.3"
 setup(
     name='GelReportModels',
     version=VERSION,


### PR DESCRIPTION
### Major changes

* Remove hotfix version numbering from build version from 6.0 onwards. To generate any mock data from build 6.0 onwards, the string `6.0` is expected instead of `6.0.0`


#### Minor Changes

* Fixed `MigrateReports400To500().migrate_cancer_interpretation_request` and `MigrateReports400To500().migrate_interpretation_request_rd` that were failing when tested with nullable fields being null. Tests are improved
* Refactored migration tests to use `_validate`