### PR TITLE
IP-1383 - Migrate clinical report RD from 5 to 4

### DIFF
--- a/protocols/migration/__init__.py
+++ b/protocols/migration/__init__.py
@@ -7,4 +7,6 @@ from .participants import MigrationParticipants103To110
 
 from .migration_reports_3_0_0_to_reports_4_0_0 import MigrateReports3To4
 from .migration_reports_4_0_0_to_reports_5_0_0 import MigrateReports400To500
+from .migration_reports_5_0_0_to_reports_4_0_0 import MigrateReports500To400
+from .migration_reports_4_0_0_to_reports_3_0_0 import MigrateReports400To300
 from .migration_helpers import MigrationHelpers

--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -47,8 +47,15 @@ from protocols.migration.model_validator import PayloadValidation
 from protocols.migration.migration import Migration2_1To3
 from protocols.migration.migration_reports_3_0_0_to_reports_4_0_0 import MigrateReports3To4
 from protocols.migration.migration_reports_4_0_0_to_reports_5_0_0 import MigrateReports400To500
-from protocols.migration.participants import \
-    MigrationReportsToParticipants1, MigrationParticipants100To103, MigrationParticipants103To110
+from protocols.migration import (
+    MigrateReports500To400,
+    MigrateReports400To300,
+)
+from protocols.migration.participants import (
+    MigrationReportsToParticipants1,
+    MigrationParticipants100To103,
+    MigrationParticipants103To110,
+)
 from protocols.reports_5_0_0 import Assembly
 
 
@@ -460,3 +467,25 @@ class MigrationHelpers(object):
             return cp_v110
 
         raise MigrationError("Cancer participant is not in versions: [1.1.0, 1.0.3, 1.0.0, reports 2.1.0]")
+
+    @staticmethod
+    def reverse_migrate_v5_RD_clinical_report_to_v3(json_dict):
+        """
+        Whether html or json, the clinical report data needs to be migrated from v5 to v3 for RD
+        :param json_dict: ClinicalReport RD v5 json
+        :return: ClinicalReport model object with cr.clinical_report_data migrated from v5 to v3
+        """
+        cr_rd_v5 = ClinicalReportRD_5_0_0.fromJsonDict(jsonDict=json_dict)
+
+        cr_rd_v4 = MigrateReports500To400().migrate_clinical_report_rd(old_instance=cr_rd_v5)
+        if not cr_rd_v4.validate(cr_rd_v4.toJsonDict()):
+            logging.warning(msg="Migration from clinical report RD v5 to v4 has failed")
+            PayloadValidation(klass=ClinicalReportRD_4_0_0, payload=cr_rd_v4.toJsonDict()).validate()
+
+        cr_rd_v3 = MigrateReports400To300().migrate_clinical_report_rd(old_instance=cr_rd_v4)
+        cr_data_v3 = cr_rd_v3.toJsonDict()
+        if not cr_rd_v3.validate(cr_data_v3):
+            logging.warning(msg="Migration from clinical report RD v4 to v3 has failed")
+            PayloadValidation(klass=ClinicalReportRD_3_0_0, payload=cr_data_v3).validate()
+
+        return cr_data_v3

--- a/protocols/migration/migration_reports_4_0_0_to_reports_3_0_0.py
+++ b/protocols/migration/migration_reports_4_0_0_to_reports_3_0_0.py
@@ -1,0 +1,93 @@
+import logging
+
+from protocols import reports_4_0_0 as reports_4_0_0
+from protocols import reports_3_0_0 as reports_3_0_0
+from protocols.migration.base_migration import BaseMigration
+from protocols.migration.base_migration import MigrationError
+
+
+class MigrateReports400To300(BaseMigration):
+
+    old_model = reports_4_0_0
+    new_model = reports_3_0_0
+
+    def migrate_clinical_report_rd(self, old_instance):
+        """
+        :type old_instance: reports_4_0_0.ClinicalReportRD
+        :rtype: reports_3_0_0.ClinicalReportRD
+        """
+        new_instance = self.convert_class(self.new_model.ClinicalReportRD, old_instance)
+
+        # interpretationRequestId changed to interpretationRequestID
+        new_instance.interpretationRequestID = old_instance.interpretationRequestId
+
+        # interpretationRequestAnalysisVersion can be null in version 4
+        if hasattr(old_instance, 'interpretationRequestAnalysisVersion') and old_instance.interpretationRequestAnalysisVersion is not None:
+            new_instance.interpretationRequestAnalysisVersion = old_instance.interpretationRequestAnalysisVersion
+        else:
+            new_instance.interpretationRequestAnalysisVersion = old_instance.interpretationRequestVersion
+
+        new_instance.candidateVariants = self.migrate_reported_variants(old_variants=old_instance.candidateVariants)
+        new_instance.candidateStructuralVariants = self.migrate_reported_structural_variants(old_structural_variants=old_instance.candidateStructuralVariants)
+
+        return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.ClinicalReportRD)
+
+    def migrate_reported_variants(self, old_variants):
+        if old_variants is None:
+            return old_variants
+        return [self.migrate_reported_variant(old_variant) for old_variant in old_variants]
+
+    def migrate_reported_variant(self, old_reported_variant):
+        new_reported_variant = self.convert_class(self.new_model.ReportedVariant, old_reported_variant)
+        new_reported_variant.dbSNPid = old_reported_variant.dbSnpId
+        new_reported_variant.calledGenotypes = self.migrate_called_genotypes(old_called_genotypes=old_reported_variant.calledGenotypes)
+        new_reported_variant.reportEvents = self.migrate_report_events(old_reported_variant.reportEvents)
+
+        return self.validate_object(object_to_validate=new_reported_variant, object_type=self.new_model.ReportedVariant)
+
+    def migrate_reported_structural_variants(self, old_structural_variants):
+        if old_structural_variants is None:
+            return old_structural_variants
+        return [self.migrate_reported_structural_variant(old_structural_variant) for old_structural_variant in old_structural_variants]
+
+    def migrate_reported_structural_variant(self, old_structural_variant):
+        new_reported_structural_variant = self.convert_class(self.new_model.ReportedStructuralVariant, old_structural_variant)
+        new_reported_structural_variant.calledGenotypes = self.migrate_called_genotypes(old_called_genotypes=old_structural_variant.calledGenotypes)
+        new_reported_structural_variant.reportEvents = self.migrate_report_events(old_structural_variant.reportEvents)
+        return self.validate_object(object_to_validate=new_reported_structural_variant, object_type=self.new_model.ReportedStructuralVariant)
+
+    def migrate_called_genotypes(self, old_called_genotypes):
+        return [self.migrate_called_genotype(old_genotype) for old_genotype in old_called_genotypes]
+
+    def migrate_called_genotype(self, old_genotype):
+        new_genotype = self.convert_class(self.new_model.CalledGenotype, old_genotype)
+        return self.validate_object(object_to_validate=new_genotype, object_type=self.new_model.CalledGenotype)
+
+    def migrate_report_events(self, old_report_events):
+        return [self.migrate_report_event(old_report_event) for old_report_event in old_report_events]
+
+    def migrate_report_event(self, old_report_event):
+        new_report_event = self.convert_class(self.new_model.ReportEvent, old_report_event)
+        new_report_event.genomicFeature = self.migrate_genomic_feature(old_report_event.genomicFeature)
+        if old_report_event.variantClassification is not None:
+            new_report_event.variantClassification = self.migrate_variant_classification(old_report_event.variantClassification)
+        return self.validate_object(object_to_validate=new_report_event, object_type=self.new_model.ReportEvent)
+
+    def migrate_variant_classification(self, old_classification):
+        variant_classification_map = {
+            self.old_model.VariantClassification.benign_variant: self.new_model.VariantClassification.BENIGN,
+            self.old_model.VariantClassification.likely_benign_variant: self.new_model.VariantClassification.LIKELY_BENIGN,
+            self.old_model.VariantClassification.variant_of_unknown_clinical_significance : self.new_model.VariantClassification.VUS,
+            self.old_model.VariantClassification.likely_pathogenic_variant: self.new_model.VariantClassification.LIKELY_PATHOGENIC,
+            self.old_model.VariantClassification.pathogenic_variant: self.new_model.VariantClassification.PATHOGENIC,
+        }
+        return variant_classification_map.get(old_classification)
+
+    def migrate_genomic_feature(self, old_genomic_feature):
+        new_genomic_feature = self.new_model.GenomicFeature(
+            featureType=old_genomic_feature.featureType,
+            ensemblId=old_genomic_feature.ensemblId,
+            HGNC=old_genomic_feature.hgnc,
+            other_ids=old_genomic_feature.otherIds,
+        )
+        return self.validate_object(object_to_validate=new_genomic_feature, object_type=self.new_model.GenomicFeature)

--- a/protocols/migration/migration_reports_5_0_0_to_reports_4_0_0.py
+++ b/protocols/migration/migration_reports_5_0_0_to_reports_4_0_0.py
@@ -1,0 +1,175 @@
+import logging
+
+from protocols import reports_4_0_0 as reports_4_0_0
+from protocols import reports_5_0_0 as reports_5_0_0
+from protocols.migration.base_migration import BaseMigration
+from protocols.migration.base_migration import MigrationError
+
+
+class MigrateReports500To400(BaseMigration):
+
+    old_model = reports_5_0_0
+    new_model = reports_4_0_0
+
+    def migrate_clinical_report_rd(self, old_instance):
+        """
+        :type old_instance: reports_5_0_0.ClinicalReportRD
+        :rtype: reports_4_0_0.ClinicalReportRD
+        """
+        new_instance = self.convert_class(self.new_model.ClinicalReportRD, old_instance)  # :type self.new_model.ClinicalReportRD
+        # type of interpretationRequestVersion has been changed from int to str
+        new_instance.interpretationRequestVersion = str(old_instance.interpretationRequestVersion)
+        # references has been renamed to supportingEvidence
+        new_instance.supportingEvidence = old_instance.references
+        new_instance.candidateVariants = self.migrate_reported_variants(old_reported_variants=old_instance.variants)
+        new_instance.additionalAnalysisPanels = self.migrate_analysis_panels(old_panels=old_instance.additionalAnalysisPanels)
+
+        return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.ClinicalReportRD)
+
+    def migrate_analysis_panels(self, old_panels):
+        if not old_panels:
+            return old_panels
+        return [self.migrate_analysis_panel(old_panel=panel) for panel in old_panels]
+
+    def migrate_analysis_panel(self, old_panel):
+        new_panel = self.new_model.AdditionalAnalysisPanel(
+            panelVersion=old_panel.panel.panelVersion,
+            panelName=old_panel.panel.panelName,
+            specificDisease=old_panel.specificDisease,
+        )
+        return self.validate_object(object_to_validate=new_panel, object_type=self.new_model.AdditionalAnalysisPanel)
+
+    def migrate_reported_variants(self, old_reported_variants):
+        if old_reported_variants is None:
+            return old_reported_variants
+        return [self.migrate_reported_variant(old_reported_variant=old_variant) for old_variant in old_reported_variants]
+
+    def migrate_reported_variant(self, old_reported_variant):
+        new_reported_variant = self.new_model.ReportedVariant(
+            dbSnpId=old_reported_variant.dbSnpId,
+            chromosome=old_reported_variant.variantCoordinates.chromosome,
+            position=old_reported_variant.variantCoordinates.position,
+            reference=old_reported_variant.variantCoordinates.reference,
+            alternate=old_reported_variant.variantCoordinates.alternate,
+            additionalTextualVariantAnnotations=old_reported_variant.additionalTextualVariantAnnotations,
+            evidenceIds=old_reported_variant.references,
+            comments=old_reported_variant.comments,
+        )
+
+        new_reported_variant.calledGenotypes = self.migrate_variant_calls_to_called_genotypes(old_reported_variant.variantCalls)
+
+        new_reported_variant.reportEvents = self.migrate_report_events(old_reported_variant.reportEvents)
+
+        new_reported_variant.additionalNumericVariantAnnotations = self.merge_annotations_and_frequencies(
+            old_reported_variant.additionalNumericVariantAnnotations, old_reported_variant.alleleFrequencies,
+        )
+        return self.validate_object(object_to_validate=new_reported_variant, object_type=self.new_model.ReportedVariant)
+
+    @staticmethod
+    def merge_annotations_and_frequencies(numeric_annotations, allele_frequencies):
+        if not isinstance(numeric_annotations, dict):
+            raise MigrationError("additionalNumericVariantAnnotations should be dict but is: {}".format(numeric_annotations))
+        if allele_frequencies is not None:
+            for af in allele_frequencies:
+                annotation_key = "{}:{}".format(af.study, af.population)
+                if annotation_key in numeric_annotations:
+                    logging.warning(
+                        "{} already exists in numeric_annotations with value {} instead of {}".format(
+                            annotation_key, numeric_annotations.get(annotation_key), af.alternateFrequency
+                        )
+                    )
+                else:
+                    numeric_annotations["{}:{}".format(af.study, af.population)] = af.alternateFrequency
+        return numeric_annotations
+
+    def migrate_genomic_entity_to_feature(self, entity):
+        feature_type_map = {
+            self.old_model.GenomicEntityType.regulatory_region: self.new_model.FeatureTypes.RegulatoryRegion,
+            self.old_model.GenomicEntityType.gene: self.new_model.FeatureTypes.Gene,
+            self.old_model.GenomicEntityType.transcript: self.new_model.FeatureTypes.Transcript,
+        }
+        feature_type = feature_type_map.get(entity.type)
+        if feature_type is None:
+            raise MigrationError(
+                "{} can not be migrated to a feature type, but be one of: {}".format(
+                    entity.type, feature_type_map.keys()
+                )
+            )
+        genomic_feature = self.new_model.GenomicFeature(
+            featureType=feature_type,
+            ensemblId=entity.ensemblId,
+            hgnc=entity.geneSymbol,
+            otherIds=entity.otherIds,
+        )
+        return self.validate_object(object_to_validate=genomic_feature, object_type=self.new_model.GenomicFeature)
+
+    def migrate_report_event(self, old_report_event):
+        new_report_event = self.convert_class(self.new_model.ReportEvent, old_report_event)
+
+        new_report_event.phenotype = ','.join(old_report_event.phenotypes)
+
+        if old_report_event.genePanel is not None:
+            if hasattr(old_report_event.genePanel, 'panelName') and hasattr(old_report_event.genePanel, 'panelVersion'):
+                new_report_event.panelName = old_report_event.genePanel.panelName
+                new_report_event.panelVersion = old_report_event.genePanel.panelVersion
+        if isinstance(old_report_event.genomicEntities, list):
+            if old_report_event.genomicEntities:
+                first_genomic_entity = old_report_event.genomicEntities[0]
+                new_report_event.genomicFeature = self.migrate_genomic_entity_to_feature(entity=first_genomic_entity)
+                if len(old_report_event.genomicEntities) > 1:
+                    logging.warning("{} genomic entities are being lost in the migration".format(len(old_report_event.genomicEntities)-1))
+
+        variant_classification_map = {
+            self.old_model.ClinicalSignificance.benign: self.new_model.VariantClassification.benign_variant,
+            self.old_model.ClinicalSignificance.likely_benign: self.new_model.VariantClassification.likely_benign_variant,
+            self.old_model.ClinicalSignificance.VUS: self.new_model.VariantClassification.variant_of_unknown_clinical_significance,
+            self.old_model.ClinicalSignificance.likely_pathogenic: self.new_model.VariantClassification.likely_pathogenic_variant,
+            self.old_model.ClinicalSignificance.pathogenic: self.new_model.VariantClassification.pathogenic_variant,
+        }
+        new_report_event.variantClassification = variant_classification_map.get(
+            old_report_event.variantClassification,
+            self.new_model.VariantClassification.not_assessed
+        )
+
+        return self.validate_object(object_to_validate=new_report_event, object_type=self.new_model.ReportEvent)
+
+    def migrate_report_events(self, old_report_events):
+        return [
+            self.migrate_report_event(old_report_event=old_report_event)
+            for old_report_event in old_report_events
+        ]
+
+    def migrate_variant_calls_to_called_genotypes(self, old_variant_calls):
+        return [
+            self.migrate_variant_call_to_called_genotype(variant_call=variant_call)
+            for variant_call in old_variant_calls
+        ]
+
+    def migrate_variant_call_to_called_genotype(self, variant_call):
+
+        genotype_map = {
+            self.old_model.Zygosity.reference_homozygous: self.new_model.Zygosity.reference_homozygous,
+            self.old_model.Zygosity.heterozygous: self.new_model.Zygosity.heterozygous,
+            self.old_model.Zygosity.alternate_homozygous: self.new_model.Zygosity.alternate_homozygous,
+            self.old_model.Zygosity.missing: self.new_model.Zygosity.missing,
+            self.old_model.Zygosity.half_missing_reference: self.new_model.Zygosity.half_missing_reference,
+            self.old_model.Zygosity.half_missing_alternate: self.new_model.Zygosity.half_missing_alternate,
+            self.old_model.Zygosity.alternate_hemizigous: self.new_model.Zygosity.alternate_hemizigous,
+            self.old_model.Zygosity.reference_hemizigous: self.new_model.Zygosity.reference_hemizigous,
+            self.old_model.Zygosity.unk: self.new_model.Zygosity.unk,
+        }
+        genotype = genotype_map.get(variant_call.zygosity)
+        if genotype is None:
+            raise MigrationError("Can not migrate variant call to genotype when zygosity is: {}".format(
+                variant_call.zygosity
+            ))
+
+        new_called_genotype = self.new_model.CalledGenotype(
+            gelId=variant_call.participantId,
+            sampleId=variant_call.sampleId,
+            genotype=genotype,
+            phaseSet=variant_call.phaseSet,
+            depthReference=variant_call.depthReference,
+            depthAlternate=variant_call.depthAlternate,
+        )
+        return self.validate_object(object_to_validate=new_called_genotype, object_type=self.new_model.CalledGenotype)

--- a/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_3_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_4_0_0_to_reports_3_0_0.py
@@ -1,0 +1,47 @@
+import factory.fuzzy
+from random import randint
+
+from protocols import reports_4_0_0
+from protocols import reports_3_0_0
+from protocols.util.dependency_manager import VERSION_61
+from protocols.util.dependency_manager import VERSION_500
+from protocols.util.dependency_manager import VERSION_400
+from protocols.util.factories.avro_factory import FactoryAvro
+from protocols.util.factories.avro_factory import GenericFactoryAvro
+from protocols.tests.test_migration.base_test_migration import TestCaseMigration
+from protocols.migration import MigrateReports400To300
+
+
+class TestMigrateReports5To400(TestCaseMigration):
+
+    old_model = reports_4_0_0
+    new_model = reports_3_0_0
+
+    def _check_variant_coordinates(self, old_variants, new_variants):
+        for new_variant, old_variant in zip(new_variants, old_variants):
+            self.assertEqual(new_variant.reference, old_variant.reference)
+            self.assertEqual(new_variant.alternate, old_variant.alternate)
+            self.assertEqual(new_variant.position, old_variant.position)
+            self.assertEqual(new_variant.chromosome, old_variant.chromosome)
+
+    def test_migrate_rd_clinical_report(self, fill_nullables=True):
+        # creates a random clinical report RD for testing filling null values
+        old_instance = GenericFactoryAvro.get_factory_avro(
+            self.old_model.ClinicalReportRD, VERSION_400, fill_nullables=fill_nullables
+        ).create(interpretationRequestVersion='1')  # we need to enforce that it can be cast to int
+
+        self._validate(old_instance)
+        if fill_nullables:
+            self._check_non_empty_fields(old_instance)
+
+        new_instance = MigrateReports400To300().migrate_clinical_report_rd(old_instance=old_instance)
+        self.assertIsInstance(new_instance, self.new_model.ClinicalReportRD)
+        self._validate(new_instance)
+        if fill_nullables:
+            self._check_variant_coordinates(
+                old_variants=old_instance.candidateVariants,
+                new_variants=new_instance.candidateVariants,
+            )
+
+    def test_migrate_rd_clinical_report_fill_nullables_false(self):
+        self.test_migrate_rd_clinical_report(fill_nullables=False)

--- a/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_3_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_3_0_0.py
@@ -1,0 +1,94 @@
+import factory.fuzzy
+from random import randint
+
+from protocols import reports_3_0_0
+from protocols import reports_4_0_0
+from protocols import reports_5_0_0
+from protocols.migration import MigrationHelpers
+from protocols.migration import MigrateReports500To400
+from protocols.migration import MigrateReports400To300
+from protocols.util.dependency_manager import VERSION_61
+from protocols.util.dependency_manager import VERSION_500
+from protocols.util.dependency_manager import VERSION_400
+from protocols.util.factories.avro_factory import FactoryAvro
+from protocols.util.factories.avro_factory import GenericFactoryAvro
+from protocols.tests.test_migration.base_test_migration import TestCaseMigration
+
+
+class TestMigrateReports5To300(TestCaseMigration):
+
+    old_model = reports_5_0_0
+    new_model = reports_3_0_0
+
+    def _check_variant_coordinates(self, old_variants, new_variants):
+        for new_variant, old_variant in zip(new_variants, old_variants):
+            self.assertEqual(new_variant.reference, old_variant.variantCoordinates.reference)
+            self.assertEqual(new_variant.alternate, old_variant.variantCoordinates.alternate)
+            self.assertEqual(new_variant.position, old_variant.variantCoordinates.position)
+            self.assertEqual(new_variant.chromosome, old_variant.variantCoordinates.chromosome)
+
+    def _check_variant_coordinates_4_3(self, old_variants, new_variants):
+        for new_variant, old_variant in zip(new_variants, old_variants):
+            self.assertEqual(new_variant.reference, old_variant.reference)
+            self.assertEqual(new_variant.alternate, old_variant.alternate)
+            self.assertEqual(new_variant.position, old_variant.position)
+            self.assertEqual(new_variant.chromosome, old_variant.chromosome)
+
+    def test_migrate_rd_clinical_report(self, fill_nullables=True):
+        # creates a random clinical report RD for testing filling null values
+        old_instance = GenericFactoryAvro.get_factory_avro(
+            self.old_model.ClinicalReportRD, VERSION_61, fill_nullables=fill_nullables
+        ).create(interpretationRequestVersion='1')  # we need to enforce that it can be cast to int
+
+        self._validate(old_instance)
+        if fill_nullables:
+            self._check_non_empty_fields(old_instance)
+
+            #################################################
+            # TODO(Greg): Remove this when IP-1394 is resolved
+            valid_tiers = ["TIER1", "TIER2", "TIER3", "NONE"]
+            for rv in old_instance.variants:
+                for re in rv.reportEvents:
+                    if re.tier not in valid_tiers:
+                        re.tier = valid_tiers[randint(0, len(valid_tiers)-1)]
+            #################################################
+
+            valid_genomic_features = [
+                self.old_model.GenomicEntityType.regulatory_region,
+                self.old_model.GenomicEntityType.gene,
+                self.old_model.GenomicEntityType.transcript,
+            ]
+            for rv in old_instance.variants:
+                for re in rv.reportEvents:
+                    entity = re.genomicEntities[0]
+                    if entity.type not in valid_genomic_features:
+                        entity.type = valid_genomic_features[randint(0, len(valid_genomic_features)-1)]
+
+            valid_genotypes = [
+                self.old_model.Zygosity.reference_homozygous,
+                self.old_model.Zygosity.heterozygous,
+                self.old_model.Zygosity.alternate_homozygous,
+                self.old_model.Zygosity.missing,
+                self.old_model.Zygosity.half_missing_reference,
+                self.old_model.Zygosity.half_missing_alternate,
+                self.old_model.Zygosity.alternate_hemizigous,
+                self.old_model.Zygosity.reference_hemizigous,
+                self.old_model.Zygosity.unk,
+            ]
+            for rv in old_instance.variants:
+                for vc in rv.variantCalls:
+                    if vc.zygosity not in valid_genotypes:
+                        vc.zygosity = valid_genotypes[randint(0, len(valid_genotypes)-1)]
+
+        new_instance_json = MigrationHelpers().reverse_migrate_v5_RD_clinical_report_to_v3(json_dict=old_instance.toJsonDict())
+        new_instance = self.new_model.ClinicalReportRD.fromJsonDict(jsonDict=new_instance_json)
+
+        self._validate(new_instance)
+        if fill_nullables:
+            self._check_variant_coordinates(
+                old_variants=old_instance.variants,
+                new_variants=new_instance.candidateVariants,
+            )
+
+    def test_migrate_rd_clinical_report_nullables_false(self):
+        self.test_migrate_rd_clinical_report(fill_nullables=False)

--- a/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_4_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_4_0_0.py
@@ -1,0 +1,203 @@
+import factory.fuzzy
+from random import randint
+
+from protocols import reports_4_0_0
+from protocols import reports_5_0_0
+from protocols.util.dependency_manager import VERSION_61
+from protocols.util.dependency_manager import VERSION_500
+from protocols.util.dependency_manager import VERSION_400
+from protocols.util.factories.avro_factory import FactoryAvro
+from protocols.util.factories.avro_factory import GenericFactoryAvro
+from protocols.tests.test_migration.base_test_migration import TestCaseMigration
+from protocols.migration.migration_reports_5_0_0_to_reports_4_0_0 import MigrateReports500To400
+
+
+class TestMigrateReports5To400(TestCaseMigration):
+
+    old_model = reports_5_0_0
+    new_model = reports_4_0_0
+
+    def _check_variant_coordinates(self, old_variants, new_variants):
+        for new_variant, old_variant in zip(new_variants, old_variants):
+            self.assertEqual(new_variant.reference, old_variant.variantCoordinates.reference)
+            self.assertEqual(new_variant.alternate, old_variant.variantCoordinates.alternate)
+            self.assertEqual(new_variant.position, old_variant.variantCoordinates.position)
+            self.assertEqual(new_variant.chromosome, old_variant.variantCoordinates.chromosome)
+
+    def test_migrate_analysis_panel(self):
+        old_panel = GenericFactoryAvro.get_factory_avro(
+            self.old_model.AdditionalAnalysisPanel, VERSION_61, fill_nullables=True
+        ).create()
+        new_panel = MigrateReports500To400().migrate_analysis_panel(old_panel=old_panel)
+        self.assertTrue(new_panel.validate(new_panel.toJsonDict()))
+
+    def test_migrate_genomic_entity_to_feature(self):
+        old_entity = GenericFactoryAvro.get_factory_avro(self.old_model.GenomicEntity, VERSION_61, fill_nullables=True).create()
+
+        valid_genomic_features = [
+            self.old_model.GenomicEntityType.regulatory_region,
+            self.old_model.GenomicEntityType.gene,
+            self.old_model.GenomicEntityType.transcript,
+        ]
+        if old_entity.type not in valid_genomic_features:
+            old_entity.type = valid_genomic_features[randint(0, len(valid_genomic_features)-1)]
+
+        entity_type = old_entity.type
+        feature_type_map = {
+            self.old_model.GenomicEntityType.regulatory_region: self.new_model.FeatureTypes.RegulatoryRegion,
+            self.old_model.GenomicEntityType.gene: self.new_model.FeatureTypes.Gene,
+            self.old_model.GenomicEntityType.transcript: self.new_model.FeatureTypes.Transcript,
+        }
+        expected_feature_type = feature_type_map.get(entity_type)
+        new_feature = MigrateReports500To400().migrate_genomic_entity_to_feature(old_entity)
+        self.assertTrue(isinstance(new_feature, self.new_model.GenomicFeature))
+        self._validate(new_feature)
+        self.assertEqual(new_feature.featureType, expected_feature_type)
+
+    def test_migrate_report_event(self):
+        old_report_event = GenericFactoryAvro.get_factory_avro(self.old_model.ReportEvent, VERSION_61, fill_nullables=True).create()
+        #################################################
+        # TODO(Greg): Remove this when IP-1394 is resolved
+        valid_tiers = ["TIER1", "TIER2", "TIER3", "NONE"]
+        if old_report_event.tier not in valid_tiers:
+            old_report_event.tier = valid_tiers[randint(0, len(valid_tiers)-1)]
+        #################################################
+
+        valid_genomic_features = [
+            self.old_model.GenomicEntityType.regulatory_region,
+            self.old_model.GenomicEntityType.gene,
+            self.old_model.GenomicEntityType.transcript,
+        ]
+        entity = old_report_event.genomicEntities[0]
+        if entity.type not in valid_genomic_features:
+            entity.type = valid_genomic_features[randint(0, len(valid_genomic_features)-1)]
+
+        new_report_event = MigrateReports500To400().migrate_report_event(old_report_event=old_report_event)
+        self.assertTrue(isinstance(new_report_event, self.new_model.ReportEvent))
+        self._validate(new_report_event)
+
+    def test_migrate_reported_variant(self):
+        old_reported_variant = GenericFactoryAvro.get_factory_avro(self.old_model.ReportedVariant, VERSION_61, fill_nullables=True).create()
+
+        #################################################
+        # TODO(Greg): Remove this when IP-1394 is resolved
+        valid_tiers = ["TIER1", "TIER2", "TIER3", "NONE"]
+        for re in old_reported_variant.reportEvents:
+            if re.tier not in valid_tiers:
+                re.tier = valid_tiers[randint(0, len(valid_tiers)-1)]
+        #################################################
+
+        valid_genomic_features = [
+            self.old_model.GenomicEntityType.regulatory_region,
+            self.old_model.GenomicEntityType.gene,
+            self.old_model.GenomicEntityType.transcript,
+        ]
+        for re in old_reported_variant.reportEvents:
+            entity = re.genomicEntities[0]
+            if entity.type not in valid_genomic_features:
+                entity.type = valid_genomic_features[randint(0, len(valid_genomic_features)-1)]
+
+        valid_genotypes = [
+            self.old_model.Zygosity.reference_homozygous,
+            self.old_model.Zygosity.heterozygous,
+            self.old_model.Zygosity.alternate_homozygous,
+            self.old_model.Zygosity.missing,
+            self.old_model.Zygosity.half_missing_reference,
+            self.old_model.Zygosity.half_missing_alternate,
+            self.old_model.Zygosity.alternate_hemizigous,
+            self.old_model.Zygosity.reference_hemizigous,
+            self.old_model.Zygosity.unk,
+        ]
+        for vc in old_reported_variant.variantCalls:
+            if vc.zygosity not in valid_genotypes:
+                vc.zygosity = valid_genotypes[randint(0, len(valid_genotypes)-1)]
+
+        new_reported_variant = MigrateReports500To400().migrate_reported_variant(old_reported_variant=old_reported_variant)
+        self.assertTrue(isinstance(new_reported_variant, self.new_model.ReportedVariant))
+        self._validate(new_reported_variant)
+
+    def test_migrate_variant_call_to_called_genotype(self):
+        old_instance = GenericFactoryAvro.get_factory_avro(
+            self.old_model.VariantCall, VERSION_61, fill_nullables=True
+        ).create()
+
+        valid_genotypes = [
+            self.old_model.Zygosity.reference_homozygous,
+            self.old_model.Zygosity.heterozygous,
+            self.old_model.Zygosity.alternate_homozygous,
+            self.old_model.Zygosity.missing,
+            self.old_model.Zygosity.half_missing_reference,
+            self.old_model.Zygosity.half_missing_alternate,
+            self.old_model.Zygosity.alternate_hemizigous,
+            self.old_model.Zygosity.reference_hemizigous,
+            self.old_model.Zygosity.unk,
+        ]
+
+        if old_instance.zygosity not in valid_genotypes:
+            old_instance.zygosity = valid_genotypes[randint(0, len(valid_genotypes)-1)]
+
+        new_instance = MigrateReports500To400().migrate_variant_call_to_called_genotype(variant_call=old_instance)
+        self.assertTrue(isinstance(new_instance, self.new_model.CalledGenotype))
+        self._validate(new_instance)
+
+    def test_migrate_rd_clinical_report(self, fill_nullables=True):
+        # creates a random clinical report RD for testing filling null values
+        old_instance = GenericFactoryAvro.get_factory_avro(
+            self.old_model.ClinicalReportRD, VERSION_61, fill_nullables=fill_nullables
+        ).create(interpretationRequestVersion='1')  # we need to enforce that it can be cast to int
+
+        self._validate(old_instance)
+        if fill_nullables:
+            self._check_non_empty_fields(old_instance)
+
+        #################################################
+        # TODO(Greg): Remove this when IP-1394 is resolved
+        valid_tiers = ["TIER1", "TIER2", "TIER3", "NONE"]
+        if old_instance.variants:
+            for rv in old_instance.variants:
+                for re in rv.reportEvents:
+                    if re.tier not in valid_tiers:
+                        re.tier = valid_tiers[randint(0, len(valid_tiers)-1)]
+        #################################################
+
+        valid_genomic_features = [
+            self.old_model.GenomicEntityType.regulatory_region,
+            self.old_model.GenomicEntityType.gene,
+            self.old_model.GenomicEntityType.transcript,
+        ]
+        if old_instance.variants:
+            for rv in old_instance.variants:
+                for re in rv.reportEvents:
+                    entity = re.genomicEntities[0]
+                    if entity.type not in valid_genomic_features:
+                        entity.type = valid_genomic_features[randint(0, len(valid_genomic_features)-1)]
+
+        valid_genotypes = [
+            self.old_model.Zygosity.reference_homozygous,
+            self.old_model.Zygosity.heterozygous,
+            self.old_model.Zygosity.alternate_homozygous,
+            self.old_model.Zygosity.missing,
+            self.old_model.Zygosity.half_missing_reference,
+            self.old_model.Zygosity.half_missing_alternate,
+            self.old_model.Zygosity.alternate_hemizigous,
+            self.old_model.Zygosity.reference_hemizigous,
+            self.old_model.Zygosity.unk,
+        ]
+        if old_instance.variants:
+            for rv in old_instance.variants:
+                for vc in rv.variantCalls:
+                    if vc.zygosity not in valid_genotypes:
+                        vc.zygosity = valid_genotypes[randint(0, len(valid_genotypes)-1)]
+
+        new_instance = MigrateReports500To400().migrate_clinical_report_rd(old_instance=old_instance)
+        self.assertTrue(isinstance(new_instance, self.new_model.ClinicalReportRD))
+        self._validate(new_instance)
+        if fill_nullables:
+            self._check_variant_coordinates(
+                old_variants=old_instance.variants,
+                new_variants=new_instance.candidateVariants,
+            )
+
+    def test_migrate_rd_clinical_report_nullables_false(self):
+        self.test_migrate_rd_clinical_report(fill_nullables=False)
+

--- a/schemas/IDLs/org.gel.models.report.avro/4.0.0/CommonInterpreted.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/4.0.0/CommonInterpreted.avdl
@@ -134,7 +134,7 @@ It is a representation of the zygosity
     This is the classification of the variant according to standard practice guidelines (e.g. ACMG)
     */
     // TODO: refactor with ACMGClassification in ExitQuestionnaire
-    enum VariantClassification {pathogenic_variant, likely_pathogenic_variant, variant_of_unknown_clinical_significance, likely_benign_variant,  benign_variant, not_assessed}
+    enum VariantClassification {pathogenic_variant, likely_pathogenic_variant, variant_of_unknown_clinical_significance, likely_benign_variant, benign_variant, not_assessed}
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ reqs = [
     "dictdiffer"
 ]
 
-VERSION = "6.1.2"
+VERSION = "6.1.3"
 setup(
     name='GelReportModels',
     version=VERSION,


### PR DESCRIPTION
[IP-1383 - Migrate clinical report RD from 5 to 4](https://jira.extge.co.uk/browse/IP-1383)
===============

Summary of Changes:
===============
* Add `MigrateReports500To400.migrate_clinical_report_rd` within `protocols/migration/migration_reports_5_0_0_to_reports_4_0_0.py` to migrate RD Clinical Reports from version 5 of reports to version 4
* Add `test_migrate_rd_clinical_report`
* Add `test_migrate_analysis_panel`
* Add `test_migrate_genomic_entity_to_feature`
* Add `test_migrate_report_event`
* Add `test_migrate_reported_variant`
* Add `test_migrate_variant_call_to_called_genotype`

- [x] Tests passing locally:
```
(.env) greg@greg-Latitude-E7470:~/gel/GelReportModels$ python -m unittest discover
----------------------------------------------------------------------
Ran 120 tests in 8.246s

OK
(.env) greg@greg-Latitude-E7470:~/gel/GelReportModels$ 

```