### PR TITLE
Proposed model changes

### DIFF
--- a/schemas/IDLs/org.gel.models.report.avro/6.0.0/CommonInterpreted.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.0.0/CommonInterpreted.avdl
@@ -590,7 +590,7 @@ protocol CommonInterpreted {
         /**
         The standardised phenotypes (i.e.: controlled terminology)
         */
-        array<StandardPhenotype> standardPhenotypes;
+        union {null, array<StandardPhenotype>} standardPhenotypes;
     }
 
     /**
@@ -827,8 +827,8 @@ protocol CommonInterpreted {
         Number of copies given by the caller in one of the allele
         */
         int numberOfCopies;
-        union{null, int} confidenceIntervalMaximun;
-        union{null, int} confidenceIntervalMinimun;
+        union{null, int} confidenceIntervalMaximum;
+        union{null, int} confidenceIntervalMinimum;
     }
 
     /**
@@ -880,7 +880,7 @@ protocol CommonInterpreted {
         /**
         Describe whether this is a somatic or Germline variant
         */
-        array<AlleleOrigin> alleleOrigins;
+        union {null, array<AlleleOrigin>} alleleOrigins;
 
         union {null, array<SupportingReadType>} supportingReadTypes;
 


### PR DESCRIPTION
* Make `Phenotypes.standardPhenotypes` nullable
* Rename `NumberOfCopies.confidenceIntervalMaximun` to `NumberOfCopies.confidenceIntervalMaximum`
* Rename `NumberOfCopies.confidenceIntervalMinimun` to `NumberOfCopies.confidenceIntervalMinimum`
* Make `VariantCall.alleleOrigins` nullable