### PR TITLE
Change builds.json

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -2,7 +2,7 @@
   "builds" :
   [
     {
-      "version": "7.1",
+      "version": "7.0",
       "packages": [
         {
           "package": "org.ga4gh.models",
@@ -64,67 +64,6 @@
       ]
     },
     {
-      "version": "7.0",
-      "packages": [
-        {
-          "package": "org.ga4gh.models",
-          "python_package": "ga4gh",
-          "version": "3.0.0",
-          "dependencies": []
-        },
-        {
-          "package": "org.gel.models.metrics.avro",
-          "python_package": "metrics",
-          "version": "1.1.0",
-          "dependencies": [
-            "org.gel.models.participant.avro"
-          ]
-        },
-        {
-          "package": "org.gel.models.participant.avro",
-          "python_package": "participant",
-          "version": "1.1.0",
-          "dependencies": []
-        },
-        {
-          "package": "org.gel.models.report.avro",
-          "python_package": "reports",
-          "version": "6.0.0",
-          "dependencies": [
-            "org.gel.models.participant.avro"
-          ]
-        },
-        {
-          "package": "org.gel.models.system.avro",
-          "python_package": "system",
-          "version": "0.1.0",
-          "dependencies": []
-        },
-        {
-          "package": "org.opencb.biodata.models.variant.avro",
-          "python_package": "opencb",
-          "version": "1.3.0",
-          "dependencies": []
-        },
-        {
-          "package": "org.gel.models.coverage.avro",
-          "python_package": "coverage",
-          "version": "0.1.0",
-          "dependencies": []
-        },
-        {
-          "package": "org.gel.models.cva.avro",
-          "python_package": "cva",
-          "version": "1.1.0",
-          "dependencies": [
-            "org.gel.models.report.avro",
-            "org.gel.models.participant.avro",
-            "org.gel.models.system.avro",
-            "org.opencb.biodata.models.variant.avro"
-          ]
-        }
-      ]
-    },    {
       "version": "6.1",
       "packages": [
         {


### PR DESCRIPTION
Changes required to build the latest version of the models
* Remove `7.0` from builds.json
* Rename `7.1` to `7.0`