### PR TITLE
IP-1734 - Migrate clinical report rd to latest to migrate to v6

### DIFF
--- a/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
@@ -41,6 +41,8 @@ class MigrateReports500To600(BaseMigration):
         )
 
     def migrate_variants(self, old_variants, panel_source='panelapp'):
+        if old_variants is None:
+            return None
         return [self.migrate_variant(old_variant=old_variant, panel_source=panel_source) for old_variant in old_variants]
 
     def migrate_variant(self, old_variant, panel_source='panelapp'):

--- a/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
@@ -182,3 +182,11 @@ class MigrateReports500To600(BaseMigration):
         return self.validate_object(
             object_to_validate=identifier, object_type=self.new_model.Identifier,
         )
+
+    def migrate_clinical_report_rd(self, old_instance):
+        migrated_instance = self.convert_class(self.new_model.ClinicalReport, old_instance)
+        migrated_instance.variants = self.migrate_variants(old_variants=old_instance.variants)
+        return self.validate_object(object_to_validate=migrated_instance, object_type=self.new_model.ClinicalReport)
+
+    def migrate_additional_analysis_panels(self, old_panels):
+        return [self.migrate_additional_analysis_panel(old_panel=old_panel) for old_panel in old_panels]

--- a/protocols/tests/test_migration/test_migration_helpers.py
+++ b/protocols/tests/test_migration/test_migration_helpers.py
@@ -319,9 +319,9 @@ class TestMigrationHelpers(TestCaseMigration):
     def test_migrate_interpreted_genome_rd_500_600_nulls(self):
         self.test_migrate_interpreted_genome_rd_500_600(fill_nullables=True)
 
-    def test_migrate_rd_clinical_report_400_500(self, fill_nullables=True):
+    def test_migrate_rd_clinical_report_400_600(self, fill_nullables=True):
 
-        # tests IG 400 -> 500
+        # tests IG 400 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_4_0_0.ClinicalReportRD, VERSION_400, fill_nullables=fill_nullables
         ).create()
@@ -332,14 +332,15 @@ class TestMigrationHelpers(TestCaseMigration):
         migrated_instance = MigrationHelpers.migrate_clinical_report_rd_to_latest(
             old_instance.toJsonDict(), assembly='GRCh38'
         )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.ClinicalReport)
         self._validate(migrated_instance)
 
-    def test_migrate_rd_clinical_report_400_500_nulls(self):
-        self.test_migrate_rd_clinical_report_400_500(fill_nullables=False)
+    def test_migrate_rd_clinical_report_400_600_nulls(self):
+        self.test_migrate_rd_clinical_report_400_600(fill_nullables=False)
 
-    def test_migrate_rd_clinical_report_300_500(self, fill_nullables=True):
+    def test_migrate_rd_clinical_report_300_600(self, fill_nullables=True):
 
-        # tests IG 300 -> 500
+        # tests IG 300 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_3_0_0.ClinicalReportRD, VERSION_300, fill_nullables=fill_nullables
         ).create()
@@ -350,14 +351,15 @@ class TestMigrationHelpers(TestCaseMigration):
 
         migrated_instance = MigrationHelpers.migrate_clinical_report_rd_to_latest(
             old_instance.toJsonDict(), assembly='GRCh38')
+        self.assertIsInstance(migrated_instance, reports_6_0_0.ClinicalReport)
         self._validate(migrated_instance)
 
-    def test_migrate_rd_clinical_report_300_500_nulls(self):
-        self.test_migrate_rd_clinical_report_300_500(fill_nullables=False)
+    def test_migrate_rd_clinical_report_300_600_nulls(self):
+        self.test_migrate_rd_clinical_report_300_600(fill_nullables=False)
 
-    def test_migrate_rd_clinical_report_210_500(self, fill_nullables=True):
+    def test_migrate_rd_clinical_report_210_600(self, fill_nullables=True):
 
-        # tests IG 210 -> 500
+        # tests IG 210 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_2_1_0.ClinicalReportRD, VERSION_210, fill_nullables=fill_nullables
         ).create()
@@ -368,14 +370,15 @@ class TestMigrationHelpers(TestCaseMigration):
 
         migrated_instance = MigrationHelpers.migrate_clinical_report_rd_to_latest(
             old_instance.toJsonDict(), assembly='GRCh38')
+        self.assertIsInstance(migrated_instance, reports_6_0_0.ClinicalReport)
         self._validate(migrated_instance)
 
-    def test_migrate_rd_clinical_report_210_500_nulls(self):
-        self.test_migrate_rd_clinical_report_210_500(fill_nullables=False)
+    def test_migrate_rd_clinical_report_210_600_nulls(self):
+        self.test_migrate_rd_clinical_report_210_600(fill_nullables=False)
 
-    def test_migrate_rd_clinical_report_500_500(self, fill_nullables=True):
+    def test_migrate_rd_clinical_report_500_600(self, fill_nullables=True):
 
-        # tests IG 500 -> 500
+        # tests IG 500 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_5_0_0.ClinicalReportRD, VERSION_61, fill_nullables=fill_nullables
         ).create()
@@ -383,12 +386,12 @@ class TestMigrationHelpers(TestCaseMigration):
         if fill_nullables:
             self._check_non_empty_fields(old_instance)
 
-        migrated_instance = MigrationHelpers.migrate_clinical_report_rd_to_latest(
-            old_instance.toJsonDict(), assembly='GRCh38')
+        migrated_instance = MigrationHelpers.migrate_clinical_report_rd_to_latest(old_instance.toJsonDict())
+        self.assertIsInstance(migrated_instance, reports_6_0_0.ClinicalReport)
         self._validate(migrated_instance)
 
-    def test_migrate_rd_clinical_report_500_500_nulls(self):
-        self.test_migrate_rd_clinical_report_500_500(fill_nullables=False)
+    def test_migrate_rd_clinical_report_500_600_nulls(self):
+        self.test_migrate_rd_clinical_report_500_600(fill_nullables=False)
 
     def test_migrate_pedigree_300_110(self, fill_nullables=True):
         # tests reports 300 -> participants 103


### PR DESCRIPTION
[IP-1734 - Migrate clinical report rd to latest to migrate to v6](https://jira.extge.co.uk/browse/IP-1734)
===============

Summary of Changes:
==============
* `migration_helpers.migrate_clinical_report_rd_to_latest` migrates to v6 of clinical report RD
* Add tests

- [x] Tests passing locally:
```
----------------------------------------------------------------------
Ran 141 tests in 9.738s

OK
```