### PR TITLE
IP-1732 - Migrate IR to IG v6

### DIFF
--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -127,41 +127,48 @@ class MigrationHelpers(object):
         :type assembly: Assembly
         :rtype: InterpretedGenomeRD_5_0_0
         """
-        ir_v500 = None
+        ig_v600 = None
 
-        if PayloadValidation(klass=InterpretedGenomeRD_5_0_0, payload=json_dict).is_valid:
-            ir_v500 = InterpretedGenomeRD_5_0_0.fromJsonDict(jsonDict=json_dict)
+        if PayloadValidation(klass=InterpretedGenome_6_0_0, payload=json_dict).is_valid:
+            ig_v600 = InterpretedGenome_6_0_0.fromJsonDict(jsonDict=json_dict)
+
+        elif PayloadValidation(klass=InterpretedGenomeRD_5_0_0, payload=json_dict).is_valid:
             logging.info("Case in models reports 5.0.0")
+            ig_v500 = InterpretedGenomeRD_5_0_0.fromJsonDict(jsonDict=json_dict)
+            ig_v600 = MigrateReports500To600().migrate_interpreted_genome_rd(old_instance=ig_v500)
 
         elif PayloadValidation(klass=InterpretationRequestRD_4_0_0, payload=json_dict).is_valid:
+            logging.info("Case in models reports 4.0.0")
             ir_v400 = InterpretationRequestRD_4_0_0.fromJsonDict(jsonDict=json_dict)
-            ir_v500 = MigrateReports400To500().migrate_interpretation_request_rd_to_interpreted_genome_rd(
+            ig_v500 = MigrateReports400To500().migrate_interpretation_request_rd_to_interpreted_genome_rd(
                 old_instance=ir_v400, assembly=assembly, interpretation_service="tiering",
                 reference_database_versions={}, software_versions={}
             )
-            logging.info("Case in models reports 4.0.0")
+            ig_v600 = MigrateReports500To600().migrate_interpreted_genome_rd(old_instance=ig_v500)
 
         elif PayloadValidation(klass=InterpretationRequestRD_3_0_0, payload=json_dict).is_valid:
+            logging.info("Case in models reports 3.0.0")
             ir_v3 = InterpretationRequestRD_3_0_0.fromJsonDict(jsonDict=json_dict)
             ir_v400 = MigrateReports3To4().migrate_interpretation_request_rd(old_instance=ir_v3)
-            ir_v500 = MigrateReports400To500().migrate_interpretation_request_rd_to_interpreted_genome_rd(
+            ig_v500 = MigrateReports400To500().migrate_interpretation_request_rd_to_interpreted_genome_rd(
                 old_instance=ir_v400, assembly=assembly, interpretation_service="tiering",
                 reference_database_versions={}, software_versions={}
             )
-            logging.info("Case in models reports 3.0.0")
+            ig_v600 = MigrateReports500To600().migrate_interpreted_genome_rd(old_instance=ig_v500)
 
         elif PayloadValidation(klass=InterpretationRequestRD_2_1_0, payload=json_dict).is_valid:
+            logging.info("Case in models reports 2.1.0")
             ir_v2 = InterpretationRequestRD_2_1_0.fromJsonDict(jsonDict=json_dict)
             ir_v3 = Migration2_1To3().migrate_interpretation_request(interpretation_request=ir_v2)
             ir_v400 = MigrateReports3To4().migrate_interpretation_request_rd(old_instance=ir_v3)
-            ir_v500 = MigrateReports400To500().migrate_interpretation_request_rd_to_interpreted_genome_rd(
+            ig_v500 = MigrateReports400To500().migrate_interpretation_request_rd_to_interpreted_genome_rd(
                 old_instance=ir_v400, assembly=assembly, interpretation_service="tiering",
                 reference_database_versions={}, software_versions={}
             )
-            logging.info("Case in models reports 2.1.0")
+            ig_v600 = MigrateReports500To600().migrate_interpreted_genome_rd(old_instance=ig_v500)
 
-        if ir_v500 is not None:
-            return ir_v500
+        if ig_v600 is not None:
+            return ig_v600
 
         raise MigrationError("Interpretation Request RD is not in versions: [2.1.0, 3.0.0, 4.0.0, 5.0.0]")
 

--- a/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
@@ -192,3 +192,68 @@ class MigrateReports500To600(BaseMigration):
 
     def migrate_additional_analysis_panels(self, old_panels):
         return [self.migrate_additional_analysis_panel(old_panel=old_panel) for old_panel in old_panels]
+
+    def migrate_rd_exit_questionnaire(self, old_instance, assembly):
+        migrated_instance = self.convert_class(self.new_model.RareDiseaseExitQuestionnaire, old_instance)
+        migrated_instance.variantGroupLevelQuestions = self.migrate_variant_group_level_questions(
+            VGLQs=old_instance.variantGroupLevelQuestions, assembly=assembly
+        )
+        return self.validate_object(object_to_validate=migrated_instance, object_type=self.new_model.RareDiseaseExitQuestionnaire)
+
+    def migrate_variant_group_level_questions(self, VGLQs, assembly):
+        return [self.migrate_variant_group_level_question(VGLQ=VGLQ, assembly=assembly) for VGLQ in VGLQs]
+
+    def migrate_variant_group_level_question(self, VGLQ, assembly):
+        migrated_vglq = self.convert_class(target_klass=self.new_model.VariantGroupLevelQuestions, instance=VGLQ)
+        migrated_vglq.variantLevelQuestions = self.migrate_variant_level_questions(
+            VLQs=VGLQ.variantLevelQuestions, assembly=assembly
+        )
+
+        return self.validate_object(object_to_validate=migrated_vglq, object_type=self.new_model.VariantGroupLevelQuestions)
+
+    def migrate_variant_level_questions(self, VLQs, assembly):
+        return [self.migrate_variant_level_question(VLQ=VLQ, assembly=assembly) for VLQ in VLQs]
+
+    def migrate_variant_level_question(self, VLQ, assembly):
+        migrated_vlq = self.convert_class(target_klass=self.new_model.VariantLevelQuestions, instance=VLQ)
+
+        migrated_vlq.variantCoordinates = self.migrate_variant_coordinates(
+            variant_details=VLQ.variantDetails, assembly=assembly
+        )
+
+        return self.validate_object(object_to_validate=migrated_vlq, object_type=self.new_model.VariantLevelQuestions)
+
+    def migrate_variant_coordinates(self, variant_details, assembly):
+
+        details = self.extract_variant_details(variant_details=variant_details)
+        variant_coordinates = self.new_model.VariantCoordinates(
+            chromosome=details.get("chromosome"),
+            position=details.get("position"),
+            reference=details.get("reference"),
+            alternate=details.get("alternate"),
+            assembly=assembly,
+        )
+        return self.validate_object(object_to_validate=variant_coordinates, object_type=self.new_model.VariantCoordinates)
+
+    @staticmethod
+    def extract_variant_details(variant_details):
+        """
+        The format of variant_details is "chr:pos:ref:alt"
+        """
+        details = variant_details.split(":")
+        if len(details) != 4:
+            raise MigrationError("Variant details: {variant_details} should be in format chr:pos:ref:alt".format(
+                variant_details=variant_details
+            ))
+        try:
+            details[1] = int(details[1])
+        except ValueError:
+            raise MigrationError("Position {position} is not an integer !".format(
+                position=details[1]
+            ))
+        return {
+            "chromosome": details[0],
+            "position": details[1],
+            "reference": details[2],
+            "alternate": details[3],
+        }

--- a/protocols/tests/test_migration/base_test_migration.py
+++ b/protocols/tests/test_migration/base_test_migration.py
@@ -1,7 +1,12 @@
 from unittest import TestCase
+from random import randint
+from protocols.reports_3_0_0 import RareDiseaseExitQuestionnaire as RD_EQ_3
 
 
 class TestCaseMigration(TestCase):
+
+    bases = ["A", "C", "G", "T"]
+    chromosomes = range(1, 23) + ["X"] + ["Y"]
 
     def _check_non_empty_fields(self, instance, exclusions=[]):
         """
@@ -30,3 +35,18 @@ class TestCaseMigration(TestCase):
 
     def _validate(self, instance):
         self.assertTrue(instance.validate(instance.toJsonDict(), verbose=True))
+
+    def populate_exit_questionnaire_variant_details(self, eq):
+        for vglq in eq.variantGroupLevelQuestions:
+            for vlq in vglq.variantLevelQuestions:
+                variant_details = "{chr}:{pos}:{ref}:{alt}".format(
+                    chr=self.chromosomes[randint(0, len(self.chromosomes)-1)],
+                    pos=randint(1, 10000),
+                    ref=self.bases[randint(0, len(self.bases)-1)],
+                    alt=self.bases[randint(0, len(self.bases)-1)],
+                )
+                if isinstance(eq, RD_EQ_3):
+                    vlq.variant_details = variant_details
+                else:
+                    vlq.variantDetails = variant_details
+        return eq

--- a/protocols/tests/test_migration/test_migration_helpers.py
+++ b/protocols/tests/test_migration/test_migration_helpers.py
@@ -178,9 +178,9 @@ class TestMigrationHelpers(TestCaseMigration):
     def test_migrate_interpretation_request_rd_500_600_no_nullables(self):
         self.test_migrate_interpretation_request_rd_500_600(fill_nullables=False)
 
-    def test_migrate_interpretation_request_rd_to_interpreted_genome_400_500(self, fill_nullables=True):
+    def test_migrate_interpretation_request_rd_to_interpreted_genome_400_600(self, fill_nullables=True):
 
-        # tests IR 400 -> 500
+        # tests IR 400 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_4_0_0.InterpretationRequestRD, VERSION_400, fill_nullables=fill_nullables
         ).create()
@@ -191,14 +191,15 @@ class TestMigrationHelpers(TestCaseMigration):
         migrated_instance = MigrationHelpers.migrate_interpretation_request_rd_to_interpreted_genome_latest(
             old_instance.toJsonDict(), assembly='GRCh38'
         )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.InterpretedGenome)
         self._validate(migrated_instance)
 
-    def test_migrate_interpretation_request_rd_to_interpreted_genome_400_500_nulls(self):
-        self.test_migrate_interpretation_request_rd_to_interpreted_genome_400_500(fill_nullables=False)
+    def test_migrate_interpretation_request_rd_to_interpreted_genome_400_600_nulls(self):
+        self.test_migrate_interpretation_request_rd_to_interpreted_genome_400_600(fill_nullables=False)
 
-    def test_migrate_interpretation_request_rd_to_interpreted_genome_300_500(self, fill_nullables=True):
+    def test_migrate_interpretation_request_rd_to_interpreted_genome_300_600(self, fill_nullables=True):
 
-        # tests IR 300 -> 500
+        # tests IR 300 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_3_0_0.InterpretationRequestRD, VERSION_300, fill_nullables=fill_nullables
         ).create()
@@ -207,14 +208,15 @@ class TestMigrationHelpers(TestCaseMigration):
         migrated_instance = MigrationHelpers.migrate_interpretation_request_rd_to_interpreted_genome_latest(
             old_instance.toJsonDict(), assembly='GRCh38'
         )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.InterpretedGenome)
         self._validate(migrated_instance)
 
-    def test_migrate_interpretation_request_rd_to_interpreted_genome_300_500_null(self):
-        self.test_migrate_interpretation_request_rd_to_interpreted_genome_300_500(fill_nullables=False)
+    def test_migrate_interpretation_request_rd_to_interpreted_genome_300_600_null(self):
+        self.test_migrate_interpretation_request_rd_to_interpreted_genome_300_600(fill_nullables=False)
 
-    def test_migrate_interpretation_request_rd_to_interpreted_genome_210_500(self, fill_nullables=True):
+    def test_migrate_interpretation_request_rd_to_interpreted_genome_210_600(self, fill_nullables=True):
 
-        # tests IR 210 -> 500
+        # tests IR 210 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_2_1_0.InterpretationRequestRD, VERSION_210, fill_nullables=fill_nullables
         ).create()
@@ -223,14 +225,15 @@ class TestMigrationHelpers(TestCaseMigration):
         migrated_instance = MigrationHelpers.migrate_interpretation_request_rd_to_interpreted_genome_latest(
             old_instance.toJsonDict(), assembly='GRCh38'
         )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.InterpretedGenome)
         self._validate(migrated_instance)
 
-    def test_migrate_interpretation_request_rd_to_interpreted_genome_210_500_nulls(self):
-        self.test_migrate_interpretation_request_rd_to_interpreted_genome_210_500(fill_nullables=False)
+    def test_migrate_interpretation_request_rd_to_interpreted_genome_210_600_nulls(self):
+        self.test_migrate_interpretation_request_rd_to_interpreted_genome_210_600(fill_nullables=False)
 
-    def test_migrate_interpretation_request_rd_to_interpreted_genome_500_500(self, fill_nullables=True):
+    def test_migrate_interpretation_request_rd_to_interpreted_genome_500_600(self, fill_nullables=True):
 
-        # tests IG 500 -> 500
+        # tests IG 500 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_5_0_0.InterpretedGenomeRD, VERSION_61, fill_nullables=fill_nullables
         ).create()
@@ -239,10 +242,11 @@ class TestMigrationHelpers(TestCaseMigration):
         migrated_instance = MigrationHelpers.migrate_interpretation_request_rd_to_interpreted_genome_latest(
             old_instance.toJsonDict(), assembly='GRCh38'
         )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.InterpretedGenome)
         self._validate(migrated_instance)
 
-    def test_migrate_interpretation_request_rd_to_interpreted_genome_500_500_null(self):
-        self.test_migrate_interpretation_request_rd_to_interpreted_genome_500_500(fill_nullables=False)
+    def test_migrate_interpretation_request_rd_to_interpreted_genome_500_600_null(self):
+        self.test_migrate_interpretation_request_rd_to_interpreted_genome_500_600(fill_nullables=False)
 
     def test_migrate_interpreted_genome_rd_400_600(self, fill_nullables=True):
 

--- a/protocols/tests/test_migration/test_migration_helpers.py
+++ b/protocols/tests/test_migration/test_migration_helpers.py
@@ -698,53 +698,65 @@ class TestMigrationHelpers(TestCaseMigration):
     def test_migrate_clinical_report_cancer_500_500_nulls(self):
         self.test_migrate_clinical_report_cancer_500_500(fill_nullables=False)
 
-    def test_migrate_questionnaire_rd_300_500(self, fill_nullables=True):
+    def test_migrate_questionnaire_rd_300_600(self, fill_nullables=True):
 
-        # tests EQ 300 -> 500
+        # tests EQ 300 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_3_0_0.RareDiseaseExitQuestionnaire, VERSION_300, fill_nullables=fill_nullables
         ).create()
+        old_instance = self.populate_exit_questionnaire_variant_details(eq=old_instance)
         self._validate(old_instance)
         if fill_nullables:
             self._check_non_empty_fields(old_instance)
 
-        migrated_instance = MigrationHelpers.migrate_exit_questionnaire_rd_to_latest(old_instance.toJsonDict())
+        migrated_instance = MigrationHelpers.migrate_exit_questionnaire_rd_to_latest(
+            json_dict=old_instance.toJsonDict(), assembly="GRCh38"
+        )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.RareDiseaseExitQuestionnaire)
         self._validate(migrated_instance)
 
-    def test_migrate_questionnaire_rd_300_500_nulls(self):
-        self.test_migrate_questionnaire_rd_300_500(fill_nullables=False)
+    def test_migrate_questionnaire_rd_300_600_nulls(self):
+        self.test_migrate_questionnaire_rd_300_600(fill_nullables=False)
 
-    def test_migrate_questionnaire_rd_400_500(self, fill_nullables=True):
+    def test_migrate_questionnaire_rd_400_600(self, fill_nullables=True):
 
-        # tests EQ 300 -> 500
+        # tests EQ 400 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_4_0_0.RareDiseaseExitQuestionnaire, VERSION_400, fill_nullables=fill_nullables
         ).create()
+        old_instance = self.populate_exit_questionnaire_variant_details(eq=old_instance)
         self._validate(old_instance)
         if fill_nullables:
             self._check_non_empty_fields(old_instance)
 
-        migrated_instance = MigrationHelpers.migrate_exit_questionnaire_rd_to_latest(old_instance.toJsonDict())
+        migrated_instance = MigrationHelpers.migrate_exit_questionnaire_rd_to_latest(
+            json_dict=old_instance.toJsonDict(), assembly="GRCh38"
+        )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.RareDiseaseExitQuestionnaire)
         self._validate(migrated_instance)
 
-    def test_migrate_questionnaire_rd_400_500_nulls(self):
-        self.test_migrate_questionnaire_rd_400_500(fill_nullables=False)
+    def test_migrate_questionnaire_rd_400_600_nulls(self):
+        self.test_migrate_questionnaire_rd_400_600(fill_nullables=False)
 
-    def test_migrate_questionnaire_rd_500_500(self, fill_nullables=True):
+    def test_migrate_questionnaire_rd_500_600(self, fill_nullables=True):
 
-        # tests EQ 300 -> 500
+        # tests EQ 500 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_5_0_0.RareDiseaseExitQuestionnaire, VERSION_61, fill_nullables=fill_nullables
         ).create()
+        old_instance = self.populate_exit_questionnaire_variant_details(eq=old_instance)
         self._validate(old_instance)
         if fill_nullables:
             self._check_non_empty_fields(old_instance)
 
-        migrated_instance = MigrationHelpers.migrate_exit_questionnaire_rd_to_latest(old_instance.toJsonDict())
+        migrated_instance = MigrationHelpers.migrate_exit_questionnaire_rd_to_latest(
+            json_dict=old_instance.toJsonDict(), assembly="GRCh38"
+        )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.RareDiseaseExitQuestionnaire)
         self._validate(migrated_instance)
 
-    def test_migrate_questionnaire_rd_500_500_nulls(self):
-        self.test_migrate_questionnaire_rd_400_500(fill_nullables=False)
+    def test_migrate_questionnaire_rd_500_600_nulls(self):
+        self.test_migrate_questionnaire_rd_500_600(fill_nullables=False)
 
     def test_migrate_cancer_participant_100_110(self, fill_nullables=True):
 

--- a/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
@@ -1,6 +1,3 @@
-import factory.fuzzy
-from random import randint
-
 from protocols import reports_6_0_0
 from protocols import reports_5_0_0
 from protocols.util.dependency_manager import VERSION_61
@@ -218,3 +215,49 @@ class TestMigrateClinicalReport5To6(TestCaseMigration):
 
     def test_migrate_clinical_report_rd_no_nullables(self):
         self.test_migrate_clinical_report_rd(fill_nullables=False)
+
+
+class TestRareDiseaseExitQuestionnaire5To6(TestCaseMigration):
+
+    old_model = reports_5_0_0
+    new_model = reports_6_0_0
+
+    def test_migrate_rd_exit_questionnaire(self, fill_nullables=True):
+        old_rd_eq = GenericFactoryAvro.get_factory_avro(
+            self.old_model.RareDiseaseExitQuestionnaire, VERSION_61, fill_nullables=fill_nullables
+        ).create()
+        old_rd_eq = self.populate_exit_questionnaire_variant_details(eq=old_rd_eq)
+        new_rd_eq = MigrateReports500To600().migrate_rd_exit_questionnaire(
+            old_instance=old_rd_eq, assembly="GRCh38"
+        )
+        self._validate(new_rd_eq)
+        self.assertIsInstance(new_rd_eq, self.new_model.RareDiseaseExitQuestionnaire)
+
+        self.assertEqual(old_rd_eq.eventDate, new_rd_eq.eventDate)
+        self.assertEqual(old_rd_eq.reporter, new_rd_eq.reporter)
+
+        self.assertIsInstance(
+            new_rd_eq.familyLevelQuestions,
+            self.new_model.FamilyLevelQuestions
+        )
+        attributes = [
+            "caseSolvedFamily", "segregationQuestion", "additionalComments"
+        ]
+        for attribute in attributes:
+            self.assertEqual(
+                getattr(old_rd_eq.familyLevelQuestions, attribute),
+                getattr(new_rd_eq.familyLevelQuestions, attribute),
+            )
+
+        for VGLQ in new_rd_eq.variantGroupLevelQuestions:
+            self.assertIsInstance(
+                VGLQ,
+                self.new_model.VariantGroupLevelQuestions
+            )
+            for VLQ in VGLQ.variantLevelQuestions:
+                self.assertIsInstance(
+                    VLQ,
+                    self.new_model.VariantLevelQuestions
+                )
+
+


### PR DESCRIPTION
[IP-1732 - Migrate IR to IG v6](https://jira.extge.co.uk/browse/IP-1732)
=========================================

Summary of Changes
===============
* When migrating RD IRs earlier than v5 to IG, migrate to v6 og IG
* Add tests

- [x] Tests passing locally:
```
----------------------------------------------------------------------
Ran 142 tests in 8.912s

OK
```

- [x] Building locally:
```
INFO:root:Build/s finished succesfully!
Removing intermediate container 1cd793ea471b
 ---> 9679ed773f57
Successfully built 9679ed773f57
Successfully tagged gel:latest
root@52a8a61b184a:/gel# 
```