### PR TITLE
IP-1736 - Migrate cancer IR to v6

### DIFF
--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -520,27 +520,33 @@ class MigrationHelpers(object):
         :type sample_id: str
         :type assembly: Assembly
         :type participant_id: str
-        :rtype: ClinicalReportCancer_5_0_0
+        :rtype: ClinicalReport_6_0_0
         """
-        cr_v500 = None
+        cr_v600 = None
 
-        if PayloadValidation(klass=ClinicalReportCancer_5_0_0, payload=json_dict).is_valid:
-            cr_v500 = ClinicalReportCancer_5_0_0.fromJsonDict(jsonDict=json_dict)
+        if PayloadValidation(klass=ClinicalReport_6_0_0, payload=json_dict).is_valid:
+            logging.info("Cancer clinical report in models reports 6.0.0")
+            cr_v600 = ClinicalReport_6_0_0.fromJsonDict(jsonDict=json_dict)
+
+        elif PayloadValidation(klass=ClinicalReportCancer_5_0_0, payload=json_dict).is_valid:
             logging.info("Cancer clinical report in models reports 5.0.0")
+            cr_v500 = ClinicalReportCancer_5_0_0.fromJsonDict(jsonDict=json_dict)
+            cr_v600 = MigrateReports500To600().migrate_cancer_clinical_report(old_instance=cr_v500)
 
         elif PayloadValidation(klass=ClinicalReportCancer_4_0_0, payload=json_dict).is_valid:
+            logging.info("Cancer clinical report in models reports 4.0.0")
             if not sample_id or not assembly or not participant_id:
                 raise MigrationError("Missing required fields to migrate cancer clinical report from 4.0.0 to 5.0.0")
             cr_v4 = ClinicalReportCancer_4_0_0.fromJsonDict(jsonDict=json_dict)
             cr_v500 = MigrateReports400To500().migrate_cancer_clinical_report(
                 old_instance=cr_v4, assembly=assembly, participant_id=participant_id, sample_id=sample_id
             )
-            logging.info("Cancer clinical report in models reports 4.0.0")
+            cr_v600 = MigrateReports500To600().migrate_cancer_clinical_report(old_instance=cr_v500)
 
-        if cr_v500 is not None:
-            return cr_v500
+        if cr_v600 is not None:
+            return cr_v600
 
-        raise MigrationError("Cancer clinical report is not in versions: [4.0.0, 5.0.0]")
+        raise MigrationError("Cancer clinical report is not in versions: [4.0.0, 5.0.0, 6.0.0]")
 
     @staticmethod
     def migrate_cancer_participant_to_latest(json_dict):

--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -36,6 +36,7 @@ from protocols.reports_5_0_0 import CancerExitQuestionnaire as CancerExitQuestio
 from protocols.reports_6_0_0 import ClinicalReport as ClinicalReport_6_0_0
 from protocols.reports_6_0_0 import InterpretedGenome as InterpretedGenome_6_0_0
 from protocols.reports_6_0_0 import InterpretationRequestRD as InterpretationRequestRD_6_0_0
+from protocols.reports_6_0_0 import CancerInterpretationRequest as CancerInterpretationRequest_6_0_0
 from protocols.reports_6_0_0 import RareDiseaseExitQuestionnaire as RareDiseaseExitQuestionnaire_6_0_0
 
 from protocols.participant_1_1_0 import Pedigree as Pedigree_1_1_0
@@ -363,29 +364,33 @@ class MigrationHelpers(object):
         :type assembly: Assembly
         :rtype: CancerInterpretationRequest_5_0_0
         """
-        ir_v500 = None
+        ir_v600 = None
 
-        if PayloadValidation(klass=CancerInterpretationRequest_5_0_0, payload=json_dict).is_valid:
-            ir_v500 = CancerInterpretationRequest_5_0_0.fromJsonDict(jsonDict=json_dict)
+        if PayloadValidation(klass=CancerInterpretationRequest_6_0_0, payload=json_dict).is_valid:
+            logging.info("Cancer interpretation request in models reports 6.0.0")
+            ir_v600 = CancerInterpretationRequest_6_0_0.fromJsonDict(jsonDict=json_dict)
+
+        elif PayloadValidation(klass=CancerInterpretationRequest_5_0_0, payload=json_dict).is_valid:
             logging.info("Cancer interpretation request in models reports 5.0.0")
+            ir_v600 = CancerInterpretationRequest_6_0_0.fromJsonDict(jsonDict=json_dict)
 
         elif PayloadValidation(klass=CancerInterpretationRequest_4_0_0, payload=json_dict).is_valid:
-            ir_v400 = CancerInterpretationRequest_4_0_0.fromJsonDict(jsonDict=json_dict)
-            ir_v500 = MigrateReports400To500().migrate_cancer_interpretation_request(old_instance=ir_v400,
-                                                                                     assembly=assembly)
             logging.info("Cancer interpretation request in models reports 4.0.0")
+            ir_v400 = CancerInterpretationRequest_4_0_0.fromJsonDict(jsonDict=json_dict)
+            ir_v500 = MigrateReports400To500().migrate_cancer_interpretation_request(old_instance=ir_v400, assembly=assembly)
+            ir_v600 = CancerInterpretationRequest_6_0_0.fromJsonDict(jsonDict=ir_v500.toJsonDict())
 
         elif PayloadValidation(klass=CancerInterpretationRequest_3_0_0, payload=json_dict).is_valid:
+            logging.info("Cancer interpretation request in models reports 3.0.0")
             ir_v300 = CancerInterpretationRequest_3_0_0.fromJsonDict(jsonDict=json_dict)
             ir_v400 = MigrateReports3To4().migrate_cancer_interpretation_request(old_interpretation_request=ir_v300)
-            ir_v500 = MigrateReports400To500().migrate_cancer_interpretation_request(old_instance=ir_v400,
-                                                                                     assembly=assembly)
-            logging.info("Cancer interpretation request in models reports 3.0.0")
+            ir_v500 = MigrateReports400To500().migrate_cancer_interpretation_request(old_instance=ir_v400, assembly=assembly)
+            ir_v600 = CancerInterpretationRequest_6_0_0.fromJsonDict(jsonDict=ir_v500.toJsonDict())
 
-        if ir_v500 is not None:
-            return ir_v500
+        if ir_v600 is not None:
+            return ir_v600
 
-        raise MigrationError("Cancer interpretation request is not in versions: [3.0.0, 4.0.0, 5.0.0]")
+        raise MigrationError("Cancer interpretation request is not in versions: [3.0.0, 4.0.0, 5.0.0, 6.0.0]")
 
     @staticmethod
     def migrate_interpretation_request_cancer_to_interpreted_genome_latest(

--- a/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
@@ -266,6 +266,8 @@ class MigrateReports500To600(BaseMigration):
         return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.InterpretedGenome)
 
     def migrate_reported_variants_cancer(self, variants):
+        if variants is None:
+            return None
         return [self.migrate_reported_variant_cancer(variant=variant) for variant in variants]
 
     def migrate_reported_variant_cancer(self, variant):
@@ -301,3 +303,8 @@ class MigrateReports500To600(BaseMigration):
     def migrate_variant_call_cancer(self, call):
         new_call = self.convert_class(target_klass=self.new_model.VariantCall, instance=call)
         return self.validate_object(object_to_validate=new_call, object_type=self.new_model.VariantCall)
+
+    def migrate_cancer_clinical_report(self, old_instance):
+        new_ccr = self.convert_class(target_klass=self.new_model.ClinicalReport, instance=old_instance)
+        new_ccr.variants = self.migrate_reported_variants_cancer(variants=old_instance.variants)
+        return self.validate_object(object_to_validate=new_ccr, object_type=self.new_model.ClinicalReport)

--- a/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
@@ -257,3 +257,47 @@ class MigrateReports500To600(BaseMigration):
             "reference": details[2],
             "alternate": details[3],
         }
+
+    def migrate_cancer_interpreted_genome(self, old_instance):
+        new_instance = self.convert_class(target_klass=self.new_model.InterpretedGenome, instance=old_instance)
+        new_instance.versionControl = self.new_model.ReportVersionControl()
+        new_instance.variants = self.migrate_reported_variants_cancer(variants=old_instance.variants)
+
+        return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.InterpretedGenome)
+
+    def migrate_reported_variants_cancer(self, variants):
+        return [self.migrate_reported_variant_cancer(variant=variant) for variant in variants]
+
+    def migrate_reported_variant_cancer(self, variant):
+        new_variant = self.convert_class(target_klass=self.new_model.SmallVariant, instance=variant)
+
+        new_variant.variantCoordinates = self.migrate_variant_coordinates_cancer(coordinates=variant.variantCoordinates)
+        new_variant.variantCalls = self.migrate_variant_calls_cancer(variant_calls=variant.variantCalls)
+        new_variant.reportEvents = self.migrate_report_events_cancer(events=variant.reportEvents)
+        new_variant.variantAttributes = self.migrate_variant_attributes(old_variant=variant)
+
+        return self.validate_object(object_to_validate=new_variant, object_type=self.new_model.SmallVariant)
+
+    def migrate_report_events_cancer(self, events):
+        return [self.migrate_report_event_cancer(event=event) for event in events]
+
+    def migrate_report_event_cancer(self, event):
+        new_event = self.convert_class(target_klass=self.new_model.ReportEvent, instance=event)
+
+        new_event.modeOfInheritance = self.new_model.ModeOfInheritance.na
+        new_event.phenotypes = self.new_model.Phenotypes()
+
+        new_event.genomicEntities = self.migrate_genomic_entities(genomic_entities=event.genomicEntities)
+        new_event.variantClassification = self.migrate_variant_classification(classification=event.variantClassification)
+        return self.validate_object(object_to_validate=new_event, object_type=self.new_model.ReportEvent)
+
+    def migrate_variant_coordinates_cancer(self, coordinates):
+        new_coordinates = self.convert_class(target_klass=self.new_model.VariantCoordinates, instance=coordinates)
+        return self.validate_object(object_to_validate=new_coordinates, object_type=self.new_model.VariantCoordinates)
+
+    def migrate_variant_calls_cancer(self, variant_calls):
+        return [self.migrate_variant_call_cancer(call=call) for call in variant_calls]
+
+    def migrate_variant_call_cancer(self, call):
+        new_call = self.convert_class(target_klass=self.new_model.VariantCall, instance=call)
+        return self.validate_object(object_to_validate=new_call, object_type=self.new_model.VariantCall)

--- a/protocols/tests/test_migration/test_migration_helpers.py
+++ b/protocols/tests/test_migration/test_migration_helpers.py
@@ -461,9 +461,9 @@ class TestMigrationHelpers(TestCaseMigration):
     def test_migrate_pedigree_110_110_nulls(self):
         self.test_migrate_pedigree_110_110(fill_nullables=False)
 
-    def test_migrate_interpretation_request_cancer_400_500(self, fill_nullables=True):
+    def test_migrate_interpretation_request_cancer_400_600(self, fill_nullables=True):
 
-        # tests IR 400 -> 500
+        # tests CIR 400 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_4_0_0.CancerInterpretationRequest, VERSION_400, fill_nullables=fill_nullables
         ).create()
@@ -476,14 +476,15 @@ class TestMigrationHelpers(TestCaseMigration):
         migrated_instance = MigrationHelpers.migrate_interpretation_request_cancer_to_latest(
             old_instance.toJsonDict(), assembly='GRCh38'
         )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.CancerInterpretationRequest)
         self._validate(migrated_instance)
 
-    def test_migrate_interpretation_request_cancer_400_500_nulls(self):
-        self.test_migrate_interpretation_request_cancer_400_500(fill_nullables=False)
+    def test_migrate_interpretation_request_cancer_400_600_nulls(self):
+        self.test_migrate_interpretation_request_cancer_400_600(fill_nullables=False)
 
-    def test_migrate_interpretation_request_cancer_300_500(self, fill_nullables=True):
+    def test_migrate_interpretation_request_cancer_300_600(self, fill_nullables=True):
 
-        # tests IR 300 -> 500
+        # tests CIR 300 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_3_0_0.CancerInterpretationRequest, VERSION_300, fill_nullables=fill_nullables
         ).create()
@@ -496,14 +497,15 @@ class TestMigrationHelpers(TestCaseMigration):
         migrated_instance = MigrationHelpers.migrate_interpretation_request_cancer_to_latest(
             old_instance.toJsonDict(), assembly='GRCh38'
         )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.CancerInterpretationRequest)
         self._validate(migrated_instance)
 
-    def test_migrate_interpretation_request_cancer_300_500_nulls(self):
-        self.test_migrate_interpretation_request_cancer_300_500(fill_nullables=False)
+    def test_migrate_interpretation_request_cancer_300_600_nulls(self):
+        self.test_migrate_interpretation_request_cancer_300_600(fill_nullables=False)
 
-    def test_migrate_interpretation_request_cancer_500_500(self, fill_nullables=True):
+    def test_migrate_interpretation_request_cancer_500_600(self, fill_nullables=True):
 
-        # tests IG 500 -> 500
+        # tests CIR 500 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_5_0_0.CancerInterpretationRequest, VERSION_61, fill_nullables=fill_nullables
         ).create()
@@ -514,10 +516,11 @@ class TestMigrationHelpers(TestCaseMigration):
         migrated_instance = MigrationHelpers.migrate_interpretation_request_cancer_to_latest(
             old_instance.toJsonDict(), assembly='GRCh38'
         )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.CancerInterpretationRequest)
         self._validate(migrated_instance)
 
-    def test_migrate_interpretation_request_cancer_500_500_nulls(self):
-        self.test_migrate_interpretation_request_cancer_500_500(fill_nullables=False)
+    def test_migrate_interpretation_request_cancer_500_600_nulls(self):
+        self.test_migrate_interpretation_request_cancer_500_600(fill_nullables=False)
 
     def test_migrate_interpretation_request_cancer_to_interpreted_genome_400_500(self, fill_nullables=True):
 

--- a/protocols/tests/test_migration/test_migration_helpers.py
+++ b/protocols/tests/test_migration/test_migration_helpers.py
@@ -239,7 +239,7 @@ class TestMigrationHelpers(TestCaseMigration):
         ).create()
         self._validate(old_instance)
 
-        migrated_instance = MigrationHelpers.migrate_interpretation_request_rd_to_interpreted_genome_latest(
+        migrated_instance = MigrationHelpers().migrate_interpretation_request_rd_to_interpreted_genome_latest(
             old_instance.toJsonDict(), assembly='GRCh38'
         )
         self.assertIsInstance(migrated_instance, reports_6_0_0.InterpretedGenome)
@@ -603,7 +603,7 @@ class TestMigrationHelpers(TestCaseMigration):
         if fill_nullables:
             self._check_non_empty_fields(old_instance)
 
-        migrated_instance = MigrationHelpers.migrate_interpreted_genome_cancer_to_latest(
+        migrated_instance = MigrationHelpers().migrate_interpreted_genome_cancer_to_latest(
             old_instance.toJsonDict(), assembly='GRCh38', participant_id='123', sample_id='456',
             interpretation_request_version=5, interpretation_service='congenica')
         self._validate(migrated_instance)
@@ -622,7 +622,7 @@ class TestMigrationHelpers(TestCaseMigration):
             self._check_non_empty_fields(old_instance, exclusions=["md5Sum"])
 
         try:
-            MigrationHelpers.migrate_interpreted_genome_cancer_to_latest(
+            MigrationHelpers().migrate_interpreted_genome_cancer_to_latest(
                 old_instance.toJsonDict(), assembly='GRCh38', participant_id='123', sample_id='456',
                 interpretation_request_version=5, interpretation_service='congenica')
             self.assertTrue(False)
@@ -632,9 +632,9 @@ class TestMigrationHelpers(TestCaseMigration):
     def test_migrate_interpreted_genome_cancer_300_500_nulls(self):
         self.test_migrate_interpreted_genome_cancer_300_500(fill_nullables=False)
 
-    def test_migrate_interpreted_genome_cancer_500_500(self, fill_nullables=True):
+    def test_migrate_interpreted_genome_cancer_500_600(self, fill_nullables=True):
 
-        # tests IG 500 -> 500
+        # tests C IG 500 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_5_0_0.CancerInterpretedGenome, VERSION_61, fill_nullables=fill_nullables
         ).create()
@@ -642,13 +642,14 @@ class TestMigrationHelpers(TestCaseMigration):
         if fill_nullables:
             self._check_non_empty_fields(old_instance)
 
-        migrated_instance = MigrationHelpers.migrate_interpreted_genome_cancer_to_latest(
-            old_instance.toJsonDict(), assembly='GRCh38', participant_id='123', sample_id='456',
-            interpretation_request_version=5, interpretation_service='congenica')
+        migrated_instance = MigrationHelpers().migrate_interpreted_genome_cancer_to_latest(
+            old_instance.toJsonDict()
+        )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.InterpretedGenome)
         self._validate(migrated_instance)
 
-    def test_migrate_interpreted_genome_cancer_500_500_nulls(self):
-        self.test_migrate_interpreted_genome_cancer_500_500(fill_nullables=False)
+    def test_migrate_interpreted_genome_cancer_500_600_nulls(self):
+        self.test_migrate_interpreted_genome_cancer_500_600(fill_nullables=False)
 
     def test_migrate_clinical_report_cancer_400_500(self, fill_nullables=True):
 

--- a/protocols/tests/test_migration/test_migration_helpers.py
+++ b/protocols/tests/test_migration/test_migration_helpers.py
@@ -581,14 +581,12 @@ class TestMigrationHelpers(TestCaseMigration):
         if fill_nullables:
             self._check_non_empty_fields(old_instance)
 
-        try:
+        with self.assertRaises(MigrationError):
             MigrationHelpers.migrate_interpretation_request_cancer_to_interpreted_genome_latest(
                 old_instance.toJsonDict(), assembly='GRCh38', interpretation_service='testing',
                 reference_database_versions={'thisdb': 'thatversion'}, software_versions={'testing': '1.2'},
                 report_url='fake.url', comments=['blah', 'blah!', 'blah?'])
             self.assertTrue(False)
-        except MigrationError:
-            self.assertTrue(True)
 
     def test_migrate_interpretation_request_cancer_to_interpreted_genome_500_500_nulls(self):
         self.test_migrate_interpretation_request_cancer_to_interpreted_genome_500_500(fill_nullables=False)
@@ -621,13 +619,11 @@ class TestMigrationHelpers(TestCaseMigration):
         if fill_nullables:
             self._check_non_empty_fields(old_instance, exclusions=["md5Sum"])
 
-        try:
+        with self.assertRaises(MigrationError):
             MigrationHelpers().migrate_interpreted_genome_cancer_to_latest(
                 old_instance.toJsonDict(), assembly='GRCh38', participant_id='123', sample_id='456',
                 interpretation_request_version=5, interpretation_service='congenica')
             self.assertTrue(False)
-        except MigrationError:
-            self.assertTrue(True)
 
     def test_migrate_interpreted_genome_cancer_300_500_nulls(self):
         self.test_migrate_interpreted_genome_cancer_300_500(fill_nullables=False)
@@ -651,9 +647,9 @@ class TestMigrationHelpers(TestCaseMigration):
     def test_migrate_interpreted_genome_cancer_500_600_nulls(self):
         self.test_migrate_interpreted_genome_cancer_500_600(fill_nullables=False)
 
-    def test_migrate_clinical_report_cancer_400_500(self, fill_nullables=True):
+    def test_migrate_clinical_report_cancer_400_600(self, fill_nullables=True):
 
-        # tests IR 400 -> 500
+        # tests IR 400 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_4_0_0.ClinicalReportCancer, VERSION_400, fill_nullables=fill_nullables
         ).create()
@@ -663,15 +659,17 @@ class TestMigrationHelpers(TestCaseMigration):
             self._check_non_empty_fields(old_instance)
 
         migrated_instance = MigrationHelpers.migrate_clinical_report_cancer_to_latest(
-            old_instance.toJsonDict(), sample_id='123', assembly='GRCh38', participant_id='456')
+            old_instance.toJsonDict(), sample_id='123', assembly='GRCh38', participant_id='456'
+        )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.ClinicalReport)
         self._validate(migrated_instance)
 
-    def test_migrate_clinical_report_cancer_400_500_nulls(self):
-        self.test_migrate_clinical_report_cancer_400_500(fill_nullables=False)
+    def test_migrate_clinical_report_cancer_400_600_nulls(self):
+        self.test_migrate_clinical_report_cancer_400_600(fill_nullables=False)
 
-    def test_migrate_clinical_report_cancer_300_500(self, fill_nullables=True):
+    def test_migrate_clinical_report_cancer_300_600(self, fill_nullables=True):
 
-        # tests IR 300 -> 500
+        # tests IR 300 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_3_0_0.ClinicalReportCancer, VERSION_300, fill_nullables=fill_nullables
         ).create()
@@ -679,19 +677,17 @@ class TestMigrationHelpers(TestCaseMigration):
         if fill_nullables:
             self._check_non_empty_fields(old_instance, exclusions=["md5Sum"])
 
-        try:
+        with self.assertRaises(MigrationError):
             MigrationHelpers.migrate_clinical_report_cancer_to_latest(
-                old_instance.toJsonDict(), sample_id='123', assembly='GRCh38', participant_id='456')
-            self.assertTrue(False)
-        except MigrationError:
-            self.assertTrue(True)
+                json_dict=old_instance.toJsonDict(), sample_id='123', assembly='GRCh38', participant_id='456'
+            )
 
-    def test_migrate_clinical_report_cancer_300_500_nulls(self):
-        self.test_migrate_clinical_report_cancer_300_500(fill_nullables=False)
+    def test_migrate_clinical_report_cancer_300_600_nulls(self):
+        self.test_migrate_clinical_report_cancer_300_600(fill_nullables=False)
 
-    def test_migrate_clinical_report_cancer_500_500(self, fill_nullables=True):
+    def test_migrate_clinical_report_cancer_500_600(self, fill_nullables=True):
 
-        # tests IG 500 -> 500
+        # tests IG 500 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_5_0_0.ClinicalReportCancer, VERSION_61, fill_nullables=fill_nullables
         ).create()
@@ -700,11 +696,13 @@ class TestMigrationHelpers(TestCaseMigration):
             self._check_non_empty_fields(old_instance)
 
         migrated_instance = MigrationHelpers.migrate_clinical_report_cancer_to_latest(
-            old_instance.toJsonDict(), sample_id='123', assembly='GRCh38', participant_id='456')
+            json_dict=old_instance.toJsonDict(),
+        )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.ClinicalReport)
         self._validate(migrated_instance)
 
-    def test_migrate_clinical_report_cancer_500_500_nulls(self):
-        self.test_migrate_clinical_report_cancer_500_500(fill_nullables=False)
+    def test_migrate_clinical_report_cancer_500_600_nulls(self):
+        self.test_migrate_clinical_report_cancer_500_600(fill_nullables=False)
 
     def test_migrate_questionnaire_rd_300_600(self, fill_nullables=True):
 

--- a/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
@@ -305,3 +305,19 @@ class TestCancerInterpretedGenome5To6(TestCaseMigration):
         )
         self.assertIsInstance(new_re_c, self.new_model.ReportEvent)
         self._validate(new_re_c)
+
+
+class TestCancerClinicalReport5To6(TestCaseMigration):
+
+    old_model = reports_5_0_0
+    new_model = reports_6_0_0
+
+    def test_migrate_cancer_clinical_report(self, fill_nullables=True):
+        old_cr_c = GenericFactoryAvro.get_factory_avro(
+            self.old_model.ClinicalReportCancer, VERSION_61, fill_nullables=fill_nullables
+        ).create()
+        new_cr_c = MigrateReports500To600().migrate_cancer_clinical_report(
+            old_instance=old_cr_c,
+        )
+        self.assertIsInstance(new_cr_c, self.new_model.ClinicalReport)
+        self._validate(new_cr_c)

--- a/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
@@ -261,3 +261,47 @@ class TestRareDiseaseExitQuestionnaire5To6(TestCaseMigration):
                 )
 
 
+class TestCancerInterpretedGenome5To6(TestCaseMigration):
+
+    old_model = reports_5_0_0
+    new_model = reports_6_0_0
+
+    def test_migrate_cancer_interpreted_genome(self, fill_nullables=True):
+        old_c_ig = GenericFactoryAvro.get_factory_avro(
+            self.old_model.CancerInterpretedGenome, VERSION_61, fill_nullables=fill_nullables
+        ).create()
+        new_c_ig = MigrateReports500To600().migrate_cancer_interpreted_genome(
+            old_instance=old_c_ig,
+        )
+        self.assertIsInstance(new_c_ig, self.new_model.InterpretedGenome)
+        self._validate(new_c_ig)
+        attributes = [
+            "interpretationRequestId", "interpretationRequestVersion", "interpretationService", "reportUrl",
+            "referenceDatabasesVersions", "softwareVersions", "comments",
+        ]
+        for attribute in attributes:
+            if getattr(old_c_ig, attribute) is not None:
+                self.assertEqual(getattr(new_c_ig, attribute), getattr(old_c_ig, attribute))
+        self.assertEqual(new_c_ig.versionControl.gitVersionControl, "6.0.0")
+
+        old_variants = old_c_ig.variants
+        new_variants = new_c_ig.variants
+        for old, new in zip(old_variants, new_variants):
+            self.assertIsInstance(new, self.new_model.SmallVariant)
+            self.assertEqual(
+                new,
+                MigrateReports500To600().migrate_reported_variant_cancer(variant=old)
+            )
+
+    def test_migrate_cancer_interpreted_genome_no_nullables(self):
+        self.test_migrate_cancer_interpreted_genome(fill_nullables=False)
+
+    def test_migrate_report_event_cancer(self, fill_nullables=True):
+        old_re_c = GenericFactoryAvro.get_factory_avro(
+            self.old_model.ReportEventCancer, VERSION_61, fill_nullables=fill_nullables
+        ).create()
+        new_re_c = MigrateReports500To600().migrate_report_event_cancer(
+            event=old_re_c,
+        )
+        self.assertIsInstance(new_re_c, self.new_model.ReportEvent)
+        self._validate(new_re_c)


### PR DESCRIPTION
[IP-1736 - Migrate cancer IR to v6](https://jira.extge.co.uk/browse/IP-1736)
=================================

Summary of Changes
=================
* When migrating cancer IR to latest, migrate to v6, which is identical to v5
* Add tests to make sure cancer IR is migrated to v6

- [x] Tests passing locally:
```
----------------------------------------------------------------------
Ran 142 tests in 14.117s

OK
```
- [x] Building locally:
```
INFO:root:Build/s finished succesfully!
Removing intermediate container 142fa350ac33
 ---> 271efd0f459e
Successfully built 271efd0f459e
Successfully tagged gel:latest
root@fd9bd4270973:/gel# 
```