### PR TITLE
IP-1738 - Migrate cancer IG to v6

### DIFF
--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -428,43 +428,83 @@ class MigrationHelpers(object):
 
         raise MigrationError("Cancer interpretation request is not in versions: [3.0.0, 4.0.0]")
 
-    @staticmethod
-    def migrate_interpreted_genome_cancer_to_latest(json_dict, assembly=None, participant_id=None,
+    def migrate_interpreted_genome_cancer_to_latest(self, json_dict, assembly=None, participant_id=None,
                                                     sample_id=None, interpretation_request_version=None,
                                                     interpretation_service=None):
         """
-        Migration from reports 3.0.0 is not supported as we ave no data in that version
+        Migration from reports 3.0.0 is not supported as we have no data in that version
         :type json_dict: dict
         :type assembly: Assembly
         :type participant_id: str
         :type sample_id: str
         :type interpretation_request_version: str
         :type interpretation_service: str
-        :rtype: CancerInterpretedGenome_5_0_0
+        :rtype: CancerInterpretedGenome_6_0_0
         """
-        ig_v500 = None
+        ig_v600 = None
 
-        if PayloadValidation(klass=CancerInterpretedGenome_5_0_0, payload=json_dict).is_valid:
-            ig_v500 = CancerInterpretedGenome_5_0_0.fromJsonDict(jsonDict=json_dict)
+        if PayloadValidation(klass=InterpretedGenome_6_0_0, payload=json_dict).is_valid:
+            logging.info("Cancer interpreted genome in models reports 6.0.0")
+            ig_v600 = InterpretedGenome_6_0_0.fromJsonDict(jsonDict=json_dict)
+
+        elif PayloadValidation(klass=CancerInterpretedGenome_5_0_0, payload=json_dict).is_valid:
             logging.info("Cancer interpreted genome in models reports 5.0.0")
+            ig_v500 = CancerInterpretedGenome_5_0_0.fromJsonDict(jsonDict=json_dict)
+            ig_v600 = MigrateReports500To600().migrate_cancer_interpreted_genome(old_instance=ig_v500)
 
         elif PayloadValidation(klass=CancerInterpretedGenome_4_0_0, payload=json_dict).is_valid:
-            if not assembly or not participant_id or not sample_id or not interpretation_request_version \
-                    or not interpretation_service:
-                raise MigrationError(
-                    "Missing required fields to migrate a cancer interpreted genome from 4.0.0 to 5.0.0")
+            logging.info("Cancer interpreted genome in models reports 4.0.0")
+            self.check_required_parameters(
+                assembly=assembly, participant_id=participant_id, sample_id=sample_id,
+                interpretation_request_version=interpretation_request_version,
+                interpretation_service=interpretation_service
+            )
             ig_v400 = CancerInterpretedGenome_4_0_0.fromJsonDict(jsonDict=json_dict)
             ig_v500 = MigrateReports400To500().migrate_cancer_interpreted_genome(
                 old_instance=ig_v400, assembly=assembly, participant_id=participant_id, sample_id=sample_id,
                 interpretation_request_version=interpretation_request_version,
                 interpretation_service=interpretation_service
             )
-            logging.info("Cancer interpreted genome in models reports 4.0.0")
+            ig_v600 = MigrateReports500To600().migrate_cancer_interpreted_genome(old_instance=ig_v500)
 
-        if ig_v500 is not None:
-            return ig_v500
+        if ig_v600 is not None:
+            return ig_v600
 
-        raise MigrationError("Cancer interpreted genome is not in versions: [4.0.0, 5.0.0]")
+        raise MigrationError("Cancer interpreted genome is not in versions: [4.0.0, 5.0.0, 6.0.0]")
+
+    @staticmethod
+    def check_required_parameters(assembly=None, participant_id=None, sample_id=None,
+                                  interpretation_request_version=None, interpretation_service=None):
+        if not assembly:
+            raise MigrationError(
+                "Missing required field {} to migrate a cancer interpreted genome from 4.0.0 to 5.0.0".format(
+                    "assembly"
+                )
+            )
+        if not participant_id:
+            raise MigrationError(
+                "Missing required field {} to migrate a cancer interpreted genome from 4.0.0 to 5.0.0".format(
+                    "participant_id"
+                )
+            )
+        if not sample_id:
+            raise MigrationError(
+                "Missing required field {} to migrate a cancer interpreted genome from 4.0.0 to 5.0.0".format(
+                    "sample_id"
+                )
+            )
+        if not interpretation_request_version:
+            raise MigrationError(
+                "Missing required field {} to migrate a cancer interpreted genome from 4.0.0 to 5.0.0".format(
+                    "interpretation_request_version"
+                )
+            )
+        if not interpretation_service:
+            raise MigrationError(
+                "Missing required field {} to migrate a cancer interpreted genome from 4.0.0 to 5.0.0".format(
+                    "interpretation_service"
+                )
+            )
 
     @staticmethod
     def migrate_clinical_report_cancer_to_latest(json_dict, sample_id=None, assembly=None, participant_id=None):

--- a/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
@@ -269,3 +269,47 @@ class MigrateReports500To600(BaseMigration):
             "reference": details[2],
             "alternate": details[3],
         }
+
+    def migrate_cancer_interpreted_genome(self, old_instance):
+        new_instance = self.convert_class(target_klass=self.new_model.InterpretedGenome, instance=old_instance)
+        new_instance.versionControl = self.new_model.ReportVersionControl()
+        new_instance.variants = self.migrate_reported_variants_cancer(variants=old_instance.variants)
+
+        return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.InterpretedGenome)
+
+    def migrate_reported_variants_cancer(self, variants):
+        return [self.migrate_reported_variant_cancer(variant=variant) for variant in variants]
+
+    def migrate_reported_variant_cancer(self, variant):
+        new_variant = self.convert_class(target_klass=self.new_model.SmallVariant, instance=variant)
+
+        new_variant.variantCoordinates = self.migrate_variant_coordinates_cancer(coordinates=variant.variantCoordinates)
+        new_variant.variantCalls = self.migrate_variant_calls_cancer(variant_calls=variant.variantCalls)
+        new_variant.reportEvents = self.migrate_report_events_cancer(events=variant.reportEvents)
+        new_variant.variantAttributes = self.migrate_variant_attributes(old_variant=variant)
+
+        return self.validate_object(object_to_validate=new_variant, object_type=self.new_model.SmallVariant)
+
+    def migrate_report_events_cancer(self, events):
+        return [self.migrate_report_event_cancer(event=event) for event in events]
+
+    def migrate_report_event_cancer(self, event):
+        new_event = self.convert_class(target_klass=self.new_model.ReportEvent, instance=event)
+
+        new_event.modeOfInheritance = self.new_model.ReportedModeOfInheritance.na
+        new_event.phenotypes = self.new_model.Phenotypes()
+
+        new_event.genomicEntities = self.migrate_genomic_entities(genomic_entities=event.genomicEntities)
+        new_event.variantClassification = self.migrate_variant_classification(classification=event.variantClassification)
+        return self.validate_object(object_to_validate=new_event, object_type=self.new_model.ReportEvent)
+
+    def migrate_variant_coordinates_cancer(self, coordinates):
+        new_coordinates = self.convert_class(target_klass=self.new_model.VariantCoordinates, instance=coordinates)
+        return self.validate_object(object_to_validate=new_coordinates, object_type=self.new_model.VariantCoordinates)
+
+    def migrate_variant_calls_cancer(self, variant_calls):
+        return [self.migrate_variant_call_cancer(call=call) for call in variant_calls]
+
+    def migrate_variant_call_cancer(self, call):
+        new_call = self.convert_class(target_klass=self.new_model.VariantCall, instance=call)
+        return self.validate_object(object_to_validate=new_call, object_type=self.new_model.VariantCall)

--- a/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
@@ -296,7 +296,7 @@ class MigrateReports500To600(BaseMigration):
     def migrate_report_event_cancer(self, event):
         new_event = self.convert_class(target_klass=self.new_model.ReportEvent, instance=event)
 
-        new_event.modeOfInheritance = self.new_model.ReportedModeOfInheritance.na
+        new_event.modeOfInheritance = self.new_model.ModeOfInheritance.na
         new_event.phenotypes = self.new_model.Phenotypes()
 
         new_event.genomicEntities = self.migrate_genomic_entities(genomic_entities=event.genomicEntities)

--- a/protocols/tests/test_migration/test_migration_helpers.py
+++ b/protocols/tests/test_migration/test_migration_helpers.py
@@ -239,7 +239,7 @@ class TestMigrationHelpers(TestCaseMigration):
         ).create()
         self._validate(old_instance)
 
-        migrated_instance = MigrationHelpers.migrate_interpretation_request_rd_to_interpreted_genome_latest(
+        migrated_instance = MigrationHelpers().migrate_interpretation_request_rd_to_interpreted_genome_latest(
             old_instance.toJsonDict(), assembly='GRCh38'
         )
         self.assertIsInstance(migrated_instance, reports_6_0_0.InterpretedGenome)
@@ -603,7 +603,7 @@ class TestMigrationHelpers(TestCaseMigration):
         if fill_nullables:
             self._check_non_empty_fields(old_instance)
 
-        migrated_instance = MigrationHelpers.migrate_interpreted_genome_cancer_to_latest(
+        migrated_instance = MigrationHelpers().migrate_interpreted_genome_cancer_to_latest(
             old_instance.toJsonDict(), assembly='GRCh38', participant_id='123', sample_id='456',
             interpretation_request_version=5, interpretation_service='congenica')
         self._validate(migrated_instance)
@@ -622,7 +622,7 @@ class TestMigrationHelpers(TestCaseMigration):
             self._check_non_empty_fields(old_instance, exclusions=["md5Sum"])
 
         try:
-            MigrationHelpers.migrate_interpreted_genome_cancer_to_latest(
+            MigrationHelpers().migrate_interpreted_genome_cancer_to_latest(
                 old_instance.toJsonDict(), assembly='GRCh38', participant_id='123', sample_id='456',
                 interpretation_request_version=5, interpretation_service='congenica')
             self.assertTrue(False)
@@ -632,9 +632,9 @@ class TestMigrationHelpers(TestCaseMigration):
     def test_migrate_interpreted_genome_cancer_300_500_nulls(self):
         self.test_migrate_interpreted_genome_cancer_300_500(fill_nullables=False)
 
-    def test_migrate_interpreted_genome_cancer_500_500(self, fill_nullables=True):
+    def test_migrate_interpreted_genome_cancer_500_600(self, fill_nullables=True):
 
-        # tests IG 500 -> 500
+        # tests C IG 500 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_5_0_0.CancerInterpretedGenome, VERSION_61, fill_nullables=fill_nullables
         ).create()
@@ -642,13 +642,14 @@ class TestMigrationHelpers(TestCaseMigration):
         if fill_nullables:
             self._check_non_empty_fields(old_instance)
 
-        migrated_instance = MigrationHelpers.migrate_interpreted_genome_cancer_to_latest(
-            old_instance.toJsonDict(), assembly='GRCh38', participant_id='123', sample_id='456',
-            interpretation_request_version=5, interpretation_service='congenica')
+        migrated_instance = MigrationHelpers().migrate_interpreted_genome_cancer_to_latest(
+            old_instance.toJsonDict()
+        )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.InterpretedGenome)
         self._validate(migrated_instance)
 
-    def test_migrate_interpreted_genome_cancer_500_500_nulls(self):
-        self.test_migrate_interpreted_genome_cancer_500_500(fill_nullables=False)
+    def test_migrate_interpreted_genome_cancer_500_600_nulls(self):
+        self.test_migrate_interpreted_genome_cancer_500_600(fill_nullables=False)
 
     def test_migrate_clinical_report_cancer_400_500(self, fill_nullables=True):
 


### PR DESCRIPTION
[IP-1738 - Migrate cancer IG to v6](https://jira.extge.co.uk/browse/IP-1738)
==============

Summary of Changes:
* In `migration_helpers`, `migrate_interpreted_genome_cancer_to_latest` now migrates to a v6 IG.
* Add cancer IG migrations to `migration_reports_5_0_0_to_reports_6_0_0.py`
* Modify existing tests to ensure migrated IG is v6

- [x] Tests passing locally:
```
----------------------------------------------------------------------
Ran 145 tests in 9.279s

OK
```
- [x] Building locally:
```
INFO:root:Build/s finished succesfully!
Removing intermediate container 3113ae655143
 ---> ecefa0b3c8ef
Successfully built ecefa0b3c8ef
Successfully tagged gel:latest
root@f130dcd90ec0:/gel# 
```