### PR TITLE
IP-1739 - Migrate clinical report cancer to v6

### DIFF
--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -514,27 +514,33 @@ class MigrationHelpers(object):
         :type sample_id: str
         :type assembly: Assembly
         :type participant_id: str
-        :rtype: ClinicalReportCancer_5_0_0
+        :rtype: ClinicalReport_6_0_0
         """
-        cr_v500 = None
+        cr_v600 = None
 
-        if PayloadValidation(klass=ClinicalReportCancer_5_0_0, payload=json_dict).is_valid:
-            cr_v500 = ClinicalReportCancer_5_0_0.fromJsonDict(jsonDict=json_dict)
+        if PayloadValidation(klass=ClinicalReport_6_0_0, payload=json_dict).is_valid:
+            logging.info("Cancer clinical report in models reports 6.0.0")
+            cr_v600 = ClinicalReport_6_0_0.fromJsonDict(jsonDict=json_dict)
+
+        elif PayloadValidation(klass=ClinicalReportCancer_5_0_0, payload=json_dict).is_valid:
             logging.info("Cancer clinical report in models reports 5.0.0")
+            cr_v500 = ClinicalReportCancer_5_0_0.fromJsonDict(jsonDict=json_dict)
+            cr_v600 = MigrateReports500To600().migrate_cancer_clinical_report(old_instance=cr_v500)
 
         elif PayloadValidation(klass=ClinicalReportCancer_4_0_0, payload=json_dict).is_valid:
+            logging.info("Cancer clinical report in models reports 4.0.0")
             if not sample_id or not assembly or not participant_id:
                 raise MigrationError("Missing required fields to migrate cancer clinical report from 4.0.0 to 5.0.0")
             cr_v4 = ClinicalReportCancer_4_0_0.fromJsonDict(jsonDict=json_dict)
             cr_v500 = MigrateReports400To500().migrate_cancer_clinical_report(
                 old_instance=cr_v4, assembly=assembly, participant_id=participant_id, sample_id=sample_id
             )
-            logging.info("Cancer clinical report in models reports 4.0.0")
+            cr_v600 = MigrateReports500To600().migrate_cancer_clinical_report(old_instance=cr_v500)
 
-        if cr_v500 is not None:
-            return cr_v500
+        if cr_v600 is not None:
+            return cr_v600
 
-        raise MigrationError("Cancer clinical report is not in versions: [4.0.0, 5.0.0]")
+        raise MigrationError("Cancer clinical report is not in versions: [4.0.0, 5.0.0, 6.0.0]")
 
     @staticmethod
     def migrate_cancer_participant_to_latest(json_dict):

--- a/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
@@ -278,6 +278,8 @@ class MigrateReports500To600(BaseMigration):
         return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.InterpretedGenome)
 
     def migrate_reported_variants_cancer(self, variants):
+        if variants is None:
+            return None
         return [self.migrate_reported_variant_cancer(variant=variant) for variant in variants]
 
     def migrate_reported_variant_cancer(self, variant):
@@ -313,3 +315,8 @@ class MigrateReports500To600(BaseMigration):
     def migrate_variant_call_cancer(self, call):
         new_call = self.convert_class(target_klass=self.new_model.VariantCall, instance=call)
         return self.validate_object(object_to_validate=new_call, object_type=self.new_model.VariantCall)
+
+    def migrate_cancer_clinical_report(self, old_instance):
+        new_ccr = self.convert_class(target_klass=self.new_model.ClinicalReport, instance=old_instance)
+        new_ccr.variants = self.migrate_reported_variants_cancer(variants=old_instance.variants)
+        return self.validate_object(object_to_validate=new_ccr, object_type=self.new_model.ClinicalReport)

--- a/protocols/tests/test_migration/test_migration_helpers.py
+++ b/protocols/tests/test_migration/test_migration_helpers.py
@@ -581,14 +581,12 @@ class TestMigrationHelpers(TestCaseMigration):
         if fill_nullables:
             self._check_non_empty_fields(old_instance)
 
-        try:
+        with self.assertRaises(MigrationError):
             MigrationHelpers.migrate_interpretation_request_cancer_to_interpreted_genome_latest(
                 old_instance.toJsonDict(), assembly='GRCh38', interpretation_service='testing',
                 reference_database_versions={'thisdb': 'thatversion'}, software_versions={'testing': '1.2'},
                 report_url='fake.url', comments=['blah', 'blah!', 'blah?'])
             self.assertTrue(False)
-        except MigrationError:
-            self.assertTrue(True)
 
     def test_migrate_interpretation_request_cancer_to_interpreted_genome_500_500_nulls(self):
         self.test_migrate_interpretation_request_cancer_to_interpreted_genome_500_500(fill_nullables=False)
@@ -621,13 +619,11 @@ class TestMigrationHelpers(TestCaseMigration):
         if fill_nullables:
             self._check_non_empty_fields(old_instance, exclusions=["md5Sum"])
 
-        try:
+        with self.assertRaises(MigrationError):
             MigrationHelpers().migrate_interpreted_genome_cancer_to_latest(
                 old_instance.toJsonDict(), assembly='GRCh38', participant_id='123', sample_id='456',
                 interpretation_request_version=5, interpretation_service='congenica')
             self.assertTrue(False)
-        except MigrationError:
-            self.assertTrue(True)
 
     def test_migrate_interpreted_genome_cancer_300_500_nulls(self):
         self.test_migrate_interpreted_genome_cancer_300_500(fill_nullables=False)
@@ -651,9 +647,9 @@ class TestMigrationHelpers(TestCaseMigration):
     def test_migrate_interpreted_genome_cancer_500_600_nulls(self):
         self.test_migrate_interpreted_genome_cancer_500_600(fill_nullables=False)
 
-    def test_migrate_clinical_report_cancer_400_500(self, fill_nullables=True):
+    def test_migrate_clinical_report_cancer_400_600(self, fill_nullables=True):
 
-        # tests IR 400 -> 500
+        # tests IR 400 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_4_0_0.ClinicalReportCancer, VERSION_400, fill_nullables=fill_nullables
         ).create()
@@ -663,15 +659,17 @@ class TestMigrationHelpers(TestCaseMigration):
             self._check_non_empty_fields(old_instance)
 
         migrated_instance = MigrationHelpers.migrate_clinical_report_cancer_to_latest(
-            old_instance.toJsonDict(), sample_id='123', assembly='GRCh38', participant_id='456')
+            old_instance.toJsonDict(), sample_id='123', assembly='GRCh38', participant_id='456'
+        )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.ClinicalReport)
         self._validate(migrated_instance)
 
-    def test_migrate_clinical_report_cancer_400_500_nulls(self):
-        self.test_migrate_clinical_report_cancer_400_500(fill_nullables=False)
+    def test_migrate_clinical_report_cancer_400_600_nulls(self):
+        self.test_migrate_clinical_report_cancer_400_600(fill_nullables=False)
 
-    def test_migrate_clinical_report_cancer_300_500(self, fill_nullables=True):
+    def test_migrate_clinical_report_cancer_300_600(self, fill_nullables=True):
 
-        # tests IR 300 -> 500
+        # tests IR 300 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_3_0_0.ClinicalReportCancer, VERSION_300, fill_nullables=fill_nullables
         ).create()
@@ -679,19 +677,17 @@ class TestMigrationHelpers(TestCaseMigration):
         if fill_nullables:
             self._check_non_empty_fields(old_instance, exclusions=["md5Sum"])
 
-        try:
+        with self.assertRaises(MigrationError):
             MigrationHelpers.migrate_clinical_report_cancer_to_latest(
-                old_instance.toJsonDict(), sample_id='123', assembly='GRCh38', participant_id='456')
-            self.assertTrue(False)
-        except MigrationError:
-            self.assertTrue(True)
+                json_dict=old_instance.toJsonDict(), sample_id='123', assembly='GRCh38', participant_id='456'
+            )
 
-    def test_migrate_clinical_report_cancer_300_500_nulls(self):
-        self.test_migrate_clinical_report_cancer_300_500(fill_nullables=False)
+    def test_migrate_clinical_report_cancer_300_600_nulls(self):
+        self.test_migrate_clinical_report_cancer_300_600(fill_nullables=False)
 
-    def test_migrate_clinical_report_cancer_500_500(self, fill_nullables=True):
+    def test_migrate_clinical_report_cancer_500_600(self, fill_nullables=True):
 
-        # tests IG 500 -> 500
+        # tests IG 500 -> 600
         old_instance = GenericFactoryAvro.get_factory_avro(
             reports_5_0_0.ClinicalReportCancer, VERSION_61, fill_nullables=fill_nullables
         ).create()
@@ -700,11 +696,13 @@ class TestMigrationHelpers(TestCaseMigration):
             self._check_non_empty_fields(old_instance)
 
         migrated_instance = MigrationHelpers.migrate_clinical_report_cancer_to_latest(
-            old_instance.toJsonDict(), sample_id='123', assembly='GRCh38', participant_id='456')
+            json_dict=old_instance.toJsonDict(),
+        )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.ClinicalReport)
         self._validate(migrated_instance)
 
-    def test_migrate_clinical_report_cancer_500_500_nulls(self):
-        self.test_migrate_clinical_report_cancer_500_500(fill_nullables=False)
+    def test_migrate_clinical_report_cancer_500_600_nulls(self):
+        self.test_migrate_clinical_report_cancer_500_600(fill_nullables=False)
 
     def test_migrate_questionnaire_rd_300_600(self, fill_nullables=True):
 

--- a/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
@@ -301,3 +301,19 @@ class TestCancerInterpretedGenome5To6(TestCaseMigration):
         )
         self.assertIsInstance(new_re_c, self.new_model.ReportEvent)
         self._validate(new_re_c)
+
+
+class TestCancerClinicalReport5To6(TestCaseMigration):
+
+    old_model = reports_5_0_0
+    new_model = reports_6_0_0
+
+    def test_migrate_cancer_clinical_report(self, fill_nullables=True):
+        old_cr_c = GenericFactoryAvro.get_factory_avro(
+            self.old_model.ClinicalReportCancer, VERSION_61, fill_nullables=fill_nullables
+        ).create()
+        new_cr_c = MigrateReports500To600().migrate_cancer_clinical_report(
+            old_instance=old_cr_c,
+        )
+        self.assertIsInstance(new_cr_c, self.new_model.ClinicalReport)
+        self._validate(new_cr_c)


### PR DESCRIPTION
[IP-1739 - Migrate clinical report cancer to v6](https://jira.extge.co.uk/browse/IP-1739)
===================================

Summary of Changes
=================
* `migrate_clinical_report_cancer_to_latest` in `migration_helpers` now migrates to v6
* Add tests

- [x] Tests passing locally:
```
----------------------------------------------------------------------
Ran 146 tests in 18.091s

OK
```
- [x] Building locally:
```
INFO:root:Build/s finished succesfully!
Removing intermediate container 61a26b457c2f
 ---> 4fc84c4a9d4a
Successfully built 4fc84c4a9d4a
Successfully tagged gel:latest
root@b44ccee7cae1:/gel# 
```