### PR TITLE
IP-1765 - Migrate Cancer EQ to v6

### DIFF
--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -7,7 +7,6 @@ from protocols.reports_2_1_0 import InterpretedGenomeRD as InterpretedGenomeRD_2
 from protocols.reports_2_1_0 import ClinicalReportCancer as ClinicalReportCancer_2_1_0
 from protocols.reports_2_1_0 import InterpretationRequestRD as InterpretationRequestRD_2_1_0
 
-
 from protocols.reports_3_0_0 import ClinicalReportRD as ClinicalReportRD_3_0_0
 from protocols.reports_3_0_0 import InterpretedGenomeRD as InterpretedGenomeRD_3_0_0
 from protocols.reports_3_0_0 import ClinicalReportCancer as ClinicalReportCancer_3_0_0
@@ -27,11 +26,18 @@ from protocols.reports_5_0_0 import Assembly as Assembly_5_0_0
 from protocols.reports_5_0_0 import ClinicalReportRD as ClinicalReportRD_5_0_0
 from protocols.reports_5_0_0 import InterpretedGenomeRD as InterpretedGenomeRD_5_0_0
 from protocols.reports_5_0_0 import ClinicalReportCancer as ClinicalReportCancer_5_0_0
-from protocols.reports_5_0_0 import InterpretationRequestRD as InterpretationRequestRD_5_0_0
+from protocols.reports_5_0_0 import CancerExitQuestionnaire as CancerExitQuestionnaire_5_0_0
 from protocols.reports_5_0_0 import CancerInterpretedGenome as CancerInterpretedGenome_5_0_0
+from protocols.reports_5_0_0 import InterpretationRequestRD as InterpretationRequestRD_5_0_0
 from protocols.reports_5_0_0 import CancerInterpretationRequest as CancerInterpretationRequest_5_0_0
 from protocols.reports_5_0_0 import RareDiseaseExitQuestionnaire as RareDiseaseExitQuestionnaire_5_0_0
-from protocols.reports_5_0_0 import CancerExitQuestionnaire as CancerExitQuestionnaire_5_0_0
+
+from protocols.reports_6_0_0 import ClinicalReport as ClinicalReport_6_0_0
+from protocols.reports_6_0_0 import InterpretedGenome as InterpretedGenome_6_0_0
+from protocols.reports_6_0_0 import CancerExitQuestionnaire as CancerExitQuestionnaire_6_0_0
+from protocols.reports_6_0_0 import InterpretationRequestRD as InterpretationRequestRD_6_0_0
+from protocols.reports_6_0_0 import CancerInterpretationRequest as CancerInterpretationRequest_6_0_0
+from protocols.reports_6_0_0 import RareDiseaseExitQuestionnaire as RareDiseaseExitQuestionnaire_6_0_0
 
 from protocols.reports_6_0_0 import ClinicalReport as ClinicalReport_6_0_0
 from protocols.reports_6_0_0 import InterpretedGenome as InterpretedGenome_6_0_0
@@ -316,6 +322,30 @@ class MigrationHelpers(object):
 
         raise MigrationError("exit Questionnaire RD is not in versions: [3.0.0, 4.0.0, 5.0.0, 6.0.0]")
 
+
+    @staticmethod
+    def migrate_cancer_exit_questionnaire_to_latest(json_dict, assembly):
+        """
+        No data exists for Cancer Exit Questionnaires in v4.2.0 of the models
+        :type json_dict: dict
+        :rtype: CancerExitQuestionnaire_6_0_0
+        """
+        if assembly is None:
+            raise MigrationError("Parameter <assembly> is required to migrate cancer exit questionnaire to version 6")
+        ceq_v600 = None
+
+        if PayloadValidation(klass=CancerExitQuestionnaire_6_0_0, payload=json_dict).is_valid:
+            ceq_v600 = CancerExitQuestionnaire_6_0_0.fromJsonDict(jsonDict=json_dict)
+
+        elif PayloadValidation(klass=CancerExitQuestionnaire_5_0_0, payload=json_dict).is_valid:
+            logging.info("Exit questionnaire in models reports 5.0.0 or 4.0.0")
+            ceq_v500 = CancerExitQuestionnaire_5_0_0.fromJsonDict(jsonDict=json_dict)
+            ceq_v600 = MigrateReports500To600().migrate_cancer_exit_questionnaire(old_instance=ceq_v500, assembly=assembly)
+
+        if ceq_v600 is not None:
+            return ceq_v600
+
+        raise MigrationError("Cancer Exit Questionnaire is not in versions: [5.0.0, 6.0.0]")
     @staticmethod
     def migrate_pedigree_to_latest(json_dict):
         """

--- a/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py
@@ -320,3 +320,53 @@ class MigrateReports500To600(BaseMigration):
         new_ccr = self.convert_class(target_klass=self.new_model.ClinicalReport, instance=old_instance)
         new_ccr.variants = self.migrate_reported_variants_cancer(variants=old_instance.variants)
         return self.validate_object(object_to_validate=new_ccr, object_type=self.new_model.ClinicalReport)
+
+    def migrate_cancer_exit_questionnaire(self, old_instance, assembly):
+        new_c_eq = self.convert_class(target_klass=self.new_model.CancerExitQuestionnaire, instance=old_instance)
+        new_c_eq.somaticVariantLevelQuestions = self.migrate_somatic_variant_level_questions(
+            old_questions=old_instance.somaticVariantLevelQuestions, assembly=assembly
+        )
+        new_c_eq.germlineVariantLevelQuestions = self.migrate_germline_variant_level_questions(
+            old_questions=old_instance.germlineVariantLevelQuestions, assembly=assembly
+        )
+        new_c_eq.otherActionableVariants = self.migrate_other_actionable_variants(
+            old_variants=old_instance.otherActionableVariants, assembly=assembly
+        )
+        return self.validate_object(object_to_validate=new_c_eq, object_type=self.new_model.CancerExitQuestionnaire)
+
+    def migrate_other_actionable_variants(self, old_variants, assembly):
+        if old_variants is None:
+            return None
+        return [self.migrate_other_actionable_variant(old_variant=old_variant, assembly=assembly) for old_variant in old_variants]
+
+    def migrate_somatic_variant_level_questions(self, old_questions, assembly):
+        if old_questions is None:
+            return None
+        return [self.migrate_somatic_variant_level_question(question=question, assembly=assembly) for question in old_questions]
+
+    def migrate_germline_variant_level_questions(self, old_questions, assembly):
+        if old_questions is None:
+            return None
+        return [self.migrate_germline_variant_level_question(question=question, assembly=assembly) for question in old_questions]
+
+    def migrate_somatic_variant_level_question(self, question, assembly):
+        new_question = self.convert_class(target_klass=self.new_model.CancerSomaticVariantLevelQuestions, instance=question)
+        new_question.variantCoordinates = self.migrate_variant_coordinates(
+            variant_details=question.variantDetails, assembly=assembly
+        )
+        return self.validate_object(object_to_validate=new_question, object_type=self.new_model.CancerSomaticVariantLevelQuestions)
+
+    def migrate_germline_variant_level_question(self, question, assembly):
+        new_question = self.convert_class(target_klass=self.new_model.CancerGermlineVariantLevelQuestions, instance=question)
+        new_question.variantCoordinates = self.migrate_variant_coordinates(
+            variant_details=question.variantDetails, assembly=assembly
+        )
+        return self.validate_object(object_to_validate=new_question, object_type=self.new_model.CancerGermlineVariantLevelQuestions)
+
+    def migrate_other_actionable_variant(self, old_variant, assembly):
+        new_question = self.convert_class(target_klass=self.new_model.AdditionalVariantsQuestions, instance=old_variant)
+        new_question.variantCoordinates = self.migrate_variant_coordinates(
+            variant_details=old_variant.variantDetails, assembly=assembly
+        )
+        return self.validate_object(object_to_validate=new_question, object_type=self.new_model.AdditionalVariantsQuestions)
+

--- a/protocols/tests/test_migration/base_test_migration.py
+++ b/protocols/tests/test_migration/base_test_migration.py
@@ -50,3 +50,29 @@ class TestCaseMigration(TestCase):
                 else:
                     vlq.variantDetails = variant_details
         return eq
+
+    def populate_c_eq_variant_level_questions_variant_details(self, old_c_eq):
+        a = old_c_eq.somaticVariantLevelQuestions is not None
+        b = old_c_eq.germlineVariantLevelQuestions is not None
+        c = old_c_eq.otherActionableVariants is not None
+        if a and b and c:
+            combined = zip(
+                old_c_eq.somaticVariantLevelQuestions,
+                old_c_eq.germlineVariantLevelQuestions,
+                old_c_eq.otherActionableVariants,
+            )
+            for somatic, germline, actionable in combined:
+                somatic = self.populate_variant_level_questions_variant_details(q=somatic)
+                germline = self.populate_variant_level_questions_variant_details(q=germline)
+                actionable = self.populate_variant_level_questions_variant_details(q=actionable)
+        return old_c_eq
+
+    def populate_variant_level_questions_variant_details(self, q):
+        variant_details = "{chr}:{pos}:{ref}:{alt}".format(
+            chr=self.chromosomes[randint(0, len(self.chromosomes) - 1)],
+            pos=randint(1, 10000),
+            ref=self.bases[randint(0, len(self.bases) - 1)],
+            alt=self.bases[randint(0, len(self.bases) - 1)],
+        )
+        q.variantDetails = variant_details
+        return q

--- a/protocols/tests/test_migration/test_migration_helpers.py
+++ b/protocols/tests/test_migration/test_migration_helpers.py
@@ -809,3 +809,21 @@ class TestMigrationHelpers(TestCaseMigration):
 
     def test_migrate_cancer_participant_110_110_nulls(self):
         self.test_migrate_cancer_participant_110_110(fill_nullables=False)
+
+    def test_migrate_cancer_exit_questionnaire_to_latest(self, fill_nullables=True):
+        # tests pedigree C EQ 5 -> C EQ 6
+        old_instance = GenericFactoryAvro.get_factory_avro(
+            reports_5_0_0.CancerExitQuestionnaire, VERSION_61, fill_nullables=fill_nullables
+        ).create()
+        old_instance = self.populate_c_eq_variant_level_questions_variant_details(old_c_eq=old_instance)
+        self._validate(old_instance)
+        if fill_nullables:
+            self._check_non_empty_fields(old_instance)
+        migrated_instance = MigrationHelpers.migrate_cancer_exit_questionnaire_to_latest(
+            json_dict=old_instance.toJsonDict(), assembly="GRCh38"
+        )
+        self.assertIsInstance(migrated_instance, reports_6_0_0.CancerExitQuestionnaire)
+        self._validate(migrated_instance)
+
+    def test_migrate_cancer_exit_questionnaire_to_latest_no_nullables(self):
+        self.test_migrate_cancer_exit_questionnaire_to_latest(fill_nullables=False)

--- a/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
@@ -317,3 +317,48 @@ class TestCancerClinicalReport5To6(TestCaseMigration):
         )
         self.assertIsInstance(new_cr_c, self.new_model.ClinicalReport)
         self._validate(new_cr_c)
+
+    def test_migrate_cancer_clinical_report_no_nullables(self):
+        self.test_migrate_cancer_clinical_report(fill_nullables=True)
+
+
+class TestCancerExitQuestionnaire5To6(TestCaseMigration):
+
+    old_model = reports_5_0_0
+    new_model = reports_6_0_0
+
+    def test_migrate_cancer_exit_questionnaire(self, fill_nullables=True):
+        old_c_eq = GenericFactoryAvro.get_factory_avro(
+            self.old_model.CancerExitQuestionnaire, VERSION_61, fill_nullables=fill_nullables
+        ).create()
+        old_c_eq = self.populate_c_eq_variant_level_questions_variant_details(old_c_eq=old_c_eq)
+        new_c_eq = MigrateReports500To600().migrate_cancer_exit_questionnaire(
+            old_instance=old_c_eq, assembly="GRCh38",
+        )
+        self.assertIsInstance(new_c_eq, self.new_model.CancerExitQuestionnaire)
+        self._validate(new_c_eq)
+
+    def test_migrate_cancer_exit_questionnaire_no_nullables(self):
+        self.test_migrate_cancer_exit_questionnaire(fill_nullables=False)
+
+    def test_migrate_somatic_variant_level_questions(self, fill_nullables=True):
+        old_q = GenericFactoryAvro.get_factory_avro(
+            self.old_model.CancerSomaticVariantLevelQuestions, VERSION_61, fill_nullables=fill_nullables
+        ).create()
+        old_q = self.populate_variant_level_questions_variant_details(q=old_q)
+        new_q = MigrateReports500To600().migrate_somatic_variant_level_question(
+            question=old_q, assembly="GRCh38"
+        )
+        self.assertIsInstance(new_q, self.new_model.CancerSomaticVariantLevelQuestions)
+        self._validate(new_q)
+
+    def test_migrate_germline_variant_level_questions(self, fill_nullables=True):
+        old_q = GenericFactoryAvro.get_factory_avro(
+            self.old_model.CancerGermlineVariantLevelQuestions, VERSION_61, fill_nullables=fill_nullables
+        ).create()
+        old_q = self.populate_variant_level_questions_variant_details(q=old_q)
+        new_q = MigrateReports500To600().migrate_germline_variant_level_question(
+            question=old_q, assembly="GRCh38"
+        )
+        self.assertIsInstance(new_q, self.new_model.CancerGermlineVariantLevelQuestions)
+        self._validate(new_q)


### PR DESCRIPTION
[IP-1765 - Migrate Cancer EQ to v6](https://jira.extge.co.uk/browse/IP-1765)
============================

Summary of Changes:
===============
* Add `migrate_cancer_exit_questionnaire_to_latest` to `migration_helpers.py` which migrates cancer exit questionnaires to v6 of the models. 
*  Add migrations in `migration_reports_5_0_0_to_reports_6_0_0.py`.
* Add tests in `test_migration_helpers.py` and `test_migration_reports_5_0_0_to_reports_6_0_0.py`.

- [x] Tests passing locally:
```
----------------------------------------------------------------------
Ran 153 tests in 13.757s

OK
```
- [x] Building locally:
```
INFO:root:Build/s finished succesfully!
Removing intermediate container b4d388f572ae
 ---> 58f13836d673
Successfully built 58f13836d673
Successfully tagged gel:latest
root@fc792d566f84:/gel# 
```