### PR TITLE
FIX - Failing test

### DIFF
--- a/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py
@@ -130,7 +130,7 @@ class TestMigrateInterpretedGenome5To6(TestCaseMigration):
         new_events = new_small_variant.reportEvents
         for old, new in zip(old_events, new_events):
             self.assertIsInstance(new, self.new_model.ReportEvent)
-            self.assertEqual(new, MigrateReports500To600().migrate_report_event(report_event=old))
+            self.assertEqual(new.toJsonDict(), MigrateReports500To600().migrate_report_event(report_event=old).toJsonDict())
 
         self.assertIsInstance(new_small_variant.variantAttributes, self.new_model.VariantAttributes)
         self.assertEqual(

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ reqs = [
     "dictdiffer"
 ]
 
-VERSION = "7.1.2"
+VERSION = "7.1.3"
 setup(
     name='GelReportModels',
     version=VERSION,


### PR DESCRIPTION
[FIX - Failing test](https://jira.extge.co.uk/browse/IP-1860)
==========

Summary of Changes
==================

* One test on master and develop is failing:
```
======================================================================
FAIL: test_migrate_reported_variant (protocols.tests.test_migration.test_migration_reports_5_0_0_to_reports_6_0_0.TestMigrateInterpretedGenome5To6)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/gel/GelReportModels/protocols/tests/test_migration/test_migration_reports_5_0_0_to_reports_6_0_0.py", line 133, in test_migrate_reported_variant
    self.assertEqual(new, MigrateReports500To600().migrate_report_event(report_event=old))
AssertionError: <protocols.reports_6_0_0.ReportEvent object at 0x7fc8187ba138> != <protocols.reports_6_0_0.ReportEvent object at 0x7fc819098b30>

----------------------------------------------------------------------
Ran 161 tests in 10.404s

FAILED (failures=1)
root@7f1015c40f55:/gel/GelReportModels# 
```
because it's comparing two different objects, not their json representation

- [x] Building and tests passing:
```
INFO:root:Build/s finished succesfully!
Removing intermediate container 842d1e2a6023
 ---> 32980537ff7f
Successfully built 32980537ff7f
Successfully tagged gel:latest
root@c2ec3af98ee8:/gel# cd GelReportModels/ && python -m unittest discover
[...]
----------------------------------------------------------------------
Ran 161 tests in 10.631s

OK
root@c2ec3af98ee8:/gel/GelReportModels# 
```