### PR TITLE
Ip 2021/eq cancer migration 6 to 5

### DIFF
--- a/protocols/migration/base_migration.py
+++ b/protocols/migration/base_migration.py
@@ -57,3 +57,7 @@ class BaseMigration(object):
             else:
                 logging.warning(message)
                 return None
+
+    @staticmethod
+    def migrate_list_of_things(things, migrate_function, default=None, **kwargs):
+        return default if things is None else [migrate_function(thing, **kwargs) for thing in things]

--- a/protocols/migration/migration_reports_4_0_0_to_reports_5_0_0.py
+++ b/protocols/migration/migration_reports_4_0_0_to_reports_5_0_0.py
@@ -809,7 +809,8 @@ class MigrateReports400To500(BaseMigration):
         if isinstance(other_files, dict):
             return {key: self.convert_class(target_klass=self.new_model.File, instance=other_file) for key, other_file in other_files.items()}
 
-    def migrate_allele_frequencies(self, additionalNumericVariantAnnotations):
+    @staticmethod
+    def migrate_allele_frequencies(additionalNumericVariantAnnotations):
         """
         NOTE: This is assuming all values in `additionalNumericVariantAnnotations` are frequencies
 

--- a/protocols/migration/migration_reports_6_0_0_to_reports_5_0_0.py
+++ b/protocols/migration/migration_reports_6_0_0_to_reports_5_0_0.py
@@ -315,3 +315,41 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         new_instance = self.convert_class(target_klass=self.new_model.ClinicalReportCancer, instance=old_instance)
         new_instance.variants = self.migrate_small_variants_to_reported_variants(small_variants=old_instance.variants)
         return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.ClinicalReportCancer)
+
+    def migrate_cancer_exit_questionnaire(self, old_instance):
+        new_object_type = self.new_model.CancerExitQuestionnaire
+        new_instance = self.convert_class(target_klass=new_object_type, instance=old_instance)
+
+        new_instance.somaticVariantLevelQuestions = self.migrate_cancer_somatic_variant_level_questions(
+            old_questions=old_instance.somaticVariantLevelQuestions
+        )
+
+        # TODO: Implement this
+        new_instance.germlineVariantLevelQuestions = self.migrate_cancer_somatic_variant_level_questions(
+            old_questions=old_instance.somaticVariantLevelQuestions
+        )
+
+        return self.validate_object(object_to_validate=new_instance, object_type=new_object_type)
+
+    def migrate_cancer_somatic_variant_level_questions(self, old_questions):
+        return None if old_questions is None else [
+            self.migrate_cancer_somatic_variant_level_question(old_instance=old_question)
+            for old_question in old_questions
+        ]
+
+    def migrate_cancer_somatic_variant_level_question(self, old_instance):
+        new_object_type = self.new_model.CancerSomaticVariantLevelQuestions
+        new_instance = self.convert_class(target_klass=new_object_type, instance=old_instance)
+        new_instance.variantDetails = self.migrate_variant_coordinates_to_variant_details(old_coordinates=old_instance.variantCoordinates)
+
+        return self.validate_object(object_to_validate=new_instance, object_type=new_object_type)
+
+    @staticmethod
+    def migrate_variant_coordinates_to_variant_details(old_coordinates):
+        variant_details_template = "{chromosome}:{position}:{reference}:{alternate}"
+        return variant_details_template.format(
+            chromosome=old_coordinates.chromosome,
+            position=old_coordinates.position,
+            reference=old_coordinates.reference,
+            alternate=old_coordinates.alternate,
+        )

--- a/protocols/migration/migration_reports_6_0_0_to_reports_5_0_0.py
+++ b/protocols/migration/migration_reports_6_0_0_to_reports_5_0_0.py
@@ -319,30 +319,28 @@ class MigrateReports600To500(BaseMigrateReports500And600):
     def migrate_cancer_exit_questionnaire(self, old_instance):
         new_object_type = self.new_model.CancerExitQuestionnaire
         new_instance = self.convert_class(target_klass=new_object_type, instance=old_instance)
-
-        new_instance.somaticVariantLevelQuestions = self.migrate_cancer_somatic_variant_level_questions(
-            old_questions=old_instance.somaticVariantLevelQuestions
+        new_instance.somaticVariantLevelQuestions = self.migrate_list_of_things(
+            things=old_instance.somaticVariantLevelQuestions,
+            migrate_function=self.migrate_only_variant_details,
+            klass=self.new_model.CancerSomaticVariantLevelQuestions
         )
-
-        # TODO: Implement this
-        new_instance.germlineVariantLevelQuestions = self.migrate_cancer_somatic_variant_level_questions(
-            old_questions=old_instance.somaticVariantLevelQuestions
+        new_instance.germlineVariantLevelQuestions = self.migrate_list_of_things(
+            things=old_instance.germlineVariantLevelQuestions,
+            migrate_function=self.migrate_only_variant_details,
+            klass=self.new_model.CancerGermlineVariantLevelQuestions
         )
-
+        new_instance.otherActionableVariants = self.migrate_list_of_things(
+            things=old_instance.otherActionableVariants,
+            migrate_function=self.migrate_only_variant_details,
+            klass=self.new_model.AdditionalVariantsQuestions
+        )
         return self.validate_object(object_to_validate=new_instance, object_type=new_object_type)
 
-    def migrate_cancer_somatic_variant_level_questions(self, old_questions):
-        return None if old_questions is None else [
-            self.migrate_cancer_somatic_variant_level_question(old_instance=old_question)
-            for old_question in old_questions
-        ]
-
-    def migrate_cancer_somatic_variant_level_question(self, old_instance):
-        new_object_type = self.new_model.CancerSomaticVariantLevelQuestions
-        new_instance = self.convert_class(target_klass=new_object_type, instance=old_instance)
-        new_instance.variantDetails = self.migrate_variant_coordinates_to_variant_details(old_coordinates=old_instance.variantCoordinates)
-
-        return self.validate_object(object_to_validate=new_instance, object_type=new_object_type)
+    def migrate_only_variant_details(self, old_instance, klass):
+        new_instance = self.convert_class(target_klass=klass, instance=old_instance)
+        new_instance.variantDetails = self.migrate_variant_coordinates_to_variant_details(
+            old_coordinates=old_instance.variantCoordinates)
+        return self.validate_object(object_to_validate=new_instance, object_type=klass)
 
     @staticmethod
     def migrate_variant_coordinates_to_variant_details(old_coordinates):

--- a/protocols/tests/test_migration/test_migration_reports_6_0_0_to_reports_5_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_6_0_0_to_reports_5_0_0.py
@@ -175,6 +175,20 @@ class TestMigrateReports600To500(TestCaseMigration):
         ceq_5 = MigrateReports600To500().migrate_cancer_exit_questionnaire(old_instance=ceq_6)
         self.assertIsInstance(ceq_5, new_model.CancerExitQuestionnaire)
         self.assertTrue(ceq_5.validate(ceq_5.toJsonDict()))
+        self._check_variant_details_conversion(ceq_6.somaticVariantLevelQuestions, ceq_5.somaticVariantLevelQuestions)
+        self._check_variant_details_conversion(ceq_6.germlineVariantLevelQuestions, ceq_5.germlineVariantLevelQuestions)
+        self._check_variant_details_conversion(ceq_6.otherActionableVariants, ceq_5.otherActionableVariants)
+
+    def _check_variant_details_conversion(self, things_with_coordinates, things_with_details):
+        if things_with_details and things_with_coordinates:
+            coordinates = [sq.variantCoordinates for sq in things_with_coordinates]
+            details = [sq.variantDetails for sq in things_with_details]
+            for c, d in zip(coordinates, details):
+                d_fields = d.split(":")
+                self.assertEqual(d_fields[0], c.chromosome)
+                self.assertEqual(d_fields[1], str(c.position))
+                self.assertEqual(d_fields[2], c.reference)
+                self.assertEqual(d_fields[3], c.alternate)
 
     def test_migrate_cancer_exit_questionnaire_no_nullables(self):
         self.test_migrate_cancer_exit_questionnaire(fill_nullables=False)

--- a/protocols/tests/test_migration/test_migration_reports_6_0_0_to_reports_5_0_0.py
+++ b/protocols/tests/test_migration/test_migration_reports_6_0_0_to_reports_5_0_0.py
@@ -169,3 +169,12 @@ class TestMigrateReports600To500(TestCaseMigration):
 
     def test_migrate_clinical_report_cancer_no_nullables(self):
         self.test_migrate_clinical_report_cancer(fill_nullables=False)
+
+    def test_migrate_cancer_exit_questionnaire(self, fill_nullables=True):
+        ceq_6 = self.get_valid_object(object_type=old_model.CancerExitQuestionnaire, version=self.version_7_0, fill_nullables=fill_nullables)
+        ceq_5 = MigrateReports600To500().migrate_cancer_exit_questionnaire(old_instance=ceq_6)
+        self.assertIsInstance(ceq_5, new_model.CancerExitQuestionnaire)
+        self.assertTrue(ceq_5.validate(ceq_5.toJsonDict()))
+
+    def test_migrate_cancer_exit_questionnaire_no_nullables(self):
+        self.test_migrate_cancer_exit_questionnaire(fill_nullables=False)

--- a/schemas/IDLs/org.gel.models.report.avro/5.0.0/ExitQuestionnaire.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/5.0.0/ExitQuestionnaire.avdl
@@ -283,7 +283,6 @@ protocol ExitQuestionnaires {
         /**
         Variant coordinates following format `chromosome:position:reference:alternate`
         */
-        // TODO: use VariantCoordinates in CommonInterpreted.avdl
         string variantDetails;
 
         /**
@@ -310,7 +309,7 @@ protocol ExitQuestionnaires {
 
     record AdditionalVariantsQuestions{
         /**
-        Chr: Pos Ref > Alt
+        Variant coordinates following format `chromosome:position:reference:alternate`
         */
         string variantDetails;
 
@@ -343,7 +342,6 @@ protocol ExitQuestionnaires {
         /**
         Variant coordinates following format `chromosome:position:reference:alternate`
         */
-        // TODO: use VariantCoordinates in CommonInterpreted.avdl
         string variantDetails;
 
         /**
@@ -412,5 +410,4 @@ protocol ExitQuestionnaires {
         */
         union {null, array<AdditionalVariantsQuestions>} otherActionableVariants;
     }
-
 }

--- a/schemas/IDLs/org.gel.models.report.avro/6.0.0/ExitQuestionnaire.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.0.0/ExitQuestionnaire.avdl
@@ -411,5 +411,4 @@ protocol ExitQuestionnaires {
         */
         union {null, array<AdditionalVariantsQuestions>} otherActionableVariants;
     }
-
 }


### PR DESCRIPTION
## NOTE:
* Generic method to convert lists of things in `BaseMigration.migrate_list_of_things()`. In subsequent PRs we should get rid of all the by list methods