### PR TITLE
More on migrations (v7.1.10)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,16 @@
+Version 7.1.10 (11th September 2018)
+--------------------------------
+
+#### Minor changes
+
+* Improve performance of migrations by:
+    - Avoid unnecessary validations
+    - Improve performance of `toJsonDict()`
+    - Avoid calling `fromJsonDict()` recursively
+* Fix some issues checking equality of cancer actions in round trip migrations
+* In `MigrationHelpers` choice the right version when an entity validates against multiple version by looking at the version control 
+
+
 Version 7.1.9 (8th September 2018)
 --------------------------------
 

--- a/protocols/migration/base_migration.py
+++ b/protocols/migration/base_migration.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
 import logging
+import types
 
 from protocols import reports_5_0_0, reports_6_0_0, reports_4_0_0
 from protocols.util import handle_avro_errors
@@ -75,7 +76,7 @@ class BaseMigration(object):
     def convert_collection(things, migrate_function, default=None, **kwargs):
         if things is None:
             return default
-        elif isinstance(things, list):
+        elif isinstance(things, (list, types.GeneratorType)):
             migrated_list = [migrate_function(thing, **kwargs) for thing in things]
             return list(filter(lambda x: x is not None, migrated_list))
         elif isinstance(things, dict):

--- a/protocols/migration/base_migration.py
+++ b/protocols/migration/base_migration.py
@@ -75,7 +75,7 @@ class BaseMigration(object):
     def convert_collection(things, migrate_function, default=None, **kwargs):
         if things is None:
             return default
-        elif isinstance(things, (list, type(zip))):
+        elif isinstance(things, (list)):
             migrated_list = [migrate_function(thing, **kwargs) for thing in things]
             return list(filter(lambda x: x is not None, migrated_list))
         elif isinstance(things, dict):

--- a/protocols/migration/base_migration.py
+++ b/protocols/migration/base_migration.py
@@ -27,11 +27,12 @@ class BaseMigration(object):
 
     @staticmethod
     def validate_object(object_to_validate, object_type):
-        if object_to_validate.validate(jsonDict=object_to_validate.toJsonDict()):
+        json_dict = object_to_validate.toJsonDict()
+        if object_to_validate.validate(jsonDict=json_dict):
             return object_to_validate
         else:
             pprint(handle_avro_errors(object_to_validate.validate_parts()))
-            for message in object_to_validate.validate(object_to_validate.toJsonDict(), verbose=True).messages:
+            for message in object_to_validate.validate(json_dict, verbose=True).messages:
                 print("---------------")
                 print(message)
             raise MigrationError("New {object_type} object is not valid".format(object_type=object_type))

--- a/protocols/migration/base_migration.py
+++ b/protocols/migration/base_migration.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 import logging
-import types
 
 from protocols import reports_5_0_0, reports_6_0_0, reports_4_0_0
 from protocols.util import handle_avro_errors
@@ -76,7 +75,7 @@ class BaseMigration(object):
     def convert_collection(things, migrate_function, default=None, **kwargs):
         if things is None:
             return default
-        elif isinstance(things, (list, types.GeneratorType)):
+        elif isinstance(things, (list, type(zip))):
             migrated_list = [migrate_function(thing, **kwargs) for thing in things]
             return list(filter(lambda x: x is not None, migrated_list))
         elif isinstance(things, dict):

--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -47,6 +47,7 @@ from protocols.participant_1_1_0 import CancerParticipant as CancerParticipant_1
 from protocols.participant_1_0_3 import CancerParticipant as CancerParticipant_1_0_3
 from protocols.participant_1_0_0 import CancerParticipant as CancerParticipant_1_0_0
 
+
 from protocols.migration.migration_reports_210_to_reports_300 import Migration21To3
 from protocols.migration.migration_reports_300_to_reports_400 import MigrateReports3To4
 from protocols.migration.migration_reports_400_to_reports_500 import MigrateReports400To500

--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -575,7 +575,7 @@ class MigrationHelpers(object):
         elif len(valid_types) > 1:
             # TODO: untie intelligently
             pass
-        typ = valid_types[0]
+        typ = valid_types[-1]
         index = types.index(typ)
         migrations_to_apply = migrations[0:index + 1]
         migrated = typ.fromJsonDict(json_dict)

--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -597,7 +597,7 @@ class MigrationHelpers(object):
                     migrated = migration(migrated)
                 return migrated
 
-        raise MigrationError("json_dict data is not one of: {}".format(types))
+        raise MigrationError("json_dict of type {} data is not one of: {}".format(type(json_dict), types))
 
     @staticmethod
     def set_version_to_6_0_0(version_controlled):

--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -599,9 +599,12 @@ class MigrationHelpers(object):
 
     @staticmethod
     def get_version_control(json_dict):
-        version = json_dict.get('versionControl', {}).get('gitVersionControl')
-        if not version:
-            version = json_dict.get('versionControl', {}).get('GitVersionControl')
+        version = None
+        version_control = json_dict.get('versionControl', {})
+        if version_control is not None:
+            version = version_control.get('gitVersionControl')
+            if not version:
+                version = json_dict.get('versionControl', {}).get('GitVersionControl')
         return version
 
     @staticmethod

--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -47,7 +47,6 @@ from protocols.participant_1_1_0 import CancerParticipant as CancerParticipant_1
 from protocols.participant_1_0_3 import CancerParticipant as CancerParticipant_1_0_3
 from protocols.participant_1_0_0 import CancerParticipant as CancerParticipant_1_0_0
 
-from protocols.migration.model_validator import PayloadValidation
 from protocols.migration.migration_reports_210_to_reports_300 import Migration21To3
 from protocols.migration.migration_reports_300_to_reports_400 import MigrateReports3To4
 from protocols.migration.migration_reports_400_to_reports_500 import MigrateReports400To500
@@ -403,10 +402,12 @@ class MigrationHelpers(object):
         :type comments: list
         :rtype: CancerInterpretationRequest_6_0_0
         """
-        if PayloadValidation(klass=CancerInterpretationRequest_5_0_0, payload=json_dict).is_valid or \
-           PayloadValidation(klass=CancerInterpretationRequest_6_0_0, payload=json_dict).is_valid:
+        if CancerInterpretationRequest_5_0_0.validate(CancerInterpretationRequest_5_0_0.fromJsonDict(json_dict)):
             raise MigrationError(
-                "Cannot transform a cancer interpretation request in version 5.0.0 or 6.0.0 into an interpreted genome")
+                "Cannot transform a cancer interpretation request in version 5.0.0 into an interpreted genome")
+        if CancerInterpretationRequest_6_0_0.validate(CancerInterpretationRequest_6_0_0.fromJsonDict(json_dict)):
+            raise MigrationError(
+                "Cannot transform a cancer interpretation request in version 6.0.0 into an interpreted genome")
 
         types = [
             InterpretedGenome_6_0_0,

--- a/protocols/migration/migration_helpers.py
+++ b/protocols/migration/migration_helpers.py
@@ -124,7 +124,6 @@ class MigrationHelpers(object):
             InterpretationRequestRD_3_0_0,
             InterpretationRequestRD_2_1_0
         ]
-
         migrations = [
             MigrationHelpers.set_version_to_6_0_0,  # needed because 5 is valid as 6
             MigrateReports500To600().migrate_interpretation_request_rd,
@@ -132,7 +131,6 @@ class MigrationHelpers(object):
             MigrateReports3To4().migrate_interpretation_request_rd,
             Migration21To3().migrate_interpretation_request
         ]
-
         return MigrationHelpers.migrate(json_dict, types, migrations)
 
     @staticmethod
@@ -152,7 +150,6 @@ class MigrationHelpers(object):
             InterpretationRequestRD_5_0_0,
             InterpretationRequestRD_6_0_0
         ]
-
         migrations = [
             lambda x: x,
             MigrateReports400To300().migrate_interpretation_request_rd,
@@ -176,7 +173,6 @@ class MigrationHelpers(object):
             InterpretationRequestRD_3_0_0,
             InterpretationRequestRD_2_1_0
         ]
-
         migrations = [
             lambda x: x,
             MigrateReports500To600().migrate_interpreted_genome_rd,
@@ -207,7 +203,6 @@ class MigrationHelpers(object):
             InterpretedGenomeRD_3_0_0,
             InterpretedGenomeRD_2_1_0
         ]
-
         migrations = [
             lambda x: x,
             lambda x: MigrateReports500To600().migrate_interpreted_genome_rd(x, panel_source=panel_source),
@@ -231,7 +226,6 @@ class MigrationHelpers(object):
             InterpretedGenomeRD_5_0_0,
             InterpretedGenome_6_0_0
         ]
-
         migrations = [
             lambda x: x,
             MigrateReports400To300().migrate_interpreted_genome_rd,
@@ -255,7 +249,6 @@ class MigrationHelpers(object):
             ClinicalReportRD_3_0_0,
             ClinicalReportRD_2_1_0
         ]
-
         migrations = [
             lambda x: x,
             MigrateReports500To600().migrate_clinical_report_rd,
@@ -279,7 +272,6 @@ class MigrationHelpers(object):
             RareDiseaseExitQuestionnaire_5_0_0,
             RareDiseaseExitQuestionnaire_3_0_0
         ]
-
         migrations = [
             lambda x: x,
             lambda x: MigrateReports500To600().migrate_rd_exit_questionnaire(old_instance=x, assembly=assembly),
@@ -300,7 +292,6 @@ class MigrationHelpers(object):
             CancerExitQuestionnaire_6_0_0,
             CancerExitQuestionnaire_5_0_0
         ]
-
         migrations = [
             lambda x: x,
             lambda x: MigrateReports500To600().migrate_cancer_exit_questionnaire(old_instance=x, assembly=assembly)
@@ -315,7 +306,6 @@ class MigrationHelpers(object):
         :return: CancerExitQuestionnaire_5_0_0
         """
         types = [CancerExitQuestionnaire_5_0_0, CancerExitQuestionnaire_6_0_0]
-
         migrations = [
             lambda x: x,
             MigrateReports600To500().migrate_cancer_exit_questionnaire
@@ -337,7 +327,6 @@ class MigrationHelpers(object):
             Pedigree_1_0_0,
             Pedigree_reports_3_0_0
         ]
-
         migrations = [
             lambda x: x,
             MigrationParticipants103To110().migrate_pedigree,
@@ -360,7 +349,6 @@ class MigrationHelpers(object):
             CancerInterpretationRequest_5_0_0,
             CancerInterpretationRequest_4_0_0
         ]
-
         migrations = [
             MigrationHelpers.set_version_to_6_0_0,
             MigrateReports500To600().migrate_interpretation_request_cancer,
@@ -424,7 +412,6 @@ class MigrationHelpers(object):
             CancerInterpretedGenome_5_0_0,
             CancerInterpretationRequest_4_0_0
         ]
-
         migrations = [
             lambda x: x,
             MigrateReports500To600().migrate_cancer_interpreted_genome,
@@ -455,7 +442,6 @@ class MigrationHelpers(object):
             CancerInterpretedGenome_5_0_0,
             CancerInterpretedGenome_4_0_0
         ]
-
         migrations = [
             lambda x: x,
             MigrateReports500To600().migrate_cancer_interpreted_genome,
@@ -475,7 +461,6 @@ class MigrationHelpers(object):
             CancerInterpretedGenome_5_0_0,
             InterpretedGenome_6_0_0
         ]
-
         migrations = [
             lambda x: x,
             MigrateReports500To400().migrate_cancer_interpreted_genome,
@@ -499,7 +484,6 @@ class MigrationHelpers(object):
             ClinicalReportCancer_5_0_0,
             ClinicalReportCancer_4_0_0
         ]
-
         migrations = [
             lambda x: x,
             MigrateReports500To600().migrate_cancer_clinical_report,
@@ -517,7 +501,6 @@ class MigrationHelpers(object):
             ClinicalReportCancer_5_0_0,
             ClinicalReport_6_0_0
         ]
-
         migrations = [
             lambda x: x,
             MigrateReports500To400().migrate_cancer_clinical_report,
@@ -537,7 +520,6 @@ class MigrationHelpers(object):
             CancerParticipant_1_0_3,
             CancerParticipant_1_0_0
         ]
-
         migrations = [
             lambda x: x,
             MigrationParticipants103To110().migrate_cancer_participant,
@@ -559,7 +541,6 @@ class MigrationHelpers(object):
             ClinicalReportRD_5_0_0,
             ClinicalReport_6_0_0
         ]
-
         migrations = [
             lambda x: x,
             MigrateReports400To300().migrate_clinical_report_rd,
@@ -577,7 +558,6 @@ class MigrationHelpers(object):
             RareDiseaseExitQuestionnaire_5_0_0,
             RareDiseaseExitQuestionnaire_6_0_0
         ]
-
         migrations = [
             lambda x: x,
             MigrateReports400To300().migrate_exit_questionnaire_rd,
@@ -589,15 +569,23 @@ class MigrationHelpers(object):
 
     @staticmethod
     def migrate(json_dict, types, migrations):
-        for i, typ in enumerate(types):
-            if PayloadValidation(klass=typ, payload=json_dict).is_valid:
-                migrated = typ.fromJsonDict(json_dict)
-                migrations_to_apply = migrations[0:i+1]
-                for migration in reversed(migrations_to_apply):
-                    migrated = migration(migrated)
-                return migrated
+        valid_types = MigrationHelpers.is_valid(json_dict, types)
+        if len(valid_types) == 0:
+            raise MigrationError("JSON dict not valid according to any model")
+        elif len(valid_types) > 1:
+            # TODO: untie intelligently
+            pass
+        typ = valid_types[0]
+        index = types.index(typ)
+        migrations_to_apply = migrations[0:index + 1]
+        migrated = typ.fromJsonDict(json_dict)
+        for migration in reversed(migrations_to_apply):
+            migrated = migration(migrated)
+        return migrated
 
-        raise MigrationError("json_dict of type {} data is not one of: {}".format(type(json_dict), types))
+    @staticmethod
+    def is_valid(json_dict, types):
+        return [i for (i, v) in zip(types, [typ.validate(json_dict) for typ in types]) if v]
 
     @staticmethod
     def set_version_to_6_0_0(version_controlled):

--- a/protocols/migration/migration_reports_210_to_reports_300.py
+++ b/protocols/migration/migration_reports_210_to_reports_300.py
@@ -15,7 +15,7 @@ class Migration21To3(BaseMigration):
         """
         new_instance = self.convert_class(self.new_model.InterpretedGenomeRD, interpreted_genome)
         new_instance.reportedVariants = self.convert_collection(
-            zip(interpreted_genome.reportedVariants, new_instance.reportedVariants), self._migrate_reported_variant)
+            list(zip(interpreted_genome.reportedVariants, new_instance.reportedVariants)), self._migrate_reported_variant)
         new_instance.reportedStructuralVariants = []
         interpreted_genome.versionControl = reports_3_0_0.VersionControl()
         new_instance.softwareVersions = {}
@@ -31,12 +31,12 @@ class Migration21To3(BaseMigration):
         new_instance.pedigree = self.migrate_pedigree(interpretation_request.pedigree)
         new_instance.versionControl = reports_3_0_0.VersionControl()
         new_instance.TieredVariants = self.convert_collection(
-            zip(interpretation_request.TieredVariants, new_instance.TieredVariants), self._migrate_reported_variant)
-        new_instance.BAMs = self.convert_collection(zip(interpretation_request.BAMs, new_instance.BAMs), self._migrate_file)
-        new_instance.VCFs = self.convert_collection(zip(interpretation_request.VCFs, new_instance.VCFs), self._migrate_file)
+            list(zip(interpretation_request.TieredVariants, new_instance.TieredVariants)), self._migrate_reported_variant)
+        new_instance.BAMs = self.convert_collection(list(zip(interpretation_request.BAMs, new_instance.BAMs)), self._migrate_file)
+        new_instance.VCFs = self.convert_collection(list(zip(interpretation_request.VCFs, new_instance.VCFs)), self._migrate_file)
         if interpretation_request.bigWigs is not None:
             new_instance.bigWigs = self.convert_collection(
-                zip(interpretation_request.bigWigs, new_instance.bigWigs), self._migrate_file)
+                list(zip(interpretation_request.bigWigs, new_instance.bigWigs)), self._migrate_file)
         if interpretation_request.pedigreeDiagram:
             new_instance.pedigreeDiagram = self._migrate_file(
                 (interpretation_request.pedigreeDiagram, new_instance.pedigreeDiagram))
@@ -52,7 +52,7 @@ class Migration21To3(BaseMigration):
         """
         new_instance = self.convert_class(self.new_model.ClinicalReportRD, clinical_report)
         new_instance.candidateVariants = self.convert_collection(
-            zip(clinical_report.candidateVariants, new_instance.candidateVariants), self._migrate_reported_variant)
+            list(zip(clinical_report.candidateVariants, new_instance.candidateVariants)), self._migrate_reported_variant)
         new_instance.candidateStructuralVariants = []
         return self.validate_object(new_instance, self.new_model.ClinicalReportRD)
 
@@ -64,7 +64,7 @@ class Migration21To3(BaseMigration):
         new_instance = self.convert_class(self.new_model.Pedigree, pedigree)
         new_instance.versionControl = reports_3_0_0.VersionControl()
         new_instance.participants = self.convert_collection(
-            zip(pedigree.participants, new_instance.participants), self._migrate_rd_participant)
+            list(zip(pedigree.participants, new_instance.participants)), self._migrate_rd_participant)
         return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.Pedigree)
 
     def _migrate_file(self, files):
@@ -109,7 +109,7 @@ class Migration21To3(BaseMigration):
         old_instance = reported_variants[0]
         new_instance = reported_variants[1]
         new_instance.calledGenotypes = self.convert_collection(
-            zip(old_instance.calledGenotypes, new_instance.calledGenotypes), self._migrate_reported_called_genotype)
+            list(zip(old_instance.calledGenotypes, new_instance.calledGenotypes)), self._migrate_reported_called_genotype)
         new_instance.reportEvents = self.convert_collection(
-            zip(old_instance.reportEvents, new_instance.reportEvents), self._migrate_report_event)
+            list(zip(old_instance.reportEvents, new_instance.reportEvents)), self._migrate_report_event)
         return new_instance

--- a/protocols/migration/migration_reports_210_to_reports_300.py
+++ b/protocols/migration/migration_reports_210_to_reports_300.py
@@ -86,7 +86,6 @@ class Migration21To3(BaseMigration):
     def _migrate_reported_called_genotype(self, called_genotypes):
         old_instance = called_genotypes[0]
         new_instance = called_genotypes[1]
-        # new_instance = self.convert_class(self.new_model.CalledGenotype, called_genotype)
         if new_instance.validate(new_instance.toJsonDict()):
             return new_instance
         else:

--- a/protocols/migration/migration_reports_300_to_reports_400.py
+++ b/protocols/migration/migration_reports_300_to_reports_400.py
@@ -31,7 +31,7 @@ class MigrateReports3To4(BaseMigration):
         new_instance.annotationFile = self._migrate_file(old_file=old_instance.annotationFile)
         new_instance.otherFiles = self.convert_collection(old_instance.otherFiles, self._migrate_file)
         new_instance.tieredVariants = self.convert_collection(
-            old_instance.TieredVariants, self._migrate_tiered_variant)
+            old_instance.TieredVariants, self._migrate_reported_variant)
         new_instance.pedigree = self.participants_migrator.migrate_pedigree(
             pedigree=old_instance.pedigree, ldp_code=next(iter(old_instance.workspace), None))
         new_instance.internalStudyId = ''
@@ -88,12 +88,6 @@ class MigrateReports3To4(BaseMigration):
         new_instance.variantClassification = self.variant_classification_map.get(
             old_instance.variantClassification, self.new_model.VariantClassification.not_assessed
         )
-        return new_instance
-
-    def _migrate_tiered_variant(self, old_instance):
-        new_instance = self.convert_class(
-            self.new_model.ReportedVariant, old_instance)  # :type: reports_5_0_0.ReportedVariant
-        new_instance.reportEvents = self.convert_collection(old_instance.reportEvents, self._migrate_report_event)
         return new_instance
 
     def _migrate_file(self, old_file):

--- a/protocols/migration/migration_reports_300_to_reports_400.py
+++ b/protocols/migration/migration_reports_300_to_reports_400.py
@@ -25,12 +25,12 @@ class MigrateReports3To4(BaseMigration):
         """
         new_instance = self.convert_class(self.new_model.InterpretationRequestRD, old_instance)
         new_instance.bams = self.convert_collection(
-            zip(old_instance.BAMs, new_instance.bams), self._migrate_file)
+            list(zip(old_instance.BAMs, new_instance.bams)), self._migrate_file)
         new_instance.vcfs = self.convert_collection(
-            zip(old_instance.VCFs, new_instance.vcfs), self._migrate_file)
+            list(zip(old_instance.VCFs, new_instance.vcfs)), self._migrate_file)
         if old_instance.bigWigs is not None:
             new_instance.bigWigs = self.convert_collection(
-                zip(old_instance.bigWigs, new_instance.bigWigs), self._migrate_file)
+                list(zip(old_instance.bigWigs, new_instance.bigWigs)), self._migrate_file)
         new_instance.pedigreeDiagram = self._migrate_file((old_instance.pedigreeDiagram, new_instance.pedigreeDiagram))
         new_instance.annotationFile = self._migrate_file((old_instance.annotationFile, new_instance.annotationFile))
         if old_instance.otherFiles is not None:
@@ -38,7 +38,7 @@ class MigrateReports3To4(BaseMigration):
                 {k: (old_file, new_instance.otherFiles[k]) for k, old_file in old_instance.otherFiles.items()},
                 self._migrate_file)
         new_instance.tieredVariants = self.convert_collection(
-            zip(old_instance.TieredVariants, new_instance.tieredVariants), self._migrate_reported_variant)
+            list(zip(old_instance.TieredVariants, new_instance.tieredVariants)), self._migrate_reported_variant)
         new_instance.pedigree = self.participants_migrator.migrate_pedigree(
             pedigree=old_instance.pedigree, ldp_code=next(iter(old_instance.workspace), None))
         new_instance.internalStudyId = ''
@@ -53,7 +53,7 @@ class MigrateReports3To4(BaseMigration):
         """
         new_instance = self.convert_class(self.new_model.InterpretedGenomeRD, old_instance)
         new_instance.reportedVariants = self.convert_collection(
-            zip(old_instance.reportedVariants, new_instance.reportedVariants), self._migrate_reported_variant)
+            list(zip(old_instance.reportedVariants, new_instance.reportedVariants)), self._migrate_reported_variant)
         new_instance.reportedStructuralVariants = self.convert_collection(
             old_instance.reportedStructuralVariants, self._migrate_reported_structural_variant)
         return self.validate_object(new_instance, self.new_model.InterpretedGenomeRD)
@@ -66,7 +66,7 @@ class MigrateReports3To4(BaseMigration):
         new_instance = self.convert_class(self.new_model.ClinicalReportRD, old_instance)
         if old_instance.candidateVariants is not None:
             new_instance.candidateVariants = self.convert_collection(
-                zip(old_instance.candidateVariants, new_instance.candidateVariants), self._migrate_reported_variant)
+                list(zip(old_instance.candidateVariants, new_instance.candidateVariants)), self._migrate_reported_variant)
         new_instance.candidateStructuralVariants = self.convert_collection(
             old_instance.candidateStructuralVariants, self._migrate_reported_structural_variant)
         return self.validate_object(new_instance, self.new_model.InterpretedGenomeRD)
@@ -85,13 +85,13 @@ class MigrateReports3To4(BaseMigration):
         old_instance = reported_variant[0]
         new_instance = reported_variant[1]
         new_instance.reportEvents = self.convert_collection(
-            zip(old_instance.reportEvents, new_instance.reportEvents), self._migrate_report_event)
+            list(zip(old_instance.reportEvents, new_instance.reportEvents)), self._migrate_report_event)
         return new_instance
 
     def _migrate_reported_structural_variant(self, old_instance):
         new_instance = self.convert_class(self.new_model.ReportedStructuralVariant, old_instance)
         new_instance.reportEvents = self.convert_collection(
-            zip(old_instance.reportEvents, new_instance.reportEvents), self._migrate_report_event)
+            list(zip(old_instance.reportEvents, new_instance.reportEvents)), self._migrate_report_event)
         return new_instance
 
     def _migrate_report_event(self, report_event):

--- a/protocols/migration/migration_reports_400_to_reports_300.py
+++ b/protocols/migration/migration_reports_400_to_reports_300.py
@@ -79,7 +79,6 @@ class MigrateReports400To300(BaseMigration):
     def _migrate_reported_variant(self, reported_variants):
         old_instance = reported_variants[0]
         new_instance = reported_variants[1]
-        # new_instance = self.convert_class(self.new_model.ReportedVariant, old_reported_variant)
         new_instance.reportEvents = self.convert_collection(
             zip(old_instance.reportEvents, new_instance.reportEvents), self._migrate_report_event)
         return new_instance
@@ -93,7 +92,6 @@ class MigrateReports400To300(BaseMigration):
     def _migrate_report_event(self, report_events):
         old_instance = report_events[0]
         new_instance = report_events[1]
-        # new_instance = self.convert_class(self.new_model.ReportEvent, old_event)
         new_instance.variantClassification = self._migrate_variant_classification(
             old_v_classification=old_instance.variantClassification)
         if new_instance.eventJustification is None:

--- a/protocols/migration/migration_reports_400_to_reports_300.py
+++ b/protocols/migration/migration_reports_400_to_reports_300.py
@@ -21,7 +21,7 @@ class MigrateReports400To300(BaseMigration):
         new_instance = self.convert_class(self.new_model.InterpretationRequestRD, old_instance)
         new_instance.versionControl = self.new_model.VersionControl()
         new_instance.TieredVariants = self.convert_collection(
-            old_instance.tieredVariants, self._migrate_reported_variant)
+            zip(old_instance.tieredVariants, new_instance.TieredVariants), self._migrate_reported_variant)
         new_instance.BAMs = self.convert_collection(old_instance.bams, self._migrate_file)
         new_instance.VCFs = self.convert_collection(old_instance.vcfs, self._migrate_file)
         new_instance.bigWigs = self.convert_collection(old_instance.bigWigs, self._migrate_file)
@@ -43,7 +43,7 @@ class MigrateReports400To300(BaseMigration):
         new_instance = self.convert_class(self.new_model.InterpretedGenomeRD, old_instance)
         new_instance.versionControl = self.new_model.VersionControl()
         new_instance.reportedVariants = self.convert_collection(
-            old_instance.reportedVariants, self._migrate_reported_variant)
+            zip(old_instance.reportedVariants, new_instance.reportedVariants), self._migrate_reported_variant)
         return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.InterpretedGenomeRD)
 
     def migrate_clinical_report_rd(self, old_instance):
@@ -59,7 +59,9 @@ class MigrateReports400To300(BaseMigration):
         else:
             new_instance.interpretationRequestAnalysisVersion = old_instance.interpretationRequestVersion
 
-        new_instance.candidateVariants = self.convert_collection(old_instance.candidateVariants, self._migrate_reported_variant)
+        if old_instance.candidateVariants is not None:
+            new_instance.candidateVariants = self.convert_collection(
+                zip(old_instance.candidateVariants, new_instance.candidateVariants), self._migrate_reported_variant)
         new_instance.candidateStructuralVariants = self.convert_collection(
             old_instance.candidateStructuralVariants, self._migrate_reported_structural_variant)
 
@@ -74,29 +76,26 @@ class MigrateReports400To300(BaseMigration):
         return self.validate_object(object_to_validate=new_instance,
                                     object_type=self.new_model.RareDiseaseExitQuestionnaire)
 
-    def _migrate_reported_variant(self, old_reported_variant):
-        new_instance = self.convert_class(self.new_model.ReportedVariant, old_reported_variant)
-        new_instance.calledGenotypes = self.convert_collection(
-            old_reported_variant.calledGenotypes, self._migrate_called_genotype)
+    def _migrate_reported_variant(self, reported_variants):
+        old_instance = reported_variants[0]
+        new_instance = reported_variants[1]
+        # new_instance = self.convert_class(self.new_model.ReportedVariant, old_reported_variant)
         new_instance.reportEvents = self.convert_collection(
-            old_reported_variant.reportEvents, self._migrate_report_event)
+            zip(old_instance.reportEvents, new_instance.reportEvents), self._migrate_report_event)
         return new_instance
 
     def _migrate_reported_structural_variant(self, old_structural_variant):
         new_instance = self.convert_class(self.new_model.ReportedStructuralVariant, old_structural_variant)
-        new_instance.calledGenotypes = self.convert_collection(
-            old_structural_variant.calledGenotypes, self._migrate_called_genotype)
         new_instance.reportEvents = self.convert_collection(
-            old_structural_variant.reportEvents, self._migrate_report_event)
+            zip(old_structural_variant.reportEvents, new_instance.reportEvents), self._migrate_report_event)
         return new_instance
 
-    def _migrate_called_genotype(self, old_genotype):
-        new_genotype = self.convert_class(self.new_model.CalledGenotype, old_genotype)
-        return new_genotype
-
-    def _migrate_report_event(self, old_event):
-        new_instance = self.convert_class(self.new_model.ReportEvent, old_event)
-        new_instance.variantClassification = self._migrate_variant_classification(old_v_classification=old_event.variantClassification)
+    def _migrate_report_event(self, report_events):
+        old_instance = report_events[0]
+        new_instance = report_events[1]
+        # new_instance = self.convert_class(self.new_model.ReportEvent, old_event)
+        new_instance.variantClassification = self._migrate_variant_classification(
+            old_v_classification=old_instance.variantClassification)
         if new_instance.eventJustification is None:
             new_instance.eventJustification = ""
         return new_instance

--- a/protocols/migration/migration_reports_400_to_reports_300.py
+++ b/protocols/migration/migration_reports_400_to_reports_300.py
@@ -21,7 +21,7 @@ class MigrateReports400To300(BaseMigration):
         new_instance = self.convert_class(self.new_model.InterpretationRequestRD, old_instance)
         new_instance.versionControl = self.new_model.VersionControl()
         new_instance.TieredVariants = self.convert_collection(
-            zip(old_instance.tieredVariants, new_instance.TieredVariants), self._migrate_reported_variant)
+            list(zip(old_instance.tieredVariants, new_instance.TieredVariants)), self._migrate_reported_variant)
         new_instance.BAMs = self.convert_collection(old_instance.bams, self._migrate_file)
         new_instance.VCFs = self.convert_collection(old_instance.vcfs, self._migrate_file)
         new_instance.bigWigs = self.convert_collection(old_instance.bigWigs, self._migrate_file)
@@ -43,7 +43,7 @@ class MigrateReports400To300(BaseMigration):
         new_instance = self.convert_class(self.new_model.InterpretedGenomeRD, old_instance)
         new_instance.versionControl = self.new_model.VersionControl()
         new_instance.reportedVariants = self.convert_collection(
-            zip(old_instance.reportedVariants, new_instance.reportedVariants), self._migrate_reported_variant)
+            list(zip(old_instance.reportedVariants, new_instance.reportedVariants)), self._migrate_reported_variant)
         return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.InterpretedGenomeRD)
 
     def migrate_clinical_report_rd(self, old_instance):
@@ -61,7 +61,7 @@ class MigrateReports400To300(BaseMigration):
 
         if old_instance.candidateVariants is not None:
             new_instance.candidateVariants = self.convert_collection(
-                zip(old_instance.candidateVariants, new_instance.candidateVariants), self._migrate_reported_variant)
+                list(zip(old_instance.candidateVariants, new_instance.candidateVariants)), self._migrate_reported_variant)
         new_instance.candidateStructuralVariants = self.convert_collection(
             old_instance.candidateStructuralVariants, self._migrate_reported_structural_variant)
 
@@ -80,13 +80,13 @@ class MigrateReports400To300(BaseMigration):
         old_instance = reported_variants[0]
         new_instance = reported_variants[1]
         new_instance.reportEvents = self.convert_collection(
-            zip(old_instance.reportEvents, new_instance.reportEvents), self._migrate_report_event)
+            list(zip(old_instance.reportEvents, new_instance.reportEvents)), self._migrate_report_event)
         return new_instance
 
     def _migrate_reported_structural_variant(self, old_structural_variant):
         new_instance = self.convert_class(self.new_model.ReportedStructuralVariant, old_structural_variant)
         new_instance.reportEvents = self.convert_collection(
-            zip(old_structural_variant.reportEvents, new_instance.reportEvents), self._migrate_report_event)
+            list(zip(old_structural_variant.reportEvents, new_instance.reportEvents)), self._migrate_report_event)
         return new_instance
 
     def _migrate_report_event(self, report_events):

--- a/protocols/migration/migration_reports_400_to_reports_500.py
+++ b/protocols/migration/migration_reports_400_to_reports_500.py
@@ -323,7 +323,6 @@ class MigrateReports400To500(BaseMigrateReports400And500):
     def _migrate_report_event(self, report_events):
         old_instance = report_events[0]
         new_instance = report_events[1]
-        # new_instance = self.convert_class(self.new_model.ReportEvent, old_instance)
         new_instance.phenotypes = [old_instance.phenotype]
         if old_instance.panelName is not None:
             new_instance.genePanel = self.new_model.GenePanel(
@@ -400,16 +399,19 @@ class MigrateReports400To500(BaseMigrateReports400And500):
         )
         new_instance.alleleOrigins = old_instance.alleleOrigins
         new_instance.reportEvents = self.convert_collection(
-            ne_instance.reportEvents, self._migrate_report_event_cancer)
+            zip(ne_instance.reportEvents, new_instance.reportEvents), self._migrate_report_event_cancer)
         return new_instance
 
-    def _migrate_report_event_cancer(self, old_instance):
-        new_instance = self.convert_class(self.new_model.ReportEventCancer, old_instance)
+    def _migrate_report_event_cancer(self, report_events):
+        old_instance = report_events[0]
+        new_instance = report_events[1]
         new_instance.genomicEntities = [self._migrate_genomic_feature_cancer(old_instance.genomicFeatureCancer)]
         if old_instance.soTerms is not None:
             new_instance.variantConsequences = [reports_5_0_0.VariantConsequence(id=so_term.id, name=so_term.name)
                                                 for so_term in old_instance.soTerms]
-        new_instance.actions = self.convert_collection(old_instance.actions, self._migrate_action)
+        if old_instance.actions is not None:
+            new_instance.actions = self.convert_collection(
+                zip(old_instance.actions, new_instance.actions), self._migrate_action)
         map_role_in_cancer = {
             None: None,
             reports_4_0_0.RoleInCancer.both: [reports_5_0_0.RoleInCancer.both],
@@ -428,8 +430,9 @@ class MigrateReports400To500(BaseMigrateReports400And500):
         )
         return new_instance
 
-    def _migrate_action(self, old_instance):
-        new_instance = self.convert_class(self.new_model.Action, old_instance)
+    def _migrate_action(self, actions):
+        old_instance = actions[0]
+        new_instance = actions[1]
         new_instance.evidenceType = old_instance.actionType
         new_instance.actionType = None
         new_instance.references = old_instance.evidence

--- a/protocols/migration/migration_reports_400_to_reports_500.py
+++ b/protocols/migration/migration_reports_400_to_reports_500.py
@@ -288,7 +288,7 @@ class MigrateReports400To500(BaseMigrateReports400And500):
         new_instance.variantCalls = self.convert_collection(
             old_instance.calledGenotypes, self._migrate_called_genotype_to_variant_call, default=[])
         new_instance.reportEvents = self.convert_collection(
-            zip(old_instance.reportEvents, new_instance.reportEvents), self._migrate_report_event)
+            list(zip(old_instance.reportEvents, new_instance.reportEvents)), self._migrate_report_event)
         new_instance.references = old_instance.evidenceIds
         new_instance.alleleOrigins = [reports_5_0_0.AlleleOrigin.germline_variant]
         if migrate_frequencies:
@@ -399,7 +399,7 @@ class MigrateReports400To500(BaseMigrateReports400And500):
         )
         new_instance.alleleOrigins = old_instance.alleleOrigins
         new_instance.reportEvents = self.convert_collection(
-            zip(ne_instance.reportEvents, new_instance.reportEvents), self._migrate_report_event_cancer)
+            list(zip(ne_instance.reportEvents, new_instance.reportEvents)), self._migrate_report_event_cancer)
         return new_instance
 
     def _migrate_report_event_cancer(self, report_events):
@@ -411,7 +411,7 @@ class MigrateReports400To500(BaseMigrateReports400And500):
                                                 for so_term in old_instance.soTerms]
         if old_instance.actions is not None:
             new_instance.actions = self.convert_collection(
-                zip(old_instance.actions, new_instance.actions), self._migrate_action)
+                list(zip(old_instance.actions, new_instance.actions)), self._migrate_action)
         map_role_in_cancer = {
             None: None,
             reports_4_0_0.RoleInCancer.both: [reports_5_0_0.RoleInCancer.both],

--- a/protocols/migration/migration_reports_400_to_reports_500.py
+++ b/protocols/migration/migration_reports_400_to_reports_500.py
@@ -287,7 +287,8 @@ class MigrateReports400To500(BaseMigrateReports400And500):
         )
         new_instance.variantCalls = self.convert_collection(
             old_instance.calledGenotypes, self._migrate_called_genotype_to_variant_call, default=[])
-        new_instance.reportEvents = self.convert_collection(old_instance.reportEvents, self._migrate_report_event)
+        new_instance.reportEvents = self.convert_collection(
+            zip(old_instance.reportEvents, new_instance.reportEvents), self._migrate_report_event)
         new_instance.references = old_instance.evidenceIds
         new_instance.alleleOrigins = [reports_5_0_0.AlleleOrigin.germline_variant]
         if migrate_frequencies:
@@ -319,8 +320,10 @@ class MigrateReports400To500(BaseMigrateReports400And500):
         # NOTE: fields that cannot be filled: vaf, alleleOrigins
         return new_instance
 
-    def _migrate_report_event(self, old_instance):
-        new_instance = self.convert_class(self.new_model.ReportEvent, old_instance)
+    def _migrate_report_event(self, report_events):
+        old_instance = report_events[0]
+        new_instance = report_events[1]
+        # new_instance = self.convert_class(self.new_model.ReportEvent, old_instance)
         new_instance.phenotypes = [old_instance.phenotype]
         if old_instance.panelName is not None:
             new_instance.genePanel = self.new_model.GenePanel(

--- a/protocols/migration/migration_reports_500_to_reports_400.py
+++ b/protocols/migration/migration_reports_500_to_reports_400.py
@@ -1,5 +1,5 @@
 import logging
-import distutils
+import distutils.util
 
 from protocols import reports_4_0_0 as reports_4_0_0
 from protocols import reports_5_0_0 as reports_5_0_0

--- a/protocols/migration/migration_reports_500_to_reports_400.py
+++ b/protocols/migration/migration_reports_500_to_reports_400.py
@@ -249,7 +249,7 @@ class MigrateReports500To400(BaseMigrateReports400And500):
     def _migrate_genomic_entity_to_feature(self, entity):
         new_instance = self.convert_class(self.new_model.GenomicFeature, entity)
         feature_type = self.feature_type_map.get(entity.type, self.new_model.FeatureTypes.Gene)
-        if feature_type != entity.type:
+        if entity.type not in self.feature_type_map.keys():
             logging.warning(
                 "{} can not be migrated to a feature type, as it is not one of: {} so is being migrated to {}".format(
                     entity.type, self.feature_type_map.keys(), self.new_model.FeatureTypes.Gene

--- a/protocols/migration/migration_reports_500_to_reports_400.py
+++ b/protocols/migration/migration_reports_500_to_reports_400.py
@@ -221,7 +221,7 @@ class MigrateReports500To400(BaseMigrateReports400And500):
         new_instance.calledGenotypes = self.convert_collection(
             old_reported_variant.variantCalls, self._migrate_variant_call_to_called_genotype)
         new_instance.reportEvents = self.convert_collection(
-            zip(old_reported_variant.reportEvents, new_instance.reportEvents), self._migrate_report_event)
+            list(zip(old_reported_variant.reportEvents, new_instance.reportEvents)), self._migrate_report_event)
         new_instance.additionalNumericVariantAnnotations = self._merge_annotations_and_frequencies(
             old_reported_variant.additionalNumericVariantAnnotations, old_reported_variant.alleleFrequencies,
         )
@@ -309,7 +309,7 @@ class MigrateReports500To400(BaseMigrateReports400And500):
         if old_rvc.proteinChanges:
             new_instance.proteinChange = next((e for e in old_rvc.proteinChanges), None)
         new_instance.reportEvents = self.convert_collection(
-            zip(old_rvc.reportEvents, new_instance.reportEvents), self._migrate_report_event_cancer)
+            list(zip(old_rvc.reportEvents, new_instance.reportEvents)), self._migrate_report_event_cancer)
         new_instance.chromosome = old_rvc.variantCoordinates.chromosome
         new_instance.position = old_rvc.variantCoordinates.position
         new_instance.reference = old_rvc.variantCoordinates.reference
@@ -366,7 +366,7 @@ class MigrateReports500To400(BaseMigrateReports400And500):
             new_instance.genomicFeatureCancer.roleInCancer = map_role_in_cancer[old_instance.roleInCancer[0]]
         if old_instance.actions is not None:
             new_instance.actions = self.convert_collection(
-                zip(old_instance.actions, new_instance.actions), self._migrate_action)
+                list(zip(old_instance.actions, new_instance.actions)), self._migrate_action)
         return new_instance
 
     def _migrate_variant_consequence_to_so_term(self, vc):

--- a/protocols/migration/migration_reports_500_to_reports_600.py
+++ b/protocols/migration/migration_reports_500_to_reports_600.py
@@ -44,7 +44,7 @@ class MigrateReports500To600(BaseMigrateReports500And600):
         new_instance = self.convert_class(self.new_model.InterpretedGenome, old_instance)
         new_instance.versionControl = self.new_model.ReportVersionControl()
         new_instance.variants = self.convert_collection(
-            zip(old_instance.variants, new_instance.variants), self._migrate_variant, panel_source=panel_source)
+            list(zip(old_instance.variants, new_instance.variants)), self._migrate_variant, panel_source=panel_source)
         return self.validate_object(
             object_to_validate=new_instance, object_type=self.new_model.InterpretedGenome
         )
@@ -57,7 +57,7 @@ class MigrateReports500To600(BaseMigrateReports500And600):
         migrated_instance = self.convert_class(self.new_model.ClinicalReport, old_instance)
         if old_instance.variants is not None:
             migrated_instance.variants = self.convert_collection(
-                zip(old_instance.variants, migrated_instance.variants), self._migrate_variant)
+                list(zip(old_instance.variants, migrated_instance.variants)), self._migrate_variant)
         return self.validate_object(object_to_validate=migrated_instance, object_type=self.new_model.ClinicalReport)
 
     def migrate_rd_exit_questionnaire(self, old_instance, assembly):
@@ -118,13 +118,13 @@ class MigrateReports500To600(BaseMigrateReports500And600):
         old_instance = variants[0]
         new_instance = variants[1]
         new_instance.variantCalls = self.convert_collection(
-            zip(old_instance.variantCalls, new_instance.variantCalls), self._migrate_variant_call)
+            list(zip(old_instance.variantCalls, new_instance.variantCalls)), self._migrate_variant_call)
         consequence_types = []
         if old_instance.additionalTextualVariantAnnotations:
             consequence_types = old_instance.additionalTextualVariantAnnotations.get('ConsequenceType', "").split(",")
             consequence_types = [c for c in consequence_types if c]
         new_instance.reportEvents = self.convert_collection(
-            zip(old_instance.reportEvents, new_instance.reportEvents),
+            list(zip(old_instance.reportEvents, new_instance.reportEvents)),
             self._migrate_report_event, panel_source=panel_source, consequence_types=consequence_types)
         new_instance.variantAttributes = self._migrate_variant_attributes(old_variant=old_instance)
         return new_instance
@@ -229,7 +229,7 @@ class MigrateReports500To600(BaseMigrateReports500And600):
         new_instance.genePanel = self._migrate_gene_panel(
             (old_instance.genePanel, new_instance.genePanel), panel_source=panel_source)
         new_instance.genomicEntities = self.convert_collection(
-            zip(old_instance.genomicEntities, new_instance.genomicEntities), self._migrate_genomic_entity)
+            list(zip(old_instance.genomicEntities, new_instance.genomicEntities)), self._migrate_genomic_entity)
         new_instance.variantClassification = self._migrate_variant_classification(
             (old_instance.variantClassification, new_instance.variantClassification))
         if old_instance.eventJustification:
@@ -367,9 +367,9 @@ class MigrateReports500To600(BaseMigrateReports500And600):
     def migrate_variant_cancer(self, variant):
         new_variant = self.convert_class(target_klass=self.new_model.SmallVariant, instance=variant)
         new_variant.variantCalls = self.convert_collection(
-            zip(variant.variantCalls, new_variant.variantCalls), self._migrate_variant_call)
+            list(zip(variant.variantCalls, new_variant.variantCalls)), self._migrate_variant_call)
         new_variant.reportEvents = self.convert_collection(
-            zip(variant.reportEvents, new_variant.reportEvents), self._migrate_report_event_cancer)
+            list(zip(variant.reportEvents, new_variant.reportEvents)), self._migrate_report_event_cancer)
         new_variant.variantAttributes = self._migrate_variant_attributes(old_variant=variant)
         return self.validate_object(object_to_validate=new_variant, object_type=self.new_model.SmallVariant)
 
@@ -379,7 +379,7 @@ class MigrateReports500To600(BaseMigrateReports500And600):
         new_instance.modeOfInheritance = self.new_model.ModeOfInheritance.na
         new_instance.phenotypes = self.new_model.Phenotypes()
         new_instance.genomicEntities = self.convert_collection(
-            zip(old_instance.genomicEntities, new_instance.genomicEntities), self._migrate_genomic_entity)
+            list(zip(old_instance.genomicEntities, new_instance.genomicEntities)), self._migrate_genomic_entity)
         new_instance.variantClassification = self._migrate_variant_classification(
             (old_instance.variantClassification, new_instance.variantClassification))
         # migrate tier to domain

--- a/protocols/migration/migration_reports_600_to_reports_500.py
+++ b/protocols/migration/migration_reports_600_to_reports_500.py
@@ -46,7 +46,7 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         new_instance.versionControl = self.new_model.ReportVersionControl()
         if old_instance.variants is not None:
             new_instance.variants = self.convert_collection(
-                zip(old_instance.variants, new_instance.variants),
+                list(zip(old_instance.variants, new_instance.variants)),
                 self._migrate_variant,
                 default=[],
                 migrate_re=self._migrate_report_event)
@@ -64,7 +64,7 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         new_instance = self.convert_class(target_klass=self.new_model.ClinicalReportRD, instance=old_instance)
         if old_instance.variants is not None:
             new_instance.variants = self.convert_collection(
-                zip(old_instance.variants, new_instance.variants),
+                list(zip(old_instance.variants, new_instance.variants)),
                 self._migrate_variant,
                 default=[],
                 migrate_re=self._migrate_report_event
@@ -118,7 +118,7 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         new_instance = self.convert_class(target_klass=self.new_model.CancerInterpretedGenome, instance=old_instance)
         new_instance.versionControl = self.new_model.ReportVersionControl()
         new_instance.variants = self.convert_collection(
-            zip(old_instance.variants, new_instance.variants),
+            list(zip(old_instance.variants, new_instance.variants)),
             self._migrate_variant,
             migrate_re=self._migrate_report_event_cancer)
         return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.CancerInterpretedGenome)
@@ -131,7 +131,7 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         new_instance = self.convert_class(target_klass=self.new_model.ClinicalReportCancer, instance=old_instance)
         if old_instance.variants is not None:
             new_instance.variants = self.convert_collection(
-                zip(old_instance.variants, new_instance.variants),
+                list(zip(old_instance.variants, new_instance.variants)),
                 self._migrate_variant,
                 default=[],
                 migrate_re=self._migrate_report_event_cancer
@@ -206,7 +206,7 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         new_instance.genePanel = self._migrate_gene_panel((old_instance.genePanel, new_instance.genePanel))
         new_instance.modeOfInheritance = self._migrate_mode_of_inheritance(old_moh=old_instance.modeOfInheritance)
         new_instance.genomicEntities = self.convert_collection(
-            zip(old_instance.genomicEntities, new_instance.genomicEntities), self._migrate_genomic_entity)
+            list(zip(old_instance.genomicEntities, new_instance.genomicEntities)), self._migrate_genomic_entity)
         if new_instance.variantClassification is not None:
             new_instance.variantClassification.drugResponseClassification = None
 
@@ -218,7 +218,7 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         old_instance = report_events[0]
         new_instance = report_events[1]
         new_instance.genomicEntities = self.convert_collection(
-            zip(old_instance.genomicEntities, new_instance.genomicEntities), self._migrate_genomic_entity)
+            list(zip(old_instance.genomicEntities, new_instance.genomicEntities)), self._migrate_genomic_entity)
         new_instance.variantClassification = self._migrate_variant_classification(
             classification=old_instance.variantClassification)
         if old_instance.domain:
@@ -287,9 +287,9 @@ class MigrateReports600To500(BaseMigrateReports500And600):
                     for allele_frequency in old_instance.variantAttributes.alleleFrequencies
                 ]
         new_instance.variantCalls = self.convert_collection(
-            zip(old_instance.variantCalls, new_instance.variantCalls), self._migrate_variant_call)
+            list(zip(old_instance.variantCalls, new_instance.variantCalls)), self._migrate_variant_call)
         new_instance.reportEvents = self.convert_collection(
-            zip(old_instance.reportEvents, new_instance.reportEvents), migrate_re)
+            list(zip(old_instance.reportEvents, new_instance.reportEvents)), migrate_re)
 
         if new_instance.alleleOrigins is None:
             new_instance.alleleOrigins = []

--- a/protocols/migration/migration_reports_600_to_reports_500.py
+++ b/protocols/migration/migration_reports_600_to_reports_500.py
@@ -44,12 +44,14 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         """
         new_instance = self.convert_class(target_klass=self.new_model.InterpretedGenomeRD, instance=old_instance)
         new_instance.versionControl = self.new_model.ReportVersionControl()
-        new_instance.variants = self.convert_collection(
-            old_instance.variants,
-            self.migrate_small_variant_to_reported_variant,
-            default=[],
-            new_type=self.new_model.ReportedVariant,
-            migrate_re=self._migrate_report_event)
+        if old_instance.variants is not None:
+            new_instance.variants = self.convert_collection(
+                zip(old_instance.variants, new_instance.variants),
+                self.migrate_small_variant_to_reported_variant,
+                default=[],
+                migrate_re=self._migrate_report_event)
+        else:
+            new_instance.variants = []
 
         return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.InterpretedGenomeRD)
 
@@ -60,13 +62,15 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         :rtype: reports_5_0_0.ClinicalReportRD
         """
         new_instance = self.convert_class(target_klass=self.new_model.ClinicalReportRD, instance=old_instance)
-        new_instance.variants = self.convert_collection(
-            old_instance.variants,
-            self.migrate_small_variant_to_reported_variant,
-            default=[],
-            new_type=self.new_model.ReportedVariant,
-            migrate_re=self._migrate_report_event
-        )
+        if old_instance.variants is not None:
+            new_instance.variants = self.convert_collection(
+                zip(old_instance.variants, new_instance.variants),
+                self.migrate_small_variant_to_reported_variant,
+                default=[],
+                migrate_re=self._migrate_report_event
+            )
+        else:
+            new_instance.variants = []
         new_instance.additionalAnalysisPanels = self.convert_collection(
             old_instance.additionalAnalysisPanels, self._migrate_additional_analysis_panel)
         new_instance.versionControl = self.new_model.ReportVersionControl()
@@ -122,13 +126,15 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         :rtype: reports_5_0_0.ClinicalReportCancer
         """
         new_instance = self.convert_class(target_klass=self.new_model.ClinicalReportCancer, instance=old_instance)
-        new_instance.variants = self.convert_collection(
-            old_instance.variants,
-            self.migrate_small_variant_to_reported_variant,
-            default=[],
-            new_type=self.new_model.ReportedVariantCancer,
-            migrate_re=self._migrate_report_event_cancer
-        )
+        if old_instance.variants is not None:
+            new_instance.variants = self.convert_collection(
+                zip(old_instance.variants, new_instance.variants),
+                self.migrate_small_variant_to_reported_variant,
+                default=[],
+                migrate_re=self._migrate_report_event_cancer
+            )
+        else:
+            new_instance.variants = []
 
         return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.ClinicalReportCancer)
 
@@ -170,10 +176,13 @@ class MigrateReports600To500(BaseMigrateReports500And600):
             alternate=coords.alternate)
         return new_instance
 
-    def migrate_small_variant_to_reported_variant(self, small_variant, new_type, migrate_re):
-        new_instance = self.convert_class(target_klass=new_type, instance=small_variant)
+    def migrate_small_variant_to_reported_variant(self, variants, migrate_re):
 
-        var_attrs = small_variant.variantAttributes
+        old_instance = variants[0]
+        new_instance = variants[1]
+        # new_instance = self.convert_class(target_klass=new_type, instance=small_variant)
+
+        var_attrs = old_instance.variantAttributes
         if var_attrs:
             new_instance.genomicChanges = var_attrs.genomicChanges
             new_instance.cdnaChanges = var_attrs.cdnaChanges
@@ -194,8 +203,8 @@ class MigrateReports600To500(BaseMigrateReports500And600):
                 new_instance.clinVarIds = var_attrs.variantIdentifiers.clinVarIds
             new_instance.variantAttributes = self._migrate_variant_attributes(old_variant_attributes=var_attrs)
 
-        new_instance.variantCalls = self.convert_collection(small_variant.variantCalls, self._migrate_variant_call)
-        new_instance.reportEvents = self.convert_collection(small_variant.reportEvents, migrate_re)
+        new_instance.variantCalls = self.convert_collection(old_instance.variantCalls, self._migrate_variant_call)
+        new_instance.reportEvents = self.convert_collection(old_instance.reportEvents, migrate_re)
 
         if new_instance.alleleOrigins is None:
             new_instance.alleleOrigins = []

--- a/protocols/migration/migration_reports_600_to_reports_500.py
+++ b/protocols/migration/migration_reports_600_to_reports_500.py
@@ -47,7 +47,7 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         if old_instance.variants is not None:
             new_instance.variants = self.convert_collection(
                 zip(old_instance.variants, new_instance.variants),
-                self.migrate_small_variant_to_reported_variant,
+                self._migrate_variant,
                 default=[],
                 migrate_re=self._migrate_report_event)
         else:
@@ -65,7 +65,7 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         if old_instance.variants is not None:
             new_instance.variants = self.convert_collection(
                 zip(old_instance.variants, new_instance.variants),
-                self.migrate_small_variant_to_reported_variant,
+                self._migrate_variant,
                 default=[],
                 migrate_re=self._migrate_report_event
             )
@@ -117,7 +117,10 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         """
         new_instance = self.convert_class(target_klass=self.new_model.CancerInterpretedGenome, instance=old_instance)
         new_instance.versionControl = self.new_model.ReportVersionControl()
-        new_instance.variants = self.convert_collection(old_instance.variants, self._migrate_variant_cancer)
+        new_instance.variants = self.convert_collection(
+            zip(old_instance.variants, new_instance.variants),
+            self._migrate_variant,
+            migrate_re=self._migrate_report_event_cancer)
         return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.CancerInterpretedGenome)
 
     def migrate_clinical_report_cancer(self, old_instance):
@@ -129,7 +132,7 @@ class MigrateReports600To500(BaseMigrateReports500And600):
         if old_instance.variants is not None:
             new_instance.variants = self.convert_collection(
                 zip(old_instance.variants, new_instance.variants),
-                self.migrate_small_variant_to_reported_variant,
+                self._migrate_variant,
                 default=[],
                 migrate_re=self._migrate_report_event_cancer
             )
@@ -176,92 +179,74 @@ class MigrateReports600To500(BaseMigrateReports500And600):
             alternate=coords.alternate)
         return new_instance
 
-    def migrate_small_variant_to_reported_variant(self, variants, migrate_re):
-
-        old_instance = variants[0]
-        new_instance = variants[1]
-        # new_instance = self.convert_class(target_klass=new_type, instance=small_variant)
-
-        var_attrs = old_instance.variantAttributes
-        if var_attrs:
-            new_instance.genomicChanges = var_attrs.genomicChanges
-            new_instance.cdnaChanges = var_attrs.cdnaChanges
-            new_instance.proteinChanges = var_attrs.proteinChanges
-            new_instance.additionalTextualVariantAnnotations = var_attrs.additionalTextualVariantAnnotations
-            new_instance.references = var_attrs.references
-            new_instance.additionalNumericVariantAnnotations = var_attrs.additionalNumericVariantAnnotations
-            new_instance.comments = var_attrs.comments
-            new_instance.alleleOrigins = var_attrs.alleleOrigins
-            if var_attrs.alleleFrequencies:
-                new_instance.alleleFrequencies = [
-                    self.convert_class(target_klass=self.new_model.AlleleFrequency, instance=allele_frequency)
-                    for allele_frequency in var_attrs.alleleFrequencies
-                ]
-            if var_attrs.variantIdentifiers:
-                new_instance.dbSnpId = var_attrs.variantIdentifiers.dbSnpId
-                new_instance.cosmicIds = var_attrs.variantIdentifiers.cosmicIds
-                new_instance.clinVarIds = var_attrs.variantIdentifiers.clinVarIds
-            new_instance.variantAttributes = self._migrate_variant_attributes(old_variant_attributes=var_attrs)
-
-        new_instance.variantCalls = self.convert_collection(old_instance.variantCalls, self._migrate_variant_call)
-        new_instance.reportEvents = self.convert_collection(old_instance.reportEvents, migrate_re)
-
-        if new_instance.alleleOrigins is None:
-            new_instance.alleleOrigins = []
-
-        return new_instance
-
     def _migrate_variant_attributes(self, old_variant_attributes):
         new_instance = self.convert_class(target_klass=self.new_model.VariantAttributes, instance=old_variant_attributes)
         new_instance.fdp50 = str(old_variant_attributes.fdp50)
         return new_instance
 
-    def _migrate_variant_call(self, old_call):
-        new_instance = self.convert_class(target_klass=self.new_model.VariantCall, instance=old_call)
+    def _migrate_variant_call(self, variant_calls):
+        old_instance = variant_calls[0]
+        new_instance = variant_calls[1]
         if new_instance.alleleOrigins is None:
             new_instance.alleleOrigins = []
-        new_instance.vaf = old_call.sampleVariantAlleleFrequency
-        if old_call.phaseGenotype is not None:
-            new_instance.phaseSet = old_call.phaseGenotype.phaseSet
+        new_instance.vaf = old_instance.sampleVariantAlleleFrequency
+        if old_instance.phaseGenotype is not None:
+            new_instance.phaseSet = old_instance.phaseGenotype.phaseSet
         return new_instance
 
-    def _migrate_report_event(self, old_event):
-        new_instance = self.convert_class(target_klass=self.new_model.ReportEvent, instance=old_event)
-        if old_event.phenotypes.nonStandardPhenotype is None:
+    def _migrate_report_event(self, report_events):
+        old_instance = report_events[0]
+        new_instance = report_events[1]
+        if old_instance.phenotypes.nonStandardPhenotype is None:
             new_instance.phenotypes = []
         else:
-            new_instance.phenotypes = old_event.phenotypes.nonStandardPhenotype
+            new_instance.phenotypes = old_instance.phenotypes.nonStandardPhenotype
         # v5 phenotypes is copied to v6 phenotypes.nonStandardPhenotype in the forward migration
         # https://github.com/genomicsengland/GelReportModels/blob/v7.1.2/protocols/migration/migration_reports_5_0_0_to_reports_6_0_0.py#L269
-        new_instance.genePanel = self._migrate_gene_panel(old_panel=old_event.genePanel)
-        new_instance.modeOfInheritance = self._migrate_mode_of_inheritance(old_moh=old_event.modeOfInheritance)
-        new_instance.genomicEntities = self.convert_collection(old_event.genomicEntities, self._migrate_genomic_entity)
+        new_instance.genePanel = self._migrate_gene_panel((old_instance.genePanel, new_instance.genePanel))
+        new_instance.modeOfInheritance = self._migrate_mode_of_inheritance(old_moh=old_instance.modeOfInheritance)
+        new_instance.genomicEntities = self.convert_collection(
+            zip(old_instance.genomicEntities, new_instance.genomicEntities), self._migrate_genomic_entity)
         if new_instance.variantClassification is not None:
             new_instance.variantClassification.drugResponseClassification = None
 
-        if old_event.tier in (self.old_model.Tier.TIERA, self.old_model.Tier.TIERB):
+        if old_instance.tier in (self.old_model.Tier.TIERA, self.old_model.Tier.TIERB):
             new_instance.tier = self.new_model.Tier.NONE
         return new_instance
 
-    def _migrate_gene_panel(self, old_panel):
-        if old_panel is None:
+    def _migrate_report_event_cancer(self, report_events):
+        old_instance = report_events[0]
+        new_instance = report_events[1]
+        new_instance.genomicEntities = self.convert_collection(
+            zip(old_instance.genomicEntities, new_instance.genomicEntities), self._migrate_genomic_entity)
+        new_instance.variantClassification = self._migrate_variant_classification(
+            classification=old_instance.variantClassification)
+        if old_instance.domain:
+            new_instance.tier = self.domain_tier_map[old_instance.domain]
+        new_instance.actions = self._migrate_actions(old_instance.actions)
+        return new_instance
+
+    def _migrate_gene_panel(self, gene_panels):
+        old_instance = gene_panels[0]
+        new_instance = gene_panels[1]
+        if old_instance is None:
             return None
-        new_instance = self.convert_class(target_klass=self.new_model.GenePanel, instance=old_panel)
-        if old_panel.panelName is None:
+        if old_instance.panelName is None:
             new_instance.panelName = ""
-        if old_panel.panelVersion is None:
+        if old_instance.panelVersion is None:
             new_instance.panelVersion = ""
         return new_instance
 
     def _migrate_mode_of_inheritance(self, old_moh):
         return self.moh_map.get(old_moh, self.new_model.ReportedModeOfInheritance.unknown)
 
-    def _migrate_genomic_entity(self, old_genomic_entity):
-        new_instance = self.convert_class(target_klass=self.new_model.GenomicEntity, instance=old_genomic_entity)
-        if old_genomic_entity.ensemblId is None:
+    def _migrate_genomic_entity(self, genomic_entities):
+        old_instance = genomic_entities[0]
+        new_instance = genomic_entities[1]
+        if old_instance.ensemblId is None:
             new_instance.ensemblId = ""
-        new_instance.otherIds = self._migrate_genomic_entity_other_ids(old_ids=old_genomic_entity.otherIds)
-        new_instance.type = self._migrate_genomic_entity_type(old_type=old_genomic_entity.type)
+        new_instance.otherIds = self._migrate_genomic_entity_other_ids(old_ids=old_instance.otherIds)
+        new_instance.type = self._migrate_genomic_entity_type(old_type=old_instance.type)
         return new_instance
 
     @staticmethod
@@ -284,42 +269,32 @@ class MigrateReports600To500(BaseMigrateReports500And600):
             ))
         return type_map.get(old_type, default)
 
-    def _migrate_variant_cancer(self, old_variant):
-        new_variant = self.convert_class(self.new_model.ReportedVariantCancer, old_variant)
-        if old_variant.variantAttributes:
-            attributes = old_variant.variantAttributes.toJsonDict()
-            new_variant.updateWithJsonDict(attributes)
-            new_variant.variantAttributes.fdp50 = str(old_variant.variantAttributes.fdp50)
-            if old_variant.variantAttributes.variantIdentifiers:
-                identifiers = old_variant.variantAttributes.variantIdentifiers.toJsonDict()
-                new_variant.updateWithJsonDict(identifiers)
+    def _migrate_variant(self, variants, migrate_re):
 
-        new_variant.variantCalls = self.convert_collection(old_variant.variantCalls, self._migrate_variant_call_cancer)
-        new_variant.reportEvents = self.convert_collection(old_variant.reportEvents, self._migrate_report_event_cancer)
+        old_instance = variants[0]
+        new_instance = variants[1]
 
-        if new_variant.alleleOrigins is None:
-            new_variant.alleleOrigins = []
+        if old_instance.variantAttributes:
+            attributes = old_instance.variantAttributes.toJsonDict()
+            new_instance.updateWithJsonDict(attributes)
+            new_instance.variantAttributes.fdp50 = str(old_instance.variantAttributes.fdp50)
+            if old_instance.variantAttributes.variantIdentifiers:
+                identifiers = old_instance.variantAttributes.variantIdentifiers.toJsonDict()
+                new_instance.updateWithJsonDict(identifiers)
+            if old_instance.variantAttributes.alleleFrequencies:
+                new_instance.alleleFrequencies = [
+                    self.convert_class(target_klass=self.new_model.AlleleFrequency, instance=allele_frequency)
+                    for allele_frequency in old_instance.variantAttributes.alleleFrequencies
+                ]
+        new_instance.variantCalls = self.convert_collection(
+            zip(old_instance.variantCalls, new_instance.variantCalls), self._migrate_variant_call)
+        new_instance.reportEvents = self.convert_collection(
+            zip(old_instance.reportEvents, new_instance.reportEvents), migrate_re)
 
-        return new_variant
+        if new_instance.alleleOrigins is None:
+            new_instance.alleleOrigins = []
 
-    def _migrate_variant_call_cancer(self, old_variant_call):
-        new_variant_call = self.convert_class(self.new_model.VariantCall, old_variant_call)
-        if old_variant_call.phaseGenotype:
-            new_variant_call.phaseSet = old_variant_call.phaseGenotype.phaseSet
-        new_variant_call.vaf = old_variant_call.sampleVariantAlleleFrequency
-        if new_variant_call.alleleOrigins is None:
-            new_variant_call.alleleOrigins = []
-        return new_variant_call
-
-    def _migrate_report_event_cancer(self, old_report_event):
-        new_event = self.convert_class(target_klass=self.new_model.ReportEventCancer, instance=old_report_event)
-        new_event.genomicEntities = [self._migrate_genomic_entity(entity) for entity in old_report_event.genomicEntities]
-        new_event.variantClassification = self._migrate_variant_classification(
-            classification=old_report_event.variantClassification)
-        if old_report_event.domain:
-            new_event.tier = self.domain_tier_map[old_report_event.domain]
-        new_event.actions = self._migrate_actions(old_report_event.actions)
-        return new_event
+        return new_instance
 
     def _migrate_variant_classification(self, classification):
         if classification is None:
@@ -359,7 +334,7 @@ class MigrateReports600To500(BaseMigrateReports500And600):
 
     def _migrate_additional_analysis_panel(self, old_panel):
         new_instance = self.convert_class(target_klass=self.new_model.AdditionalAnalysisPanel, instance=old_panel)
-        new_instance.panel = self._migrate_gene_panel(old_panel=old_panel.panel)
+        new_instance.panel = self._migrate_gene_panel((old_panel.panel, new_instance.panel))
         return self.validate_object(object_to_validate=new_instance, object_type=self.new_model.ClinicalReportRD)
 
     def _migrate_only_variant_details(self, old_instance, klass):

--- a/protocols/protocol.py
+++ b/protocols/protocol.py
@@ -101,16 +101,14 @@ class ProtocolElement(object):
         for field in self.schema.fields:
             val = getattr(self, field.name)
             if self.isEmbeddedType(field.name):
-                if isinstance(val, list):
+                if val is None:
+                    out[field.name] = None
+                elif isinstance(val, list):
                     out[field.name] = list(el.toJsonDict() for el in val)
                 elif isinstance(val, dict):
                     out[field.name] = {key: el.toJsonDict() for key, el in val.items()}
-                elif val is None:
-                    out[field.name] = None
                 else:
                     out[field.name] = val.toJsonDict()
-            elif isinstance(val, list):
-                out[field.name] = list(val)
             else:
                 out[field.name] = val
         return out

--- a/protocols/protocol.py
+++ b/protocols/protocol.py
@@ -100,10 +100,10 @@ class ProtocolElement(object):
         out = {}
         for field in self.schema.fields:
             val = getattr(self, field.name)
-            if self.isEmbeddedType(field.name):
-                if val is None:
-                    out[field.name] = None
-                elif isinstance(val, list):
+            if val is None:
+                out[field.name] = None
+            elif self.isEmbeddedType(field.name):
+                if isinstance(val, list):
                     out[field.name] = list(el.toJsonDict() for el in val)
                 elif isinstance(val, dict):
                     out[field.name] = {key: el.toJsonDict() for key, el in val.items()}

--- a/protocols/protocol.py
+++ b/protocols/protocol.py
@@ -319,9 +319,10 @@ class ProtocolElement(object):
             raise ValueError("Required values not set in {0}".format(cls))
 
         if isinstance(jsonDict, dict):
-            key_mapping = {key_mapper(key): key for key in jsonDict.keys()}
+            json_key_mapping = {key_mapper(key): key for key in jsonDict.keys()}
         else:
-            key_mapping = dict()
+            json_key_mapping = dict()
+        protocol_key_mapping = {key_mapper(key): key for key in cls.__slots__}
 
         instance = cls()
         for field in cls.schema.fields:
@@ -329,10 +330,11 @@ class ProtocolElement(object):
                 instanceVal = field.default
             else:
                 instanceVal = None
-            if key_mapper(field.name) in key_mapping:
-                mapped_name = key_mapping[key_mapper(field.name)]
-                val = jsonDict[mapped_name]
-                if cls.isEmbeddedType(mapped_name):
+            if key_mapper(field.name) in json_key_mapping:
+                json_mapped_name = json_key_mapping[key_mapper(field.name)]
+                protocol_mapped_name = protocol_key_mapping[key_mapper(field.name)]
+                val = jsonDict[json_mapped_name]
+                if cls.isEmbeddedType(protocol_mapped_name):
                     instanceVal = cls._decodeEmbedded(field, val, key_mapper=key_mapper)
                 else:
                     instanceVal = val

--- a/protocols/tests/test_migration/base_test_migration.py
+++ b/protocols/tests/test_migration/base_test_migration.py
@@ -150,7 +150,7 @@ class BaseRoundTripper(object):
         for re in report_events:
             if re.actions:
                 for a in re.actions:
-                    key = "{}-{}-{}".format(a.url, a.actionType, a.variantActionable)
+                    key = "{}-{}-{}".format(a.url if a.url else '', a.actionType, a.variantActionable)
                     if key not in actions:
                         actions[key] = []
                     actions[key].append(a)
@@ -166,9 +166,10 @@ class BaseRoundTripper(object):
                     logging.error("Diff. Action type left='{}' right='{}' for key {}".format(
                         a[0].actionType, a[1].actionType, key))
                 differ |= differ_action_type
-                differ_url = a[0].url != a[1].url
+                differ_url = (a[0].url if a[0].url else None) != (a[1].url if a[1].url else None)
                 if differ_url:
-                    logging.error("Diff. URL left='{}' right='{}' for key {}".format(a[0].url, a[1].url, key))
+                    logging.error("Diff. URL left='{}' right='{}' for key {}".format(
+                        a[0].url, a[1].url, key))
                 differ |= differ_url
                 differ_actionable = a[0].variantActionable != a[1].variantActionable
                 if differ_actionable:

--- a/protocols/tests/test_migration/base_test_migration.py
+++ b/protocols/tests/test_migration/base_test_migration.py
@@ -131,9 +131,7 @@ class BaseRoundTripper(object):
                 field_path = [field_path]
             if self.is_field_ignored(field_path, ignore_fields):
                 continue
-            if isinstance(values, list):
-                values = values[0]
-            expected = values[1]
+            expected = values[1] if len(values) > 1 else None
             observed = values[0]
             if observed in self._empty_values and expected in self._empty_values:
                 continue

--- a/protocols/tests/test_migration/test_migration_reports_300_to_reports_400.py
+++ b/protocols/tests/test_migration/test_migration_reports_300_to_reports_400.py
@@ -37,7 +37,7 @@ class TestMigrateReports3To4(TestCaseMigration):
             self.old_model.ClinicalReportRD, VERSION_300, fill_nullables=False
         ).create()
         self._validate(old_instance)
-        migrated_instance = MigrateReports3To4().migrate_clinical_report_rd(old_clinical_report_rd=old_instance)
+        migrated_instance = MigrateReports3To4().migrate_clinical_report_rd(old_instance=old_instance)
         self._validate(migrated_instance)
 
         # fill all nullables
@@ -45,7 +45,7 @@ class TestMigrateReports3To4(TestCaseMigration):
             self.old_model.ClinicalReportRD, VERSION_300, fill_nullables=True
         ).create()
         self._validate(old_instance)
-        migrated_instance = MigrateReports3To4().migrate_clinical_report_rd(old_clinical_report_rd=old_instance)
+        migrated_instance = MigrateReports3To4().migrate_clinical_report_rd(old_instance=old_instance)
         self._validate(migrated_instance)
 
     def test_migrate_interpreted_genome_rd(self):

--- a/protocols/tests/test_migration/test_migration_reports_500_to_reports_300.py
+++ b/protocols/tests/test_migration/test_migration_reports_500_to_reports_300.py
@@ -3,7 +3,6 @@ from random import randint
 from protocols import reports_3_0_0
 from protocols import reports_5_0_0
 from protocols.migration import MigrationHelpers
-from protocols.migration.model_validator import PayloadValidation
 from protocols.tests.test_migration.base_test_migration import TestCaseMigration
 from protocols.util.dependency_manager import VERSION_61
 

--- a/protocols/tests/test_migration/test_migration_reports_500_to_reports_400.py
+++ b/protocols/tests/test_migration/test_migration_reports_500_to_reports_400.py
@@ -7,7 +7,7 @@ from protocols.util.dependency_manager import VERSION_61
 from protocols.util.factories.avro_factory import FactoryAvro
 from protocols.util.factories.avro_factory import GenericFactoryAvro
 from protocols.tests.test_migration.base_test_migration import TestCaseMigration
-from protocols.migration import MigrateReports500To400
+from protocols.migration import MigrateReports500To400, BaseMigration
 
 
 class TestMigrateReports5To400(TestCaseMigration):
@@ -148,7 +148,8 @@ class TestMigrateReports5To400(TestCaseMigration):
 
     def test_migrate_report_event(self):
         old_report_event = GenericFactoryAvro.get_factory_avro(self.old_model.ReportEvent, VERSION_61, fill_nullables=True).create()
-        new_report_event = MigrateReports500To400()._migrate_report_event(old_report_event=old_report_event)
+        new_report_event = BaseMigration.convert_class(reports_4_0_0.ReportEvent, old_report_event)
+        new_report_event = MigrateReports500To400()._migrate_report_event((old_report_event, new_report_event))
         self.assertTrue(isinstance(new_report_event, self.new_model.ReportEvent))
         self._validate(new_report_event)
 

--- a/protocols/tests/test_migration/test_migration_reports_500_to_reports_400.py
+++ b/protocols/tests/test_migration/test_migration_reports_500_to_reports_400.py
@@ -254,14 +254,6 @@ class TestMigrateReports5To400(TestCaseMigration):
         self.assertEqual(so_4.name, vc_5.name)
         self.assertEqual(so_4.id, vc_5.id)
 
-    def test_migrate_report_event_cancer(self):
-        rec_5 = self.get_valid_object(object_type=self.old_model.ReportEventCancer, version=self.version_6_1)
-        rec_4 = MigrateReports500To400()._migrate_report_event_cancer(old_rec=rec_5)
-        self.assertIsInstance(rec_4, self.new_model.ReportEventCancer)
-        self.assertTrue(rec_4.validate(rec_4.toJsonDict()))
-        for action in rec_4.actions:
-            self.assertIsInstance(action, self.new_model.Actions)
-
     def test_migrate_rd_interpreted_genome(self, fill_nullables=True):
         # creates a random clinical report RD for testing filling null values
         old_instance = GenericFactoryAvro.get_factory_avro(

--- a/protocols/tests/test_migration/test_migration_reports_500_to_reports_600.py
+++ b/protocols/tests/test_migration/test_migration_reports_500_to_reports_600.py
@@ -124,13 +124,13 @@ class TestMigrateInterpretedGenome5To6(TestCaseMigration):
         new_calls = new_small_variant.variantCalls
         for old, new in zip(old_calls, new_calls):
             self.assertIsInstance(new, self.new_model.VariantCall)
-            self.assertEqual(new, MigrateReports500To600()._migrate_variant_call(variant_call=old))
+            self.assertEqual(new, MigrateReports500To600()._migrate_variant_call((old, new)))
 
         old_events = old_reported_variant.reportEvents
         new_events = new_small_variant.reportEvents
         for old, new in zip(old_events, new_events):
             self.assertIsInstance(new, self.new_model.ReportEvent)
-            self.assertEqual(new.toJsonDict(), MigrateReports500To600()._migrate_report_event(report_event=old).toJsonDict())
+            self.assertEqual(new.toJsonDict(), MigrateReports500To600()._migrate_report_event((old, new)).toJsonDict())
 
         self.assertIsInstance(new_small_variant.variantAttributes, self.new_model.VariantAttributes)
         self.assertEqual(
@@ -153,28 +153,6 @@ class TestMigrateInterpretedGenome5To6(TestCaseMigration):
         self.assertTrue(new_small_variant.reportEvents[0].variantConsequences[0].name == 'initiator_codon_variant')
         self.assertEqual(len(new_small_variant.reportEvents[1].variantConsequences), 1)
         self.assertTrue(new_small_variant.reportEvents[1].variantConsequences[0].name == 'incomplete_terminal_codon_variant')
-
-    def test_migrate_variant_call(self, fill_nullables=True):
-        old_variant_call = GenericFactoryAvro.get_factory_avro(
-            self.old_model.VariantCall, VERSION_61, fill_nullables=fill_nullables
-        ).create()
-        new_variant_call = MigrateReports500To600()._migrate_variant_call(variant_call=old_variant_call)
-        self._validate(new_variant_call)
-        self.assertIsInstance(new_variant_call, self.new_model.VariantCall)
-
-    def test_migrate_variant_call_no_nullables(self):
-        self.test_migrate_variant_call(fill_nullables=False)
-
-    def test_migrate_report_event(self, fill_nullables=True):
-        old_report_event = GenericFactoryAvro.get_factory_avro(
-            self.old_model.ReportEvent, VERSION_61, fill_nullables=fill_nullables
-        ).create()
-        new_report_event = MigrateReports500To600()._migrate_report_event(report_event=old_report_event)
-        self._validate(new_report_event)
-        self.assertIsInstance(new_report_event, self.new_model.ReportEvent)
-
-    def test_migrate_report_event_no_nullables(self):
-        self.test_migrate_report_event(fill_nullables=False)
 
     def test_migrate_phenotypes(self):
         new_phenotypes = MigrateReports500To600()._migrate_phenotypes(phenotypes=["some", "strings"])

--- a/protocols/tests/test_migration/test_migration_reports_500_to_reports_600.py
+++ b/protocols/tests/test_migration/test_migration_reports_500_to_reports_600.py
@@ -1,5 +1,6 @@
 from protocols import reports_6_0_0
 from protocols import reports_5_0_0
+from protocols.migration import BaseMigration
 from protocols.util.dependency_manager import VERSION_61
 from protocols.util.factories.avro_factory import FactoryAvro
 from protocols.util.factories.avro_factory import GenericFactoryAvro
@@ -68,7 +69,7 @@ class TestMigrateInterpretedGenome5To6(TestCaseMigration):
             self.assertIsInstance(new, self.new_model.SmallVariant)
             self.assertEqual(
                 new,
-                MigrateReports500To600()._migrate_variant(old_variant=old)
+                MigrateReports500To600()._migrate_variant((old, new))
             )
         for v in new_variants:
             for re in v.reportEvents:
@@ -85,7 +86,8 @@ class TestMigrateInterpretedGenome5To6(TestCaseMigration):
         old_reported_variant = GenericFactoryAvro.get_factory_avro(
             self.old_model.ReportedVariant, VERSION_61, fill_nullables=fill_nullables
         ).create()
-        new_small_variant = MigrateReports500To600()._migrate_variant(old_variant=old_reported_variant)
+        new_small_variant = BaseMigration.convert_class(reports_6_0_0.SmallVariant, old_reported_variant)
+        new_small_variant = MigrateReports500To600()._migrate_variant((old_reported_variant, new_small_variant))
         self._validate(new_small_variant)
         self.assertIsInstance(new_small_variant, self.new_model.SmallVariant)
 
@@ -146,7 +148,8 @@ class TestMigrateInterpretedGenome5To6(TestCaseMigration):
             'ConsequenceType': "initiator_codon_variant,incomplete_terminal_codon_variant"}
         old_reported_variant.reportEvents[0].tier = self.old_model.Tier.TIER1
         old_reported_variant.reportEvents[1].tier = self.old_model.Tier.TIER2
-        new_small_variant = MigrateReports500To600()._migrate_variant(old_variant=old_reported_variant)
+        new_small_variant = BaseMigration.convert_class(reports_6_0_0.SmallVariant, old_reported_variant)
+        new_small_variant = MigrateReports500To600()._migrate_variant((old_reported_variant, new_small_variant))
         self._validate(new_small_variant)
         self.assertIsInstance(new_small_variant, self.new_model.SmallVariant)
         self.assertEqual(len(new_small_variant.reportEvents[0].variantConsequences), 1)
@@ -232,7 +235,7 @@ class TestMigrateClinicalReport5To6(TestCaseMigration):
                 self._validate(new)
                 self.assertEqual(
                     new,
-                    MigrateReports500To600()._migrate_variant(old_variant=old)
+                    MigrateReports500To600()._migrate_variant((old, new))
                 )
 
         if old_clinical_report_rd.additionalAnalysisPanels is not None:

--- a/protocols/tests/test_migration/test_migration_reports_500_to_reports_600.py
+++ b/protocols/tests/test_migration/test_migration_reports_500_to_reports_600.py
@@ -114,7 +114,6 @@ class TestMigrateInterpretedGenome5To6(TestCaseMigration):
             new_frequencies = new_small_variant.variantAttributes.alleleFrequencies
             for old, new in zip(old_frequencies, new_frequencies):
                 self.assertIsInstance(new, self.new_model.AlleleFrequency)
-                self.assertEqual(new, MigrateReports500To600()._migrate_allele_frequency(old_frequency=old))
 
         if old_reported_variant.alleleOrigins is not None:
             old_origins = old_reported_variant.alleleOrigins
@@ -162,43 +161,8 @@ class TestMigrateInterpretedGenome5To6(TestCaseMigration):
         self._validate(new_phenotypes)
         self.assertIsInstance(new_phenotypes, self.new_model.Phenotypes)
 
-    def test_migrate_genomic_entity(self, fill_nullables=True):
-        old_genomic_entity = GenericFactoryAvro.get_factory_avro(
-            self.old_model.GenomicEntity, VERSION_61, fill_nullables=fill_nullables
-        ).create()
-        new_genomic_entity = MigrateReports500To600()._migrate_genomic_entity(genomic_entity=old_genomic_entity)
-        self._validate(new_genomic_entity)
-        self.assertIsInstance(new_genomic_entity, self.new_model.GenomicEntity)
-
-    def test_migrate_genomic_entity_no_nullables(self):
-        self.test_migrate_genomic_entity(fill_nullables=False)
-
-    def test_migrate_allele_frequency(self, fill_nullables=True):
-        old_allele_frequency = GenericFactoryAvro.get_factory_avro(
-            self.old_model.AlleleFrequency, VERSION_61, fill_nullables=fill_nullables
-        ).create()
-        new_allele_frequency = MigrateReports500To600()._migrate_allele_frequency(old_frequency=old_allele_frequency)
-        self._validate(new_allele_frequency)
-        self.assertIsInstance(new_allele_frequency, self.new_model.AlleleFrequency)
-
-    def test_migrate_allele_frequency_no_nullables(self):
-        self.test_migrate_allele_frequency(fill_nullables=False)
-
     def test_migrate_reported_variant_no_nullables(self):
         self.test_migrate_reported_variant(fill_nullables=False)
-
-    def test_migrate_variant_classification(self, fill_nullables=True):
-        old_variant_classification = GenericFactoryAvro.get_factory_avro(
-            self.old_model.VariantClassification, VERSION_61, fill_nullables=fill_nullables
-        ).create()
-        new_variant_classification = MigrateReports500To600()._migrate_variant_classification(
-            classification=old_variant_classification
-        )
-        self._validate(new_variant_classification)
-        self.assertIsInstance(new_variant_classification, self.new_model.VariantClassification)
-
-    def test_migrate_variant_classification_no_nullables(self):
-        self.test_migrate_variant_classification(fill_nullables=False)
 
 
 class TestMigrateClinicalReport5To6(TestCaseMigration):
@@ -325,16 +289,6 @@ class TestCancerInterpretedGenome5To6(TestCaseMigration):
 
     def test_migrate_cancer_interpreted_genome_no_nullables(self):
         self.test_migrate_cancer_interpreted_genome(fill_nullables=False)
-
-    def test_migrate_report_event_cancer(self, fill_nullables=True):
-        old_re_c = GenericFactoryAvro.get_factory_avro(
-            self.old_model.ReportEventCancer, VERSION_61, fill_nullables=fill_nullables
-        ).create()
-        new_re_c = MigrateReports500To600()._migrate_report_event_cancer(
-            event=old_re_c,
-        )
-        self.assertIsInstance(new_re_c, self.new_model.ReportEvent)
-        self._validate(new_re_c)
 
     def test_migrate_actions(self):
 

--- a/protocols/tests/test_migration/test_migration_reports_600_to_reports_500.py
+++ b/protocols/tests/test_migration/test_migration_reports_600_to_reports_500.py
@@ -19,78 +19,6 @@ class TestMigrateReports600To500(TestCaseMigration):
     def test_migrate_interpretation_request_rd_nulls(self):
         self.test_migrate_interpretation_request_rd(fill_nullables=False)
 
-    def test_migrate_variant_attributes(self, fill_nullables=True):
-        small_variant = self.variant_with_type_valid_in_both_models()
-
-        reported_variant = MigrateReports600To500()._migrate_variant_cancer(old_variant=small_variant)
-
-        self.assertEqual(reported_variant.genomicChanges, small_variant.variantAttributes.genomicChanges)
-        self.assertEqual(reported_variant.cdnaChanges, small_variant.variantAttributes.cdnaChanges)
-
-        va_6 = self.get_valid_object(
-            object_type=old_model.VariantAttributes, version=self.version_7_0, fill_nullables=fill_nullables
-        )
-        va_5 = MigrateReports600To500()._migrate_variant_attributes(old_variant_attributes=va_6)
-        self.assertIsInstance(va_5, new_model.VariantAttributes)
-        self.assertTrue(va_5.validate(va_5.toJsonDict()))
-
-    def test_migrate_variant_attributes_no_nullables(self):
-        self.test_migrate_variant_attributes(fill_nullables=False)
-
-    def test_migrate_variant_identifiers(self):
-        small_variant = self.variant_with_type_valid_in_both_models()
-
-        reported_variant = MigrateReports600To500()._migrate_variant_cancer(old_variant=small_variant)
-
-        self.assertEqual(reported_variant.dbSnpId, small_variant.variantAttributes.variantIdentifiers.dbSnpId)
-
-    def test_migrate_variant_call(self):
-        small_variant = self.variant_with_type_valid_in_both_models()
-
-        reported_variant = MigrateReports600To500()._migrate_variant_cancer(old_variant=small_variant)
-
-        original_variant_calls = small_variant.variantCalls
-        new_variant_calls = reported_variant.variantCalls
-
-        for original_call, new_call in zip(original_variant_calls, new_variant_calls):
-            self.assertEqual(new_call.phaseSet, original_call.phaseGenotype.phaseSet)
-            self.assertEqual(new_call.vaf, original_call.sampleVariantAlleleFrequency)
-
-        # AlleleOrigins are required for v5 so v6 can not have any nullables not filled
-        vc_6 = self.get_valid_object(
-            object_type=old_model.VariantCall, version=self.version_7_0, fill_nullables=True,
-        )
-        vc_5 = MigrateReports600To500()._migrate_variant_call(old_call=vc_6)
-        self.assertIsInstance(vc_5, new_model.VariantCall)
-        self.assertTrue(vc_5.validate(vc_5.toJsonDict()))
-        self.assertEqual(vc_5.phaseSet, vc_6.phaseGenotype.phaseSet)
-        self.assertEqual(vc_5.vaf, vc_6.sampleVariantAlleleFrequency)
-
-    def test_migrate_report_events(self):
-        small_variant = self.variant_with_type_valid_in_both_models()
-
-        reported_variant = MigrateReports600To500()._migrate_variant_cancer(old_variant=small_variant)
-
-        original_reports = small_variant.reportEvents
-        new_reports = reported_variant.reportEvents
-
-        for original_report, new_report in zip(original_reports, new_reports):
-            self.assertEqual(MigrateReports500To600.tier_domain_map[new_report.tier], original_report.domain)
-
-            actions = original_report.actions
-            expected_action_length = sum(map(len, (actions.prognosis, actions.therapies, actions.trials)))
-            self.assertEqual(len(new_report.actions), expected_action_length)
-
-            clinical_significance = new_report.variantClassification.clinicalSignificance
-            self.assertEqual(
-                BaseMigrateReports500And600.clinical_signicance_map[clinical_significance],
-                original_report.variantClassification.clinicalSignificance
-            )
-
-            new_types = [ge.type for ge in new_report.genomicEntities]
-            old_types = [ge.type for ge in original_report.genomicEntities]
-            self.assertEqual(new_types, old_types)
-
     def variant_with_type_valid_in_both_models(self):
         small_variant = self.get_valid_object(object_type=old_model.SmallVariant, version=self.version_7_0)
         for re in small_variant.reportEvents:
@@ -124,20 +52,6 @@ class TestMigrateReports600To500(TestCaseMigration):
         ig_rd_5 = MigrateReports600To500().migrate_interpreted_genome_to_interpreted_genome_rd(old_instance=ig_6)
         self.assertIsInstance(ig_rd_5, new_model.InterpretedGenomeRD)
         self.assertTrue(ig_rd_5.validate(ig_rd_5.toJsonDict()))
-
-    def test_migrate_report_event(self):
-        # Can not reverse migrate v6 Report Event if phenotypes does not have nonStandardPhenotype populated as v5
-        # phenotypes is required, so nullables must be filled
-        re_6 = self.get_valid_object(
-            object_type=old_model.ReportEvent, version=self.version_7_0, fill_nullables=True,
-        )
-        re_5 = MigrateReports600To500()._migrate_report_event(old_event=re_6)
-        self.assertIsInstance(re_5, new_model.ReportEvent)
-        self.assertTrue(re_5.validate(re_5.toJsonDict()))
-
-        for vc in re_5.variantConsequences:
-            self.assertIsInstance(vc, new_model.VariantConsequence)
-        self.assertIsInstance(re_5.variantClassification, new_model.VariantClassification)
 
     def test_migrate_clinical_report_rd(self, fill_nullables=True):
         cr_rd_6 = self.get_valid_object(object_type=old_model.ClinicalReport, version=self.version_7_0, fill_nullables=fill_nullables)

--- a/protocols/tests/test_migration/test_migration_reports_600_to_reports_500.py
+++ b/protocols/tests/test_migration/test_migration_reports_600_to_reports_500.py
@@ -125,22 +125,6 @@ class TestMigrateReports600To500(TestCaseMigration):
         self.assertIsInstance(ig_rd_5, new_model.InterpretedGenomeRD)
         self.assertTrue(ig_rd_5.validate(ig_rd_5.toJsonDict()))
 
-    def test_migrate_small_variant_to_reported_variant(self):
-        # Can not reverse migrate a v6 SmallVariant to a v5 ReportedVariant if variantAttributes is None as
-        # alleleOrigins is a required field in v5 ReportedVariant so nullables must be filled
-        sv_6 = self.get_valid_object(
-            object_type=old_model.SmallVariant, version=self.version_7_0, fill_nullables=True,
-        )
-        migrate = MigrateReports600To500()
-        rv_5 = migrate.migrate_small_variant_to_reported_variant(
-            small_variant=sv_6, new_type=new_model.ReportedVariant, migrate_re=migrate._migrate_report_event
-        )
-        self.assertIsInstance(rv_5, new_model.ReportedVariant)
-        self.assertTrue(rv_5.validate(rv_5.toJsonDict()))
-
-        for af in rv_5.alleleFrequencies:
-            self.assertIsInstance(af, new_model.AlleleFrequency)
-
     def test_migrate_report_event(self):
         # Can not reverse migrate v6 Report Event if phenotypes does not have nonStandardPhenotype populated as v5
         # phenotypes is required, so nullables must be filled

--- a/protocols_utils/utils/abstract_migration_test_real_data.py
+++ b/protocols_utils/utils/abstract_migration_test_real_data.py
@@ -4,7 +4,11 @@ import abc
 import os.path
 import ujson as json
 import threading
+import glob
+import re
 from pycipapi.cipapi_client import CipApiClient, CipApiCase
+
+from protocols.reports_6_0_0 import Assembly
 from protocols.tests.test_migration.migration_runner import MigrationRunner
 
 
@@ -12,34 +16,37 @@ class AbstractRealRoundTripper(object):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, log_file,  program, data_folder=None):
+    def __init__(self, log_file,  program, data_folder=None, use_data=False):
         # configures logging to get only logs about the failed cases
         self.log_file = log_file
         self.program = program
         self.data_folder = data_folder
+        self.use_data = use_data
         logging.basicConfig(filename=self.log_file, level=logging.ERROR,
                             format='%(asctime)s.%(msecs)03d\t%(message)s',
                             datefmt='%H:%M:%S' ,)
-        gel_user = raw_input("User:")
-        gel_password = getpass.getpass("Password:")
-        cipapi_url = raw_input("URL:")
-        self.cipapi_client = CipApiClient(cipapi_url, user=gel_user, password=gel_password, retries=-1)
+        if not use_data:
+            gel_user = raw_input("User:")
+            gel_password = getpass.getpass("Password:")
+            cipapi_url = raw_input("URL:")
+            self.cipapi_client = CipApiClient(cipapi_url, user=gel_user, password=gel_password, retries=-1)
         self.migration_runner = MigrationRunner()
 
     @staticmethod
     def log(status, _type, model_version, case_id, version, *args):
-        message = "{status}\t{type}\t{model_version}\t{case_id}-{version}".format(
+        message = "{status}\t{type}\t{model_version}\t{case_id}-{version}\t0".format(
             status=status, type=_type, model_version=model_version, case_id=case_id, version=version)
         message = "\t".join([message] + list(args))
         logging.error(message)
 
     @staticmethod
-    def log_case(_type, case_id, version, model_version, differ, is_valid, is_valid_round_tripped):
+    def log_case(_type, case_id, version, model_version, differ, is_valid, is_valid_round_tripped, millis):
         if not is_valid:
-            logging.error("INVALID_FORWARD\t{}\t{}\t{}-{}".format(_type, model_version, case_id, version))
+            logging.error("INVALID_FORWARD\t{}\t{}\t{}-{}\t{}".format(_type, model_version, case_id, version, millis))
         if not is_valid_round_tripped:
-            logging.error("INVALID_BACKWARD\t{}\t{}\t{}-{}".format(_type, model_version, case_id, version))
-        logging.error("{}\t{}\t{}\t{}-{}".format("DIFFER" if differ else "OK", _type, model_version, case_id, version))
+            logging.error("INVALID_BACKWARD\t{}\t{}\t{}-{}\t{}".format(_type, model_version, case_id, version, millis))
+        logging.error("{}\t{}\t{}\t{}-{}\t{}".format(
+            "DIFFER" if differ else "OK", _type, model_version, case_id, version, millis))
 
     @abc.abstractmethod
     def process_case(self, case):
@@ -72,11 +79,54 @@ class AbstractRealRoundTripper(object):
                 raw_eq, os.path.join(data_folder, "{program}-{id}-{version}-{type}.json".format(
                     program=program, type="EQ", id=case_id, version=version)))
 
+    def build_case(self, ir_json_name):
+        matches = re.search(".*{}-(.*)-(.*)-IR.json".format(self.program), ir_json_name)
+        if matches:
+            case_id = matches.group(1)
+            case_version = matches.group(2)
+        else:
+            raise ValueError("Failed to read id and version from file name")
+        raw_ir = json.load(open(ir_json_name))
+        raw_ig = None
+        raw_cr = None
+        raw_eq = None
+        igs = glob.glob(
+            os.path.join(self.data_folder, "*-{}-{}-IG.json".format(case_id, case_version)))
+        if igs:
+            ig_json_name = igs[0]
+            raw_ig = json.load(open(ig_json_name))
+        crs = glob.glob(
+            os.path.join(self.data_folder, "*-{}-{}-CR.json".format(case_id, case_version)))
+        if crs:
+            cr_json_name = crs[0]
+            raw_cr = json.load(open(cr_json_name))
+        eqs = glob.glob(
+            os.path.join(self.data_folder, "*-{}-{}-EQ.json".format(case_id, case_version)))
+        if eqs:
+            eq_json_name = eqs[0]
+            raw_eq = json.load(open(eq_json_name))
+        case = CipApiCase(case_id, case_version, self.program, Assembly.GRCh38, raw_ir, raw_ig, raw_cr, raw_eq)
+        return case
+
     def run(self):
         print "Check your results in '{}'".format(self.log_file)
-        for case in self.cipapi_client.get_cases(program=self.program):  # type: CipApiCase
-            self.process_case(case)
-            if self.data_folder:
-                save_thread = threading.Thread(target=AbstractRealRoundTripper.save_case, args=(case, self.program, self.data_folder))
-                save_thread.start()
-                # AbstractRealRoundTripper.save_case(case, self.program, self.data_folder)
+        if self.use_data:
+            def patched_init(self, case_id, version, program, assembly, raw_ir, raw_ig, raw_cr, raw_eq):
+                self.assembly = assembly
+                self.program = program
+                self.case_id = case_id
+                self.case_version = version
+                self.raw_interpretation_request = raw_ir
+                self.raw_interpreted_genome = raw_ig
+                self.raw_clinical_report = raw_cr
+                self.raw_questionnaire = raw_eq
+            CipApiCase.__init__ = patched_init
+            for ir_json_name in glob.glob(os.path.join(self.data_folder, "{}-*-IR.json".format(self.program))):
+                case = self.build_case(ir_json_name)
+                self.process_case(case)
+        else:
+            for case in self.cipapi_client.get_cases(program=self.program):  # type: CipApiCase
+                self.process_case(case)
+                if self.data_folder:
+                    save_thread = threading.Thread(target=AbstractRealRoundTripper.save_case, args=(case, self.program, self.data_folder))
+                    save_thread.start()

--- a/protocols_utils/utils/migration_test_real_data_cancer.py
+++ b/protocols_utils/utils/migration_test_real_data_cancer.py
@@ -4,12 +4,14 @@ from protocols import reports_4_0_0, reports_5_0_0, reports_6_0_0
 from protocols.migration.base_migration import MigrationError
 from protocols.reports_6_0_0 import Program
 from itertools import chain
+import time
 
 
 class RealRoundTripperCancer(AbstractRealRoundTripper):
 
     def __init__(self):
-        super(RealRoundTripperCancer, self).__init__("real_data_cancer_round_trip.log", Program.cancer, "data")
+        super(RealRoundTripperCancer, self).__init__(
+            "real_data_cancer_round_trip.log", Program.cancer, "data", use_data=True)
 
     def _check_actions(self, original_reported_variants, round_tripped_reported_variants):
         expected_report_events = chain.from_iterable(
@@ -20,10 +22,14 @@ class RealRoundTripperCancer(AbstractRealRoundTripper):
 
     def process_case(self, case):
         # interpretation request
-        raw_ir, case_id, version = case._get_raw_interpretation_request()
+        raw_ir = case.raw_interpretation_request
+        case_id = case.case_id
+        case_version = case.case_version
         ir = reports_4_0_0.CancerInterpretationRequest.fromJsonDict(raw_ir)
         try:
+            start = int(round(time.time() * 1000))
             ir_migrated, ir_round_tripped = self.migration_runner.roundtrip_cancer_ir(ir, case.assembly)
+            run_time = int(round(time.time() * 1000)) - start
             is_valid = ir_migrated.validate(reports_6_0_0.CancerInterpretationRequest, ir_migrated.toJsonDict())
             is_valid_round_tripped = ir_round_tripped.validate(
                 reports_4_0_0.CancerInterpretationRequest, ir_round_tripped.toJsonDict())
@@ -36,32 +42,38 @@ class RealRoundTripperCancer(AbstractRealRoundTripper):
                                "additionalInfo"
                                ])
             differ |= self._check_actions(ir.tieredVariants, ir_round_tripped.tieredVariants)
-            RealRoundTripperCancer.log_case("IR", case_id, version, '4.0.0', differ, is_valid, is_valid_round_tripped)
+            RealRoundTripperCancer.log_case(
+                "IR", case_id, case_version, '4.0.0', differ, is_valid, is_valid_round_tripped, run_time)
         except MigrationError as e:
-            RealRoundTripperCancer.log("MIGRATION_ERROR", "IR", '4.0.0', case_id, version, e.message)
+            RealRoundTripperCancer.log("MIGRATION_ERROR", "IR", '4.0.0', case_id, case_version, e.message)
 
         # interpreted genome
         if case.has_interpreted_genome():
             ig = reports_4_0_0.CancerInterpretedGenome.fromJsonDict(
                 case.raw_interpreted_genome)  # type: reports_4_0_0.CancerInterpretedGenome
             try:
+                start = int(round(time.time() * 1000))
                 ig_migrated, ig_round_tripped = self.migration_runner.roundtrip_cancer_ig(ig, case.assembly)
+                run_time = int(round(time.time() * 1000)) - start
                 is_valid = ig_migrated.validate(reports_6_0_0.InterpretedGenome, ig_migrated.toJsonDict())
                 is_valid_round_tripped = ig_round_tripped.validate(
                     reports_4_0_0.CancerInterpretedGenome, ig_round_tripped.toJsonDict())
                 differ = self.migration_runner.diff_round_tripped(
                     ig, ig_round_tripped, ignore_fields=["analysisId", "additionalTextualVariantAnnotations", "commonAf"])
                 differ |= self._check_actions(ig.reportedVariants, ig_round_tripped.reportedVariants)
-                RealRoundTripperCancer.log_case("IG", case_id, version, '4.0.0', differ, is_valid, is_valid_round_tripped)
+                RealRoundTripperCancer.log_case(
+                    "IG", case_id, case_version, '4.0.0', differ, is_valid, is_valid_round_tripped, run_time)
             except MigrationError as e:
-                RealRoundTripperCancer.log("MIGRATION_ERROR", "IG", '4.0.0', case_id, version, e.message)
+                RealRoundTripperCancer.log("MIGRATION_ERROR", "IG", '4.0.0', case_id, case_version, e.message)
 
         # clinical report
         if case.has_clinical_report():
             cr = reports_4_0_0.ClinicalReportCancer.fromJsonDict(
                 case.raw_clinical_report)  # type: reports_4_0_0.ClinicalReportCancer
             try:
+                start = int(round(time.time() * 1000))
                 cr_migrated, cr_round_tripped = self.migration_runner.roundtrip_cancer_cr(cr, case.assembly)
+                run_time = int(round(time.time() * 1000)) - start
                 is_valid = cr_migrated.validate(reports_6_0_0.ClinicalReport, cr_migrated.toJsonDict())
                 is_valid_round_tripped = cr_round_tripped.validate(
                     reports_4_0_0.ClinicalReportCancer, cr_round_tripped.toJsonDict())
@@ -69,24 +81,26 @@ class RealRoundTripperCancer(AbstractRealRoundTripper):
                     cr, cr_round_tripped, ignore_fields=["analysisId", "additionalTextualVariantAnnotations", "commonAf",
                                                          "genePanelsCoverage", "actions"])
                 differ |= self._check_actions(cr.candidateVariants, cr_round_tripped.candidateVariants)
-                RealRoundTripperCancer.log_case("CR", case_id, version, '4.0.0', differ, is_valid,
-                                                is_valid_round_tripped)
+                RealRoundTripperCancer.log_case(
+                    "CR", case_id, case_version, '4.0.0', differ, is_valid, is_valid_round_tripped, run_time)
             except MigrationError as e:
-                RealRoundTripperCancer.log("MIGRATION_ERROR", "CR", '4.0.0', case_id, version, e.message)
+                RealRoundTripperCancer.log("MIGRATION_ERROR", "CR", '4.0.0', case_id, case_version, e.message)
 
         if case.has_exit_questionnaire():
             eq = reports_5_0_0.CancerExitQuestionnaire.fromJsonDict(case.raw_questionnaire)
             try:
+                start = int(round(time.time() * 1000))
                 eq_migrated, eq_round_tripped = self.migration_runner.roundtrip_cancer_eq(eq, case.assembly)
+                run_time = int(round(time.time() * 1000)) - start
                 is_valid = eq_migrated.validate(reports_6_0_0.CancerExitQuestionnaire, eq_migrated.toJsonDict())
                 is_valid_round_tripped = eq_round_tripped.validate(
                     reports_5_0_0.CancerExitQuestionnaire, eq_round_tripped.toJsonDict())
                 differ = self.migration_runner.diff_round_tripped(
                     eq, eq_round_tripped, ignore_fields=[])
-                RealRoundTripperCancer.log_case("EQ", case_id, version, '5.0.0', differ, is_valid,
-                                                is_valid_round_tripped)
+                RealRoundTripperCancer.log_case(
+                    "EQ", case_id, case_version, '5.0.0', differ, is_valid, is_valid_round_tripped, run_time)
             except MigrationError as e:
-                RealRoundTripperCancer.log("MIGRATION_ERROR", "EQ", '5.0.0', case_id, version, e.message)
+                RealRoundTripperCancer.log("MIGRATION_ERROR", "EQ", '5.0.0', case_id, case_version, e.message)
 
 
 if __name__ == '__main__':

--- a/protocols_utils/utils/migration_test_real_data_rd.py
+++ b/protocols_utils/utils/migration_test_real_data_rd.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import time
 from protocols import reports_2_1_0, reports_3_0_0, reports_6_0_0
 from protocols.migration import Migration21To3
 from protocols.migration.base_migration import MigrationError
@@ -9,100 +10,134 @@ from protocols_utils.utils.abstract_migration_test_real_data import AbstractReal
 class RealRoundTripperRd(AbstractRealRoundTripper):
 
     def __init__(self):
-        super(RealRoundTripperRd, self).__init__("real_data_rd_round_trip.log", Program.rare_disease, "data")
+        super(RealRoundTripperRd, self).__init__(
+            "real_data_rd_round_trip.log", Program.rare_disease, "data", use_data=True)
 
     def process_case(self, case):
         # interpretation request
-        raw_ir, case_id, version = case._get_raw_interpretation_request()
+        # raw_ir, case_id, version = case._get_raw_interpretation_request()
+        raw_ir = case.raw_interpretation_request
+        case_id = case.case_id
+        case_version = case.case_version
         try:
-            ir = reports_2_1_0.InterpretationRequestRD.fromJsonDict(raw_ir)
-            model_version = '3.0.0'
-            if ir.versionControl.GitVersionControl == '2.1.0':
+            is_valid_210 = reports_2_1_0.InterpretationRequestRD.validate(raw_ir)
+            is_valid_300 = reports_3_0_0.InterpretationRequestRD.validate(raw_ir)
+            if is_valid_210 and not is_valid_300:
                 model_version = '2.1.0'
-                ir = Migration21To3().migrate_interpretation_request(
-                    reports_2_1_0.InterpretationRequestRD.fromJsonDict(raw_ir))
-            else:
+                ir = reports_2_1_0.InterpretationRequestRD.fromJsonDict(raw_ir)
+            elif is_valid_300:
+                model_version = '3.0.0'
                 ir = reports_3_0_0.InterpretationRequestRD.fromJsonDict(raw_ir)
+            else:
+                raise ValueError("Payload invalid according to 2.1.0 and 3.0.0")
+            start = int(round(time.time() * 1000))
             ir_migrated, ir_round_tripped = self.migration_runner.roundtrip_rd_ir(ir, case.assembly)
+            run_time = int(round(time.time() * 1000)) - start
             is_valid = ir_migrated.validate(reports_6_0_0.InterpretationRequestRD, ir_migrated.toJsonDict())
             is_valid_round_tripped = ir_round_tripped.validate(
                 reports_3_0_0.InterpretationRequestRD, ir_round_tripped.toJsonDict())
+            if model_version == '2.1.0':
+                ir = Migration21To3().migrate_interpretation_request(ir)
             differ = self.migration_runner.diff_round_tripped(
                 ir, ir_round_tripped,
                 ignore_fields=[
                     "ageOfOnset", "consanguineousPopulation", "reportUri", "GitVersionControl",
                     "analysisId", "genomeAssemblyVersion", "modifiers", "additionalInfo"
                 ])
-            RealRoundTripperRd.log_case("IR", case_id, version, model_version, differ, is_valid, is_valid_round_tripped)
+            RealRoundTripperRd.log_case(
+                "IR", case_id, case_version, model_version, differ, is_valid, is_valid_round_tripped, run_time)
         except MigrationError as e:
-            RealRoundTripperRd.log("MIGRATION_ERROR", "IR", model_version, case_id, version, e.message)
+            RealRoundTripperRd.log("MIGRATION_ERROR", "IR", model_version, case_id, case_version, e.message)
+        except ValueError as e:
+            RealRoundTripperRd.log("INVALID_SCHEMA", "IR", model_version, case_id, case_version, e.message)
 
         # interpreted genome
         if case.has_interpreted_genome():
             raw_ig = case.raw_interpreted_genome
             try:
-                is_valid_210 = reports_2_1_0.InterpretedGenomeRD.validate(
-                    reports_2_1_0.InterpretedGenomeRD, reports_2_1_0.InterpretedGenomeRD.fromJsonDict(raw_ir))
-                is_valid_300 = reports_3_0_0.InterpretedGenomeRD.validate(
-                    reports_3_0_0.InterpretedGenomeRD, reports_3_0_0.InterpretedGenomeRD.fromJsonDict(raw_ir))
+                is_valid_210 = reports_2_1_0.InterpretedGenomeRD.validate(raw_ig)
+                is_valid_300 = reports_3_0_0.InterpretedGenomeRD.validate(raw_ig)
                 if is_valid_210 and not is_valid_300:
                     model_version = '2.1.0'
-                    ig = reports_2_1_0.InterpretedGenomeRD.fromJsonDict(raw_ir)
-                    ig = Migration21To3().migrate_interpreted_genome(ig)
+                    ig = reports_2_1_0.InterpretedGenomeRD.fromJsonDict(raw_ig)
                 elif is_valid_300:
                     model_version = '3.0.0'
                     ig = reports_3_0_0.InterpretedGenomeRD.fromJsonDict(raw_ig)
                 else:
-                    raise MigrationError("Payload invalid according to 2.1.0 and 3.0.0")
+                    raise ValueError("Payload invalid according to 2.1.0 and 3.0.0")
+                start = int(round(time.time() * 1000))
                 ig_migrated, ig_round_tripped = self.migration_runner.roundtrip_rd_ig(ig, case.assembly)
+                run_time = int(round(time.time() * 1000)) - start
                 is_valid = ig_migrated.validate(reports_6_0_0.InterpretedGenome, ig_migrated.toJsonDict())
                 is_valid_round_tripped = ig_round_tripped.validate(
                     reports_3_0_0.InterpretedGenomeRD, ig_round_tripped.toJsonDict())
+                if model_version == '2.1.0':
+                    ig = Migration21To3().migrate_interpreted_genome(ig)
                 differ = self.migration_runner.diff_round_tripped(
                     ig, ig_round_tripped,
                     ignore_fields=['additionalNumericVariantAnnotations', "reportURI", "analysisId",
                                    "GitVersionControl"])
-                RealRoundTripperRd.log_case("IG", case_id, version, model_version, differ, is_valid,
-                                            is_valid_round_tripped)
+                RealRoundTripperRd.log_case("IG", case_id, case_version, model_version, differ, is_valid,
+                                            is_valid_round_tripped, run_time)
             except MigrationError as e:
-                RealRoundTripperRd.log("MIGRATION_ERROR", "IG", model_version, case_id, version, e.message)
+                RealRoundTripperRd.log("MIGRATION_ERROR", "IG", model_version, case_id, case_version, e.message)
+            except ValueError as e:
+                RealRoundTripperRd.log("INVALID_SCHEMA", "IG", model_version, case_id, case_version, e.message)
 
         # clinical report
         if case.has_clinical_report():
             raw_cr = case.raw_clinical_report
             try:
-                model_version = '3.0.0'
-                if reports_2_1_0.ClinicalReportRD.validate(
-                        reports_2_1_0.InterpretedGenomeRD, reports_2_1_0.InterpretedGenomeRD.fromJsonDict(raw_cr)):
+                is_valid_210 = reports_2_1_0.ClinicalReportRD.validate(raw_cr)
+                is_valid_300 = reports_3_0_0.ClinicalReportRD.validate(raw_cr)
+                if is_valid_210 and not is_valid_300:
                     model_version = '2.1.0'
-                    cr = Migration21To3().migrate_clinical_report(reports_2_1_0.ClinicalReportRD.fromJsonDict(raw_cr))
-                else:
+                    cr = reports_2_1_0.ClinicalReportRD.fromJsonDict(raw_cr)
+                elif is_valid_300:
+                    model_version = '3.0.0'
                     cr = reports_3_0_0.ClinicalReportRD.fromJsonDict(raw_cr)
+                else:
+                    raise ValueError("Payload invalid according to 2.1.0 and 3.0.0")
+                start = int(round(time.time() * 1000))
                 cr_migrated, cr_round_tripped = self.migration_runner.roundtrip_rd_cr(cr, case.assembly)
+                run_time = int(round(time.time() * 1000)) - start
                 is_valid = cr_migrated.validate(reports_6_0_0.ClinicalReport, cr_migrated.toJsonDict())
                 is_valid_round_tripped = cr_round_tripped.validate(
                     reports_3_0_0.ClinicalReportRD, cr_round_tripped.toJsonDict())
+                if model_version == '2.1.0':
+                    cr = Migration21To3().migrate_clinical_report(cr)
                 differ = self.migration_runner.diff_round_tripped(
                     cr, cr_round_tripped, ignore_fields=["interpretationRequestAnalysisVersion", "GitVersionControl"])
-                RealRoundTripperRd.log_case("CR", case_id, version, model_version, differ, is_valid,
-                                            is_valid_round_tripped)
+                RealRoundTripperRd.log_case("CR", case_id, case_version, model_version, differ, is_valid,
+                                            is_valid_round_tripped, run_time)
             except MigrationError as e:
-                RealRoundTripperRd.log("MIGRATION_ERROR", "CR", model_version, case_id, version, e.message)
+                RealRoundTripperRd.log("MIGRATION_ERROR", "CR", model_version, case_id, case_version, e.message)
+            except ValueError as e:
+                RealRoundTripperRd.log("INVALID_SCHEMA", "CR", model_version, case_id, case_version, e.message)
 
         if case.has_exit_questionnaire():
             raw_eq = case.raw_questionnaire
-            eq = reports_3_0_0.RareDiseaseExitQuestionnaire.fromJsonDict(raw_eq)
             try:
+                is_valid_300 = reports_3_0_0.RareDiseaseExitQuestionnaire.validate(raw_eq)
+                if is_valid_300:
+                    model_version = '3.0.0'
+                    eq = reports_3_0_0.RareDiseaseExitQuestionnaire.fromJsonDict(raw_eq)
+                else:
+                    raise ValueError("Payload invalid according to 3.0.0")
+                start = int(round(time.time() * 1000))
                 eq_migrated, eq_round_tripped = self.migration_runner.roundtrip_rd_eq(eq, case.assembly)
+                run_time = int(round(time.time() * 1000)) - start
                 is_valid = eq_migrated.validate(reports_6_0_0.RareDiseaseExitQuestionnaire, eq_migrated.toJsonDict())
                 is_valid_round_tripped = eq_round_tripped.validate(
                     reports_3_0_0.RareDiseaseExitQuestionnaire, eq_round_tripped.toJsonDict())
                 differ = self.migration_runner.diff_round_tripped(
                     eq, eq_round_tripped, ignore_fields=[])
-                RealRoundTripperRd.log_case("EQ", case_id, version, '3.0.0', differ, is_valid,
-                                            is_valid_round_tripped)
+                RealRoundTripperRd.log_case("EQ", case_id, case_version, model_version, differ, is_valid,
+                                            is_valid_round_tripped, run_time)
             except MigrationError as e:
-                RealRoundTripperRd.log("MIGRATION_ERROR", "EQ", '3.0.0', case_id, version, e.message)
+                RealRoundTripperRd.log("MIGRATION_ERROR", "EQ", '3.0.0', case_id, case_version, e.message)
+            except ValueError as e:
+                RealRoundTripperRd.log("INVALID_SCHEMA", "EQ", '3.0.0', case_id, case_version, e.message)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ elif target_version == '3':
 else:
     raise ValueError("Not supported python version {}".format(target_version))
 
-VERSION = "7.1.9"
+VERSION = "7.1.10"
 setup(
     name='GelReportModels',
     version=VERSION,


### PR DESCRIPTION
## Minor changes

* Improve performance of migrations by:
    - Avoid unnecessary validations
    - Improve performance of `toJsonDict()`
    - Avoid calling `fromJsonDict()` recursively
* Fix some issues checking equality of cancer actions in round trip migrations
* In `MigrationHelpers` choice the right version when an entity validates against multiple version by looking at the version control 
