### PR TITLE
Hacky fix to data model name clash

### DIFF
--- a/schemas/IDLs/org.gel.models.report.avro/6.0.0/CommonInterpreted.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.0.0/CommonInterpreted.avdl
@@ -128,7 +128,11 @@ enum TimeUnit {years, months, weeks, days, hours, minutes, na}
         uncertain_significance
     }
 
-    enum DrugResponseClassification {
+    /**
+    This is to avoid a naming conflict.
+    There is an equivalent change in biotools that will mean we can remove this in the next version.
+    */
+    enum GelDrugResponseClassification {
         altered_sensitivity,
         reduced_sensitivity,
         increased_sensitivity,

--- a/schemas/IDLs/org.gel.models.report.avro/6.0.0/CommonInterpreted.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.0.0/CommonInterpreted.avdl
@@ -529,7 +529,7 @@ see Expanded Access Data Element Definitions).
         /**
         associated effect of the drug
         */
-        DrugResponseClassification drugResponseClassification;
+        GelDrugResponseClassification drugResponseClassification;
     }
 
     record Therapy{
@@ -744,7 +744,7 @@ see Expanded Access Data Element Definitions).
         /**
         The variant's pharmacogenomics classification.
         */
-        union{null, DrugResponseClassification} drugResponseClassification;
+        union{null, GelDrugResponseClassification} drugResponseClassification;
         /**
         The variant's trait association.
         */


### PR DESCRIPTION
There is an equivalent change in biotools that will mean we can remove this in the next version.