### PR TITLE
IP-3251: Add extra id fields so we can tell the id of a variant more often

### DIFF
--- a/schemas/IDLs/org.gel.models.cva.avro/1.3.0/CvaVariant.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.3.0/CvaVariant.avdl
@@ -66,6 +66,10 @@ protocol VariantProtocol {
     */
     record Variant {
         /**
+        The id of the variant
+        **/
+        union {null, string} id;
+        /**
         A list of variant representations
         */
         array<VariantRepresentation> variants = [];

--- a/schemas/IDLs/org.gel.models.cva.avro/1.3.0/ReportEvent.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.3.0/ReportEvent.avdl
@@ -187,6 +187,14 @@ Duplication of the prior fields is not be supported.
         */
         union {null, ReportEventQuestionnaireCancer} reportEventQuestionnaireCancer;
         /**
+        The variant ids
+        **/
+        array<string> variantIds = [];
+        /**
+        The id of the combined compound hetrozygous variants if present
+        **/
+        union {null, string} compoundHetrozygousVariantId;
+        /**
         The observed variants
         */
         array<ObservedVariant> observedVariants = [];


### PR DESCRIPTION
(in CVA only)