### PR TITLE
feature/initialise-empty-ct: variantConsequences field within report …

### DIFF
--- a/schemas/IDLs/org.gel.models.report.avro/6.0.0/CommonInterpreted.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.0.0/CommonInterpreted.avdl
@@ -824,7 +824,7 @@ see Expanded Access Data Element Definitions).
         /**
         Sequence Ontology terms for relevant consequence types for this report event
         */
-        array<VariantConsequence> variantConsequences;
+        array<VariantConsequence> variantConsequences = [];
 
         /**
         The panel of genes to which this report corresponds


### PR DESCRIPTION

variantConsequences field within ReportEvent objects was raising problems downstream Tiering.

This field might actually be empty and therefore is now initialised to an empty list by default.