### PR TITLE
Use list for selection events in FamilySelection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.gel.models</groupId>
     <artifactId>gel-models</artifactId>
-    <version>7.3.3</version>
+    <version>7.3.4</version>
     <packaging>${p.type}</packaging>
 
     <properties>

--- a/schemas/IDLs/org.gel.models.metrics.avro/1.2.1/FamilySelection.avdl
+++ b/schemas/IDLs/org.gel.models.metrics.avro/1.2.1/FamilySelection.avdl
@@ -4,8 +4,6 @@ This protocol defines the metrics we calculate and store for family selection in
 */
 protocol FamilySelection {
 
-    import idl "CommonParticipant.avdl";
-
     /**
     Definitions
     ========================================
@@ -43,6 +41,7 @@ protocol FamilySelection {
     */
     enum SelectionFlag {
         UNUSUAL_SEX_KARYOTYPE,
+        UNKNOWN_PHENOTYPIC_SEX,
         INCORRECT_OR_DISCORDANT_SEX_KARYOTYPE,
         INFERRED_GENETIC_AND_REPORTED_SEX_DISCORDANT
     }

--- a/schemas/IDLs/org.gel.models.metrics.avro/1.2.1/FamilySelection.avdl
+++ b/schemas/IDLs/org.gel.models.metrics.avro/1.2.1/FamilySelection.avdl
@@ -53,6 +53,10 @@ protocol FamilySelection {
     */
     record SelectionEvent {
         /**
+        Name of the test performed during this event
+        */
+        SelectionTest name;
+        /**
         Whether the test passed or failed
         */
         boolean passed;
@@ -73,10 +77,9 @@ protocol FamilySelection {
     */
     record FamilySelection {
         /**
-        Dictionary of SelectionEvents, one for each test performed
-        Keys should be Test enum values
+        List of SelectionEvents, one for each test performed
         */
-        map<SelectionEvent> events;
+        array<SelectionEvent> events;
         /**
         Overall family selection status
         */

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ elif target_version == '3':
 else:
     raise ValueError("Not supported python version {}".format(target_version))
 
-VERSION = "7.3.3"
+VERSION = "7.3.4"
 
 # read the contents of your README file
 this_directory = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
* Map is not supported as a type in OpenCGA, so use array/list instead
* Added extra flag enum value to FamilySelection also
* Bump version to 7.3.4