### PR TITLE
fix: removes ig version from additional findings clinical report model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
 
     <groupId>org.gel.models</groupId>
     <artifactId>gel-models</artifactId>
-    <version>7.4.3</version>
+    <version>7.5.2</version>
     <packaging>${p.type}</packaging>
 
     <properties>
-        <models.version>7.4</models.version>
+        <models.version>7.5</models.version>
         <opencb.models.version>1.3.0</opencb.models.version>
         <opencb.models.package>org.opencb.biodata.models.variant.avro</opencb.models.package>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/schemas/IDLs/org.gel.models.report.avro/6.1.0/ClinicalReport.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.1.0/ClinicalReport.avdl
@@ -115,11 +115,6 @@ protocol ClinicalReports {
         string participantId;
 
         /**
-        This is the version of the latest interpreted genome as an identifier (i.e.: second number in 12345678-1)
-        */
-        int interpretedGenomeVersion;
-
-        /**
         Date of this report in format YYYY-MM-DD
         */
         string reportingDate;

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ elif target_version == '3':
 else:
     raise ValueError("Not supported python version {}".format(target_version))
 
-VERSION = "7.4.3"
+VERSION = "7.5.2"
 
 # read the contents of your README file
 this_directory = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION

- Removes Interpreted Genome version from AdditionalFindingsClinicalReport model
- Bumps version from 7.5.1 --> 7.5.2