### PR TITLE
GRM-29 - Variant Interpretation Log no Evidence field

### DIFF
--- a/builds.json
+++ b/builds.json
@@ -2,6 +2,68 @@
   "builds" :
   [
     {
+      "version": "7.8",
+      "packages": [
+        {
+          "package": "org.ga4gh.models",
+          "python_package": "ga4gh",
+          "version": "3.1.0",
+          "dependencies": []
+        },
+        {
+          "package": "org.gel.models.metrics.avro",
+          "python_package": "metrics",
+          "version": "1.2.2",
+          "dependencies": [
+            "org.gel.models.participant.avro"
+          ]
+        },
+        {
+          "package": "org.gel.models.participant.avro",
+          "python_package": "participant",
+          "version": "1.3.0",
+          "dependencies": []
+        },
+        {
+          "package": "org.gel.models.report.avro",
+          "python_package": "reports",
+          "version": "6.2.0",
+          "dependencies": [
+            "org.gel.models.participant.avro"
+          ]
+        },
+        {
+          "package": "org.gel.models.system.avro",
+          "python_package": "system",
+          "version": "0.1.0",
+          "dependencies": []
+        },
+        {
+          "package": "org.opencb.biodata.models.variant.avro",
+          "python_package": "opencb",
+          "version": "1.3.0",
+          "dependencies": []
+        },
+        {
+          "package": "org.gel.models.coverage.avro",
+          "python_package": "coverage",
+          "version": "0.1.0",
+          "dependencies": []
+        },
+        {
+          "package": "org.gel.models.cva.avro",
+          "python_package": "cva",
+          "version": "1.5.2",
+          "dependencies": [
+            "org.gel.models.report.avro",
+            "org.gel.models.participant.avro",
+            "org.gel.models.system.avro",
+            "org.opencb.biodata.models.variant.avro"
+          ]
+        }
+      ]
+    },
+    {
       "version": "7.7",
       "packages": [
         {

--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
 
     <groupId>org.gel.models</groupId>
     <artifactId>gel-models</artifactId>
-    <version>7.7.0</version>
+    <version>7.8.0</version>
     <packaging>${p.type}</packaging>
 
     <properties>
-        <models.version>7.7</models.version>
+        <models.version>7.8</models.version>
         <opencb.models.version>1.3.0</opencb.models.version>
         <opencb.models.package>org.opencb.biodata.models.variant.avro</opencb.models.package>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/protocols/resources/builds.json
+++ b/protocols/resources/builds.json
@@ -2,6 +2,68 @@
   "builds" :
   [
     {
+      "version": "7.8",
+      "packages": [
+        {
+          "package": "org.ga4gh.models",
+          "python_package": "ga4gh",
+          "version": "3.1.0",
+          "dependencies": []
+        },
+        {
+          "package": "org.gel.models.metrics.avro",
+          "python_package": "metrics",
+          "version": "1.2.2",
+          "dependencies": [
+            "org.gel.models.participant.avro"
+          ]
+        },
+        {
+          "package": "org.gel.models.participant.avro",
+          "python_package": "participant",
+          "version": "1.3.0",
+          "dependencies": []
+        },
+        {
+          "package": "org.gel.models.report.avro",
+          "python_package": "reports",
+          "version": "6.2.0",
+          "dependencies": [
+            "org.gel.models.participant.avro"
+          ]
+        },
+        {
+          "package": "org.gel.models.system.avro",
+          "python_package": "system",
+          "version": "0.1.0",
+          "dependencies": []
+        },
+        {
+          "package": "org.opencb.biodata.models.variant.avro",
+          "python_package": "opencb",
+          "version": "1.3.0",
+          "dependencies": []
+        },
+        {
+          "package": "org.gel.models.coverage.avro",
+          "python_package": "coverage",
+          "version": "0.1.0",
+          "dependencies": []
+        },
+        {
+          "package": "org.gel.models.cva.avro",
+          "python_package": "cva",
+          "version": "1.5.2",
+          "dependencies": [
+            "org.gel.models.report.avro",
+            "org.gel.models.participant.avro",
+            "org.gel.models.system.avro",
+            "org.opencb.biodata.models.variant.avro"
+          ]
+        }
+      ]
+    },
+    {
       "version": "7.7",
       "packages": [
         {

--- a/protocols/tests/test_util/test_dependency_manager.py
+++ b/protocols/tests/test_util/test_dependency_manager.py
@@ -5,7 +5,7 @@ import protocols.reports_6_0_0
 import protocols.reports_5_0_0
 import protocols.reports_4_2_0
 import protocols.reports_4_0_0
-import protocols.reports_6_1_1
+import protocols.reports_6_2_0
 
 
 class TestDependencyManager(TestCase):
@@ -15,7 +15,7 @@ class TestDependencyManager(TestCase):
         assert dependency_manager is not None
         latest_dependencies = dependency_manager.get_latest_version_dependencies()
         assert isinstance(latest_dependencies, dict)
-        assert latest_dependencies["org.gel.models.report.avro"] == protocols.reports_6_1_1
+        assert latest_dependencies["org.gel.models.report.avro"] == protocols.reports_6_2_0
         dependencies_400 = dependency_manager.get_version_dependencies("4.0.0")
         assert isinstance(dependencies_400, dict)
         assert dependencies_400["org.gel.models.report.avro"] == protocols.reports_4_0_0

--- a/protocols/util/dependency_manager.py
+++ b/protocols/util/dependency_manager.py
@@ -4,6 +4,7 @@ import os.path
 import inspect
 from protocols.util.singleton import Singleton
 
+VERSION_78 = "7.8"
 VERSION_77 = "7.7"
 VERSION_76 = "7.6"
 VERSION_74 = "7.4"

--- a/schemas/IDLs/org.gel.models.cva.avro/1.5.2/Comment.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.5.2/Comment.avdl
@@ -1,0 +1,22 @@
+@namespace("org.gel.models.cva.avro")
+
+protocol CommentProtocol {
+
+    /**
+    A generic comment.
+    */
+    record Comment {
+        /**
+        The text of the comment
+        */
+        string text;
+        /**
+        Date in format yyyyMMddhhmm
+        */
+        string `date`;
+        /**
+        The author of the curation event
+        */
+        string userid;
+    }
+}

--- a/schemas/IDLs/org.gel.models.cva.avro/1.5.2/CvaEvidence.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.5.2/CvaEvidence.avdl
@@ -1,0 +1,159 @@
+@namespace("org.gel.models.cva.avro")
+
+protocol EvidencesProtocol {
+
+    // CVA references
+    import idl "Comment.avdl";
+    import idl "ReportEvent.avdl";
+    import idl "CvaVariant.avdl";
+    // Report models references
+    import idl "CommonInterpreted.avdl";
+    // OpenCB references
+    import idl "variant.avdl";
+    import idl "evidence.avdl";
+
+
+    /**
+    The curation record contains all information that might be stored from a curation event.
+    */
+    record Curation {
+        /**
+        The heritable phenotype to which the curation refers.
+        */
+        org.opencb.biodata.models.variant.avro.HeritableTrait heritableTrait;
+        /**
+        The transcript to which the curation refers
+        */
+        union {null, org.opencb.biodata.models.variant.avro.GenomicFeature} genomicFeature;
+        /**
+        The assembly to which the curation refers
+        */
+        union {null, org.gel.models.report.avro.Assembly} assembly;
+        /**
+        The variant's classification.
+        */
+        union{null, org.opencb.biodata.models.variant.avro.VariantClassification} variantClassification;
+        /**
+        The curation confidence.
+        */
+        union {null, org.opencb.biodata.models.variant.avro.Confidence} confidence;
+        /**
+        The automatic consistency status. The value is automatically inferred from evidences.
+        */
+        org.opencb.biodata.models.variant.avro.ConsistencyStatus automaticConsistencyStatus;
+        /**
+        The manual consistency status. The value is optionally provided by a curator.
+        */
+        union {null, org.opencb.biodata.models.variant.avro.ConsistencyStatus} manualConsistencyStatus;
+        /**
+        The penetrance of the phenotype for this genotype. Value in the range [0, 1]
+        */
+        union {null, org.opencb.biodata.models.variant.avro.Penetrance} penetrance;
+        /**
+        Variable expressivity of a given phenotype for the same genotype
+        */
+        union {null, boolean} variableExpressivity;
+        /**
+        Can this variant be reported as a secondary finding?
+        */
+        union {null, boolean} reportableAsSecondaryFinding;
+        /**
+        Is this variant actionable?
+        */
+        union {null, boolean} actionable;
+        /**
+        Confirmation flag to support two-step curation
+        */
+        union {null, boolean} confirmed;
+        /**
+        A list of additional properties in the form name-value.
+        */
+        array<org.opencb.biodata.models.variant.avro.Property> additionalProperties = [];
+        /**
+        Bibliography
+        */
+        array<string> bibliography = [];
+    }
+
+    /**
+    A curation history entry, stores previous and new curation state, the date of the change and the author.
+    */
+    record CurationHistoryEntry {
+        /**
+        Date in format yyyyMMddhhmm
+        */
+        string `date`;
+        /**
+        The current curation at date
+        */
+        Curation curation;
+        /**
+        The author of the curation event
+        */
+        string userId;
+    }
+
+    /**
+    A curation for a known variant contains the current curation state and the curation history.
+    Must be unique by `curation.phenotype` and `curation.inheritanceMode`.
+    */
+    record CurationEntry {
+        /**
+        Date in format yyyyMMddhhmm
+        */
+        string `date`;
+        /**
+        The current curation state
+        */
+        Curation curation;
+        /**
+        The curation history
+        */
+        array<CurationHistoryEntry> history = [];
+        /**
+        Comments on the curation event
+        */
+        array<Comment> comments = [];
+    }
+
+    /*
+    An enum of property names.
+    */
+    /*
+    enum PropertyName {
+        OBI_0001617,                            // pubmed id, http://purl.obolibrary.org/obo/OBI_0001617
+        SIO_001066,                             // study, http://semanticscience.org/resource/SIO_001066
+        SIO_001315,                             // author list, http://semanticscience.org/resource/SIO_001315
+        SIO_000160,                             // journal, http://semanticscience.org/resource/SIO_000160
+        STATO_0000088,                          // study group population size, http://purl.obolibrary.org/obo/STATO_0000088
+        OBI_0000175,                            // pvalue,http://purl.obolibrary.org/obo/OBI_0000175
+        OBI_0001265,                            // FWER_adjusted_pvalue, http://purl.obolibrary.org/obo/OBI_0001265
+        OBI_0001442,                            // qvalue, http://purl.obolibrary.org/obo/OBI_0001442
+        STATO_0000200,                          // study_power, http://purl.obolibrary.org/obo/STATO_0000200
+        STATO_0000053,                          //false_positive_report_probability, http://purl.obolibrary.org/obo/STATO_0000053
+        STATO_0000182,                          //odds_ratio, http://purl.obolibrary.org/obo/STATO_0000182
+        STATO_0000245,                          //relative_risk, http://purl.obolibrary.org/obo/STATO_0000245
+        STATO_0000196,                          //confidence_interval, http://purl.obolibrary.org/obo/STATO_0000196
+        OBI_0000789,                           //OBI_0000789, http://purl.obolibrary.org/obo/OBI_0000789
+        STATO_0000254                           //population_allele_frequency, http://purl.obolibrary.org/obo/STATO_0000254
+    }
+    */
+
+    /**
+    A curation and the variants coordinates to which it corresponds
+    */
+    record CurationAndVariants {
+        VariantsCoordinates variantsCoordinates;
+        Curation curation;
+    }
+
+    /**
+    An evidence entry and the variants coordinates to which it corresponds
+    */
+    record EvidenceEntryAndVariants {
+        VariantsCoordinates variantsCoordinates;
+        union {null, VariantsCoordinates} markersCoordinates;
+        org.opencb.biodata.models.variant.avro.EvidenceEntry evidenceEntry;
+        union {null, org.gel.models.report.avro.Actions} actions;
+    }
+}

--- a/schemas/IDLs/org.gel.models.cva.avro/1.5.2/CvaVariant.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.5.2/CvaVariant.avdl
@@ -1,0 +1,81 @@
+@namespace("org.gel.models.cva.avro")
+
+protocol VariantProtocol {
+
+    // OpenCB references
+    import idl "variant.avdl";
+    // Report models references
+    import idl "CommonInterpreted.avdl";
+
+    /**
+    A variant represented in a given assembly
+    */
+    record VariantRepresentation {
+        /**
+        The assembly on which this variant is represented
+        */
+        org.gel.models.report.avro.Assembly assembly;
+        /**
+        The annotator software version
+        */
+        union {null, string} annotatorVersion;
+        /**
+        The annotator data version
+        */
+        union {null, string} annotationsVersion;
+        /**
+        Small variant coordinates if this is a small variant
+        */
+        union {null, org.gel.models.report.avro.VariantCoordinates} smallVariantCoordinates;
+        /**
+        Structural variant coordinates if this is a structural variant
+        */
+        union {null, org.gel.models.report.avro.Coordinates} structuralVariantCoordinates;
+        /**
+        Small Variant Type
+        */
+        union {null, org.opencb.biodata.models.variant.avro.VariantType} smallVariantType;
+        /**
+        Structural Variant Type as would appear in VCF
+        */
+        union {null, org.gel.models.report.avro.StructuralVariantType} variantType;
+        /**
+        Left insertion sequence
+        */
+        union {null, string} leftInsSeq;
+        /**
+        Right insertion sequence
+        */
+        union {null, string} rightInsSeq;
+        /**
+        Short Tandem Repeat reference data
+        */
+        union {null, org.gel.models.report.avro.ShortTandemRepeatReferenceData} shortTandemRepeatReferenceData;
+        /**
+        Chromosomal rearrangements breakpoints
+        */
+        union {null, array<org.gel.models.report.avro.BreakPoint>} breakpoints;
+        /**
+        Chromosomal rearrangement
+        */
+        union {null, array<org.gel.models.report.avro.Rearrangement>} rearrangement;
+        /**
+        Variant annotation
+        */
+        union {null, org.opencb.biodata.models.variant.avro.VariantAnnotation } annotation;
+    }
+
+    /**
+    The map of variants in the different assemblies
+    */
+    record Variant {
+        /**
+        The id of the variant
+        **/
+        string id;
+        /**
+        A list of variant representations
+        */
+        array<VariantRepresentation> variants = [];
+    }
+}

--- a/schemas/IDLs/org.gel.models.cva.avro/1.5.2/DataIntake.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.5.2/DataIntake.avdl
@@ -1,0 +1,319 @@
+@namespace("org.gel.models.cva.avro")
+
+/**
+The DataIntakeProtocol defines two records for injecting report events into CVA:
+
+   - InterpretedGenomeInject
+   - ClinicalReportInject
+
+The above entities contain either an InterpretedGenome or a ClinicalReport that have list of variants,
+having themselves lists of report events. The variants will go through the variant ingestion pipeline,
+normalised, checked against the reference genome for validity and lifted over.
+
+The DataIntakeProtocol defined two records to inject exit questionnaires into CVA:
+
+    - ExitQuestionnaireInjectRD
+    - ExitQuestionnaireInjectCancer
+
+The exit questionnaires are transformed into a report event for storage in CVA. Variants are also
+processed through the variant ingestion pipeline as described above.
+
+The DataIntakeProtocol defines two records for injecting sample information into CVA:
+
+    - PedigreeInject
+    - CancerParticipantInject
+
+Pedigree and cancer participant data are stored in ad hoc collections and the most relevant bits of
+information (e.g.: proband present HPO terms) are used to annotate the cases.
+
+When any of these entities is pushed to CVA, a Transaction will be created and processing will happen
+asynchronously. Successful push does not imply successful processing.
+
+*/
+protocol DataIntakeProtocol {
+
+    import idl "CvaVariant.avdl";
+    import idl "CvaEvidence.avdl";
+    import idl "InterpretedGenome.avdl";
+    import idl "ClinicalReport.avdl";
+    import idl "ExitQuestionnaire.avdl";
+    import idl "RDParticipant.avdl";
+    import idl "CancerParticipant.avdl";
+    import idl "Ngis.avdl";
+    import idl "VariantInterpretationLog.avdl";
+
+    /**
+    Predefined authors.
+
+* `tiering`: the author for tiered report events
+* `clinical`: the author for pedigrees and cancer participants
+
+    Other data will have custom authors corresponding to interpretation services or to clinicians.
+    */
+    enum Authors {
+        tiering,
+        clinical
+    }
+
+    enum Category {
+        HundredK,
+        NGIS
+    }
+
+    /**
+    An organisation which may own or be assigned to a case
+    */
+    record Organisation {
+        /**
+        ODS code
+        */
+        string ods;
+        /**
+        The GMC name
+        */
+        union {null, string} gmc;
+        /**
+        The site name
+        */
+        union {null, string} site;
+    }
+
+    /**
+    Metadata about injected data
+    */
+    record InjectionMetadata {
+        /**
+        Report avro models version
+        */
+        string reportModelVersion;
+        /**
+        The entity identifier
+        */
+        string id;
+        /**
+        The entity version. This is a correlative number being the highest value the latest version.
+        */
+        int version;
+        /**
+        The case identifier
+        */
+        string caseId;
+        /**
+        The case version. This is a correlative number being the highest value the latest version.
+        */
+        int caseVersion;
+        /**
+        The family identifier
+        */
+        string groupId;
+        /**
+        The cohort identifier (the same family can have several cohorts)
+        */
+        string cohortId;
+        /**
+        The author of the ReportedVariant, either tiering, exomiser, a given cip (e.g.: omicia) or a given GMCs user name
+        */
+        string author;
+        /**
+        The author version of the ReportedVariant, either tiering, exomiser or a given cip. Only applicable for automated processes.
+        */
+        union {null, string} authorVersion;
+        /**
+        The assembly to which the variants refer
+        */
+        union {null, org.gel.models.report.avro.Assembly} assembly;
+        /**
+        The 100K Genomes program to which the reported variant belongs.
+        */
+        org.gel.models.report.avro.Program program;
+        /**
+        The category to which the case belongs.
+        */
+        Category category;
+        /**
+        The creation date of the case (ISO-8601)
+        */
+        union {null, string} caseCreationDate;
+        /**
+        The last modified date of the case (ISO-8601)
+        */
+        union {null, string} caseLastModifiedDate;
+        /**
+        The organisation responsible for this payload (Pedigree and CancerParticipant will correspond to the case
+        owner and the ClinicalReport will correspond to the case assignee)
+        */
+        union {null, Organisation} organisation;
+        /**
+        The NGIS organisation responsible for this payload
+        */
+        union {null, org.gel.models.participant.avro.OrganisationNgis} organisationNgis;
+        /**
+        Test unique identifier (only sent for NGIS cases)
+        */
+        union {null, string} referralTestId;
+        /**
+        Referral unique identifier (only sent for NGIS cases)
+        */
+        union {null, string} referralId;
+    }
+
+    /**
+    Record for tiered variant injection as part of the data intake for CVA
+    */
+    record InterpretedGenomeInject {
+        /**
+        Metadata on the report events in the interpreted genome
+        */
+        InjectionMetadata metadata;
+        /**
+        Rare disease Interpreted Genome
+        */
+        org.gel.models.report.avro.InterpretedGenome interpretedGenome;
+    }
+
+    /**
+    Record for candidate variant injection as part of the data intake for CVA
+    */
+    record ClinicalReportInject {
+        /**
+        Metadata on the report events in the clinical report
+        */
+        InjectionMetadata metadata;
+        /**
+        Information that Genomics England needs to generate a clinical report
+        */
+        org.gel.models.report.avro.ClinicalReport clinicalReport;
+    }
+
+    /**
+    This is an entity to hold the information in org.gel.models.report.avro.RareDiseaseExitQuestionnaire in
+    a form compatible with CVA.
+    */
+    record ExitQuestionnaireRD {
+        /**
+        The list variant group level questions (this list will be unwinded during ingestion)
+        */
+        array<ReportedVariantQuestionnaireRD> variants;
+    }
+
+    /**
+    Record for exit questionnaire injection as part of the data intake for CVA
+    */
+    record ExitQuestionnaireInjectRD {
+        /**
+        Metadata on the exit questionnaire
+        */
+        InjectionMetadata metadata;
+        /**
+        Exit questionnaire for rare disease
+        */
+        union {null, ExitQuestionnaireRD} exitQuestionnaireRd;
+        /**
+        Rare disease exit questionnaire
+        */
+        union {null, org.gel.models.report.avro.RareDiseaseExitQuestionnaire} rareDiseaseExitQuestionnaire;
+    }
+
+    /**
+    Record for tiered variant injection as part of the data intake for CVA
+    */
+    record PedigreeInjectRD {
+        /**
+        Metadata on the report events in the clinical report
+        */
+        InjectionMetadata metadata;
+        /**
+        Rare disease pedigree
+        */
+        org.gel.models.participant.avro.Pedigree pedigree;
+    }
+
+    /**
+    A record holding the somatic variant level questions for a single variant together with its normalized variant coordinates
+    */
+    record CancerSomaticVariantLevelQuestionnaire {
+        /**
+        The coordinates of a given variant: assembly, chromosome, position, reference and alternate
+        */
+        org.gel.models.report.avro.VariantCoordinates variantCoordinates;
+        /**
+        The questions at variant level
+        */
+        org.gel.models.report.avro.CancerSomaticVariantLevelQuestions variantLevelQuestions;
+    }
+
+    /**
+    A record holding the germline variant level questions for a single variant together with its normalized variant coordinates
+    */
+    record CancerGermlineVariantLevelQuestionnaire {
+        /**
+        The coordinates of a given variant: assembly, chromosome, position, reference and alternate
+        */
+        org.gel.models.report.avro.VariantCoordinates variantCoordinates;
+        /**
+        The questions at variant level
+        */
+        org.gel.models.report.avro.CancerGermlineVariantLevelQuestions variantLevelQuestions;
+    }
+
+    /**
+    Record for cancer exit questionnaire injection as part of the data intake for CVA
+    */
+    record ExitQuestionnaireInjectCancer {
+        /**
+        Metadata on the report events in the clinical report
+        */
+        InjectionMetadata metadata;
+        /**
+        Case level questions
+        */
+        org.gel.models.report.avro.CancerCaseLevelQuestions cancercaseLevelQuestions;
+        /**
+        Cancer somatic exit questionnaire
+        */
+        array<CancerSomaticVariantLevelQuestionnaire> cancerSomaticExitQuestionnaires;
+        /**
+        Germline somatic exit questionnaire
+        */
+        array<CancerGermlineVariantLevelQuestionnaire> cancerGermlineExitQuestionnaires;
+        /**
+        Please enter any additional comments you may have about the case here.
+        */
+        union {null, string} additionalComments;
+        /**
+        Other actionable variants or entities.
+        Please provide other (potentially) actionable entities: e.g domain 3 small variants,
+        SV/CNV, mutational signatures, mutational burden
+        */
+        union {null, array<org.gel.models.report.avro.AdditionalVariantsQuestions>} otherActionableVariants;
+    }
+
+    /**
+    Record for tiered variant injection as part of the data intake for CVA
+    */
+    record CancerParticipantInject {
+        /**
+        Metadata on the report events in the clinical report
+        */
+        InjectionMetadata metadata;
+        /**
+        The information on the cancer participant
+        */
+        org.gel.models.participant.avro.CancerParticipant participant;
+    }
+
+    /**
+    Record for Variant Interpretation Log as part of data intake for CVA
+    */
+    record VariantInterpretationLogInject {
+        /**
+        Metadata on the variant interpretation log
+        */
+        InjectionMetadata metadata;
+        /**
+        The variant interpretation log
+        */
+        org.gel.models.report.avro.VariantInterpretationLog variantInterpretationLog;
+    }
+
+}

--- a/schemas/IDLs/org.gel.models.cva.avro/1.5.2/ObservedVariant.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.5.2/ObservedVariant.avdl
@@ -1,0 +1,53 @@
+@namespace("org.gel.models.cva.avro")
+
+protocol ObservedVariantProtocol {
+
+    // CVA references
+    import idl "CvaVariant.avdl";
+    // Report models references
+    import idl "CommonInterpreted.avdl";
+    import idl "CommonParticipant.avdl";
+    // OpenCB references
+    import idl "variant.avdl";
+    import idl "evidence.avdl";
+
+    /**
+A variant observed in a specific sample.
+The information about the observation is contained within a CalledGenotype, it is linked to one abstract Variant.
+
+Every ObservedVariant is uniquely identified by:
+
+* sample id
+* variant identifier (being a variant identifier formed by chromosome + position + reference + alternate)
+
+Duplication of the prior fields is not to be supported.
+    */
+    record ObservedVariant {
+        /**
+        The registration date
+        */
+        string `date`;
+        /**
+        The assembly to which the variant refers
+        */
+        org.gel.models.report.avro.Assembly assembly;
+        /**
+        The abstract variant
+        */
+        Variant variant;
+
+        /**
+        Variant call
+        */
+        union {null, org.gel.models.report.avro.VariantCall} variantCall;
+
+        /**
+        Validation flag
+        */
+        boolean validated = false;
+        /**
+        A list of additional properties in the form name-value.
+        */
+        array<org.opencb.biodata.models.variant.avro.Property> additionalProperties = [];
+    }
+}

--- a/schemas/IDLs/org.gel.models.cva.avro/1.5.2/ReportEvent.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.5.2/ReportEvent.avdl
@@ -1,0 +1,219 @@
+@namespace("org.gel.models.cva.avro")
+
+protocol ReportEventProtocol {
+
+    // CVA references
+    import idl "Comment.avdl";
+    import idl "ObservedVariant.avdl";
+    // Report models references
+    import idl "CommonInterpreted.avdl";
+    import idl "CommonRequest.avdl";
+    import idl "ExitQuestionnaire.avdl";
+    import idl "evidence.avdl";
+
+    /**
+    The type of the ReportedVariant
+    
+* reported: this is a variant reported by a GMC
+* candidate: this is a variant suggested by a Clinical Interpretation Partner
+* tiered: this is a variant highlighted by the tiering process
+* other: any other source
+    */
+    enum ReportEventType {
+        reported,
+        candidate,
+        genomics_england_tiering,
+        questionnaire,
+        other
+    }
+
+    /**
+    The report event for a questionnaire in RD.
+    */
+    record ReportEventQuestionnaireRD {
+        /**
+        The identifier used to group variants together
+        */
+        union {null, int} groupOfVariants;
+        /**
+        The variant level questions
+        */
+        org.gel.models.report.avro.VariantLevelQuestions variantLevelQuestions;
+        /**
+        The variant group level questions
+        */
+        org.gel.models.report.avro.VariantGroupLevelQuestions variantGroupLevelQuestions;
+        /**
+        The family level questions
+        */
+        org.gel.models.report.avro.FamilyLevelQuestions familyLevelQuestions;
+    }
+
+    /**
+    A list of variant coordinates
+    */
+    record VariantsCoordinates {
+        array<org.gel.models.report.avro.VariantCoordinates> variants = [];
+    }
+
+    /**
+    This object holds all questionnaire questions together with normalized variant coordinates.
+    */
+    record ReportedVariantQuestionnaireRD {
+        /**
+        The normalized representation of variants coordinates
+        */
+        org.gel.models.report.avro.VariantCoordinates variantCoordinates;
+        /**
+        The questionnaire report event
+        */
+        ReportEventQuestionnaireRD reportEvent;
+    }
+
+    record ReportEventQuestionnaireCancer {
+        /**
+        The somatic variant level questions for the cancer program
+        */
+        union {null, org.gel.models.report.avro.CancerSomaticVariantLevelQuestions} cancerSomaticVariantLevelQuestions;
+        /**
+        The variant group level questions for the cancer program
+        */
+        union {null, org.gel.models.report.avro.CancerGermlineVariantLevelQuestions} cancerGermlineVariantLevelQuestions;
+        /**
+        Cancer case level questions
+        */
+        org.gel.models.report.avro.CancerCaseLevelQuestions cancercaseLevelQuestions;
+        /**
+        Please enter any additional comments you may have about the case here.
+        */
+        union {null, string} additionalComments;
+        /**
+        Other actionable variants or entities.
+        Please provide other (potentially) actionable entities: e.g domain 3 small variants,
+        SV/CNV, mutational signatures, mutational burden
+        */
+        union {null, array<org.gel.models.report.avro.AdditionalVariantsQuestions>} otherActionableVariants;
+    }
+
+    /**
+A variant or variants (i.e.: composite heterozygous) reported by any manual or automated means.
+The information about the report is contained within a ReportEvent, it is linked to one or more
+ObservedVariant.
+
+Every ReportedVariant is uniquely identified by:
+
+* report event id
+* report model version
+* id
+* version
+* family id
+* cohort id
+* variants identifiers (being a variant identifier formed by chromosome + position + reference + alternate)
+
+Duplication of the prior fields is not be supported.
+    */
+    record ReportEventEntry {
+        /**
+        Report avro models version
+        */
+        string reportModelVersion;
+        /**
+        The identifier for the higher level entity, either InterpretationRequest, InterpretedGenome or ClinicalReport
+        */
+        string id;
+        /**
+        The version for the higher level entity, either InterpretationRequest, InterpretedGenome or ClinicalReport
+        */
+        int version;
+        /**
+        A flag to indicate that this report event corresponds to the latest interpretation of the same case as defined by the highest `version`
+        */
+        union {null, boolean} latest;
+        /**
+        The identifier for the InterpretationRequest
+        */
+        union {null, string} caseId;
+        /**
+        The version for the InterpretationRequest
+        */
+        union {null, int} caseVersion;
+        /**
+        The group identifier, either a family identifier for RD or a participant id for cancer
+        */
+        string groupId;
+        /**
+        The cohort identifier (the same family can have several cohorts)
+        */
+        string cohortId;
+        /**
+        Date in format yyyyMMddhhmm
+        */
+        string `date`;
+        /**
+        The author of the ReportedVariant, either tiering, exomiser, a given cip (e.g.: omicia) or a given GMCs user name
+        */
+        string author;
+        /**
+        The author version of the ReportedVariant, either tiering, exomiser or a given cip. Only applicable for automated processes.
+        */
+        union {null, string} authorVersion;
+        /**
+        Type of ReportedVariant
+        */
+        ReportEventType type;
+        /**
+        The 100K Genomes program to which the reported variant belongs.
+        */
+        org.gel.models.report.avro.Program program;
+        /**
+        Validation flag
+        */
+        boolean validated = false;
+        /**
+        The workspace. This field is used to control authorisation to
+        access each case.
+        */
+        array<string> workspace = [];
+        /**
+        The report event for the rare disease program
+        */
+        union {null, org.gel.models.report.avro.ReportEvent} reportEvent;
+        /**
+        The report event for the questionnaire reports in the rare disease program
+        */
+        union {null, ReportEventQuestionnaireRD} reportEventQuestionnaire;
+        /**
+        The report event for the questionnaire reports in the cancer program
+        */
+        union {null, ReportEventQuestionnaireCancer} reportEventQuestionnaireCancer;
+        /**
+        The variant id
+        **/
+        string variantId;
+        /**
+        The id of the combined compound heterozygous variants if present
+        **/
+        union {null, string} compoundHeterozygousVariantId;
+        /**
+        The abstract variant (NOTE: this should not be nullable once the Variant is removed from the list of
+        observed variants)
+        */
+        union {null, Variant} variant;
+        /**
+        The observed variants
+        */
+        array<ObservedVariant> observedVariants = [];
+        /**
+        Comments for this diagnostic event
+        */
+        array<Comment> comments = [];
+        /**
+        A list of additional properties in the form name-value.
+        */
+        array<org.opencb.biodata.models.variant.avro.Property> additionalProperties = [];
+        /**
+        Additional variant attributes
+        */
+        union {null, org.gel.models.report.avro.VariantAttributes } variantAttributes;
+    }
+}

--- a/schemas/IDLs/org.gel.models.cva.avro/1.5.2/Transactions.avdl
+++ b/schemas/IDLs/org.gel.models.cva.avro/1.5.2/Transactions.avdl
@@ -1,0 +1,167 @@
+@namespace("org.gel.models.cva.avro")
+
+protocol TransactionProtocol {
+
+    // CVA references
+    import idl "CvaVariant.avdl";
+    import idl "DataIntake.avdl";
+
+    /**
+    The transaction status:
+
+* PENDING: a transaction in the queue pending to be processed
+* BLOCKED: a transaction already being processed
+* PROCESSING: a transaction being processed (normalised, lifted over and annotated)
+* PERSISTING: a transaction being persisted in the database
+* BLOCKED: a transaction already being processed
+* DONE: a transaction has been successfully processed
+* CANCELLING: a transaction is being rolled back
+* CANCELLED: a transaction has been rolled back
+* ERROR: erroneous transaction that cannot be processed, nor retried (this is caused by reported variants already in the database)
+* ROLLBACK_ERROR: a transaction failed to roll back (this may leave the database in an inconsistent state)
+* DELETED: a transaction has been deleted by a user (same effect as CANCELLED but user triggered)
+
+    The happy path is PENDING -> BLOCKED -> PROCESSING -> PERSISTING -> DONE
+    */
+    enum TransactionStatus {
+        PENDING,
+        BLOCKED,
+        PROCESSING,
+        PERSISTING,
+        DONE,
+        CANCELLING,
+        CANCELLED,
+        ERROR,
+        ROLLBACK_ERROR,
+        DELETED
+    }
+
+    /**
+    Keeps track of a transaction status change
+    */
+    record TransactionStatusChange {
+        /**
+        The new transaction status
+        */
+        TransactionStatus to;
+        /**
+        A timestamp with the status change
+        */
+        string timestamp;
+        /**
+        A message
+        */
+        union {null,string} message;
+        /**
+        An error message in case the transaction ingestion failed
+        */
+        union {null, string} errorMessage;
+        /**
+        The stracktrace in case the transaction ingestion failed
+        */
+        union {null, string} stackTrace;
+        /**
+        The CVA version that processed the transaction
+        */
+        union {null, string} cvaVersion;
+    }
+
+    /**
+    Details about the content of a transaction and some logs.
+    */
+    record TransactionDetails {
+        /**
+        The type of the transaction (e.g.: org.gel.models.cva.avro.InterpretedGenomeInject)
+        */
+        string type;
+        /**
+        The number of elements contained in the transaction
+        */
+        int numberOfElements;
+        /**
+        Metadata on the injection data
+        */
+        InjectionMetadata metadata;
+        /**
+        Messages
+        */
+        array<TransactionStatusChange> history;
+    }
+
+    /**
+    Details about the transaction sender
+    */
+    record RequestDetails {
+        /**
+        IP address
+        */
+        union {null,string} ip;
+        /**
+        Hostname
+        */
+        union {null,string} host;
+        /**
+        Port
+        */
+        union {null,int} port;
+        /**
+        User
+        */
+        union {null,string} user;
+        /**
+        URI
+        */
+        union {null,string} uri;
+        /**
+        URL
+        */
+        union {null,string} url;
+        /**
+        Authentication type
+        */
+        union {null,string} authType;
+    }
+
+    /**
+    A transaction having all necessary data to process it into the database
+    */
+    record Transaction {
+        /**
+        The identifier of the transaction
+        */
+        string id;
+        /**
+        Timestamp of last transaction status modification
+        */
+        string lastModified;
+        /**
+        Transaction status
+        */
+        TransactionStatus status;
+        /**
+        The data to be ingested in CVA compressed
+        */
+        union {null, bytes} compressedData;
+        /**
+        A MD5 hash signature of the transaction used to discard identical requests.
+        To have a 50% chance of a collision by the birthday paradox we need 2**64 transactions
+        */
+        string requestSignature;
+        /**
+        Options to process the transaction
+        */
+        map<string> options;
+        /**
+        The number of milliseconds to process the transaction.
+        */
+        union {null, int} processingMilli;
+        /**
+        The details of a transaction
+        */
+        TransactionDetails transactionDetails;
+        /**
+        The details of a request
+        */
+        union {null, RequestDetails} requestDetails;
+    }
+}

--- a/schemas/IDLs/org.gel.models.report.avro/6.2.0/ClinicalReport.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.2.0/ClinicalReport.avdl
@@ -1,0 +1,184 @@
+@namespace("org.gel.models.report.avro")
+
+protocol ClinicalReports {
+
+    import idl "CommonInterpreted.avdl";
+    import idl "ReportVersionControl.avdl";
+
+    /**
+    A panel of genes and the specific disease that it assesses
+    */
+    record AdditionalAnalysisPanel {
+        /*
+        The specific disease
+        */
+        string specificDisease;
+        /*
+        The panel of genes
+        */
+        GenePanel panel;
+    }
+
+    /**
+    A clinical report. This holds the list of reported variants by an expert together with all
+    the relevant information that identify the case and how these conclusions were reached.
+    */
+    record ClinicalReport {
+        /**
+        This is the interpretation request identifier (i.e.: first number in 123-1)
+        */
+        string interpretationRequestId;
+
+        /**
+        This is the version of the interpretation request identifier (i.e.: second number in 123-1)
+        */
+        int interpretationRequestVersion;
+
+        /**
+        Date of this report in format YYYY-MM-DD
+        */
+        string reportingDate;
+
+        /**
+        Author of this report
+        */
+        string user;
+
+        /**
+        List of small reported variants
+        */
+        union {null, array<SmallVariant>} variants;
+
+        /**
+        List of simple structural reported variants (duplications, deletions, insertions, inversions, CNVs)
+        */
+        union {null, array<StructuralVariant>} structuralVariants;
+
+        /**
+        List of complex structural reported variants (chomosomal rearrangement)
+        */
+        union {null, array<ChromosomalRearrangement>} chromosomalRearrangements;
+
+        /**
+        List of short tandem repeat variants
+        */
+        union {null, array<ShortTandemRepeat>} shortTandemRepeats;
+
+        /**
+        List of uniparental disomies across all the individuals in this report
+        */
+        union {null, array<UniparentalDisomy>} uniparentalDisomies;
+
+        /**
+        List of inferred karyotypes across all the individuals in this report
+        */
+        union {null, array<Karyotype>} karyotypes;
+
+        /**
+        Summary of the interpretation, this should reflect the positive conclusions of this interpretation
+        */
+        string genomicInterpretation;
+
+        /**
+        The list of panels analysed to generate this report
+        */
+        union {null, array<AdditionalAnalysisPanel>} additionalAnalysisPanels;
+
+        /**
+        Supporting evidence (pubmed identifiers)
+        */
+        union {null, array<string>} references;
+
+        /**
+        This map contains the versions of the different databases used in the process, being the database names the
+        keys and the versions the values.
+        */
+        map<string> referenceDatabasesVersions;
+
+        /**
+        This map contains the versions of the different software systems used in the process, being the software
+        names the keys and the versions the values.
+        */
+        map<string> softwareVersions;
+    }
+
+    /*
+    -------------------------------------------------
+    ADDITIONAL FINDINGS CLINICAL REPORT
+    -------------------------------------------------
+    */
+
+    record AdditionalFindingsClinicalReport{
+        /**
+        This is the unique identifier (i.e.: in case of additionalFindings can be participantId)
+        */
+        string participantId;
+
+        /**
+        Date of this report in format YYYY-MM-DD
+        */
+        string reportingDate;
+
+        /**
+        Author of this report
+        */
+        string user;
+
+        /**
+        List of small reported variants
+        */
+        union {null, array<SmallVariant>} variants;
+
+        /**
+        List of simple structural reported variants (duplications, deletions, insertions, inversions, CNVs)
+        */
+        union {null, array<StructuralVariant>} structuralVariants;
+
+        /**
+        List of complex structural reported variants (chomosomal rearrangement)
+        */
+        union {null, array<ChromosomalRearrangement>} chromosomalRearrangements;
+
+        /**
+        List of short tandem repeat variants
+        */
+        union {null, array<ShortTandemRepeat>} shortTandemRepeats;
+
+        /**
+        List of uniparental disomies across all the individuals in this report
+        */
+        union {null, array<UniparentalDisomy>} uniparentalDisomies;
+
+        /**
+        List of inferred karyotypes across all the individuals in this report
+        */
+        union {null, array<Karyotype>} karyotypes;
+
+        /**
+        Summary of the interpretation, this should reflect the positive conclusions of this interpretation
+        */
+        string genomicInterpretation;
+
+        /**
+        The list of panels analysed to generate this report
+        */
+        union {null, array<AdditionalAnalysisPanel>} additionalAnalysisPanels;
+
+        /**
+        Supporting evidence (pubmed identifiers)
+        */
+        union {null, array<string>} references;
+
+        /**
+        This map contains the versions of the different databases used in the process, being the database names the
+        keys and the versions the values.
+        */
+        map<string> referenceDatabasesVersions;
+
+        /**
+        This map contains the versions of the different software systems used in the process, being the software
+        names the keys and the versions the values.
+        */
+        map<string> softwareVersions;
+    }
+}

--- a/schemas/IDLs/org.gel.models.report.avro/6.2.0/CommonInterpreted.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.2.0/CommonInterpreted.avdl
@@ -1,0 +1,1412 @@
+@namespace("org.gel.models.report.avro")
+/**
+This protocol defines common definitions for Genomics England reports models
+*/
+protocol CommonInterpreted {
+
+    import idl "CommonParticipant.avdl";
+
+
+enum SegregationPattern {
+    UniparentalIsodisomy,
+    SimpleRecessive,
+    CompoundHeterozygous,
+    deNovo,
+    InheritedAutosomalDominant,
+    InheritedAutosomalDominantMaternallyImprinted,
+    InheritedAutosomalDominantPaternallyImprinted,
+    XLinkedCompoundHeterozygous,
+    XLinkedSimpleRecessive,
+    XLinkedMonoallelic,
+    MitochondrialGenome
+}
+
+enum UniparentalDisomyType {isodisomy, heterodisomy, both}
+enum UniparentalDisomyOrigin {paternal, maternal, unknown}
+
+enum TimeUnit {years, months, weeks, days, hours, minutes, na}
+
+/**
+   Allele origin.
+
+* `SO_0001781`: de novo variant. http://purl.obolibrary.org/obo/SO_0001781
+* `SO_0001778`: germline variant. http://purl.obolibrary.org/obo/SO_0001778
+* `SO_0001775`: maternal variant. http://purl.obolibrary.org/obo/SO_0001775
+* `SO_0001776`: paternal variant. http://purl.obolibrary.org/obo/SO_0001776
+* `SO_0001779`: pedigree specific variant. http://purl.obolibrary.org/obo/SO_0001779
+* `SO_0001780`: population specific variant. http://purl.obolibrary.org/obo/SO_0001780
+* `SO_0001777`: somatic variant. http://purl.obolibrary.org/obo/SO_0001777
+    */
+    enum AlleleOrigin {
+        de_novo_variant,
+        germline_variant,
+        maternal_variant,
+        paternal_variant,
+        pedigree_specific_variant,
+        population_specific_variant,
+        somatic_variant
+    }
+
+/**
+    An enumeration for the different mode of inheritances:
+
+* `monoallelic_not_imprinted`: MONOALLELIC, autosomal or pseudoautosomal, not imprinted
+* `monoallelic_maternally_imprinted`: MONOALLELIC, autosomal or pseudoautosomal, maternally imprinted (paternal allele expressed)
+* `monoallelic_paternally_imprinted`: MONOALLELIC, autosomal or pseudoautosomal, paternally imprinted (maternal allele expressed)
+* `monoallelic`: MONOALLELIC, autosomal or pseudoautosomal, imprinted status unknown
+* `biallelic`: BIALLELIC, autosomal or pseudoautosomal
+* `monoallelic_and_biallelic`: BOTH monoallelic and biallelic, autosomal or pseudoautosomal
+* `monoallelic_and_more_severe_biallelic`: BOTH monoallelic and biallelic, autosomal or pseudoautosomal (but BIALLELIC mutations cause a more SEVERE disease form), autosomal or pseudoautosomal
+* `xlinked_biallelic`: X-LINKED: hemizygous mutation in males, biallelic mutations in females
+* `xlinked_monoallelic`: X linked: hemizygous mutation in males, monoallelic mutations in females may cause disease (may be less severe, later onset than males)
+* `mitochondrial`: MITOCHONDRIAL
+* `unknown`: Unknown
+    */
+    enum ModeOfInheritance {
+        monoallelic,
+        monoallelic_not_imprinted,
+        monoallelic_maternally_imprinted,
+        monoallelic_paternally_imprinted,
+        biallelic,
+        monoallelic_and_biallelic,
+        monoallelic_and_more_severe_biallelic,
+        xlinked_biallelic,
+        xlinked_monoallelic,
+        mitochondrial,
+        unknown,
+        na
+    }
+
+    /**
+    It is a representation of the zygosity
+
+* `reference_homozygous`: 0/0, 0|0
+* `heterozygous`: 0/1, 1/0, 1|0, 0|1
+* `alternate_homozygous`: 1/1, 1|1
+* `missing`: ./., .|.
+* `half_missing_reference`: ./0, 0/., 0|., .|0
+* `half_missing_alternate`: ./1, 1/., 1|., .|1
+* `alternate_hemizigous`: 1
+* `reference_hemizigous`: 0
+* `unk`: Anything unexpected
+    */
+    enum Zygosity {
+        reference_homozygous,
+        heterozygous,
+        alternate_homozygous,
+        missing,
+        half_missing_reference,
+        half_missing_alternate,
+        alternate_hemizigous,
+        reference_hemizigous,
+        unk,
+        na
+
+    }
+    enum SupportingReadType {
+        spanning,
+        flanking,
+        inrepeat
+    }
+
+
+    /**
+    Variant tiers as defined by Genomics England
+    */
+    enum Tier {NONE, TIER1, TIER2, TIER3, TIER4, TIER5, TIERA, TIERB}
+
+    /**
+    The reference genome assembly
+    */
+    enum Assembly {GRCh38, GRCh37}
+
+    enum ClinicalSignificance {
+        benign,
+        likely_benign,
+        likely_pathogenic,
+        pathogenic,
+        uncertain_significance
+    }
+
+    enum DrugResponseClassification {
+        altered_sensitivity,
+        reduced_sensitivity,
+        increased_sensitivity,
+        altered_resistance,
+        increased_resistance,
+        reduced_resistance,
+        increased_risk_of_toxicity,
+        reduced_risk_of_toxicity,
+        altered_toxicity,
+        adverse_drug_reaction,
+        indication,
+        contraindication,
+        dosing_alteration,
+        increased_dose,
+        reduced_dose,
+        increased_monitoring,
+        increased_efficacy,
+        reduced_efficacy,
+        altered_efficacy
+    }
+
+    enum PrognosisClassification{
+        altered_prognosis,
+        favourable_prognosis,
+        unfavourable_prognosis
+    }
+
+    enum TraitAssociation {
+        established_risk_allele,
+        likely_risk_allele,
+        uncertain_risk_allele,
+        protective
+    }
+
+    enum TumorigenesisClassification {
+        driver,
+        passenger,
+        modifier
+    }
+
+    enum VariantFunctionalEffect {
+        dominant_negative_variant,
+        gain_of_function_variant,
+        lethal_variant,
+        loss_of_function_variant,
+        loss_of_heterozygosity,
+        null_variant
+    }
+
+    enum Domain {
+        DOMAIN1, DOMAIN2, DOMAIN3, DOMAIN4, NONE
+    }
+
+    /**
+    The role of a given genomic feature in cancer
+
+* `NCIT_C16936`: oncogene. A gene that is a mutated (changed) form of a gene involved in normal cell growth. Oncogenes may cause the growth of cancer cells. Mutations in genes that become oncogenes can be inherited or caused by being exposed to substances in the environment that cause cancer. http://purl.obolibrary.org/obo/NCIT_C16936
+* `NCIT_C17362`: tumor_suppressor_gene. A type of gene that makes a protein called a tumor suppressor protein that helps control cell growth. Mutations (changes in DNA) in antioncogenes may lead to cancer. http://purl.obolibrary.org/obo/NCIT_C17362
+    */
+    enum RoleInCancer {
+        oncogene,
+        tumor_suppressor_gene,
+        both
+    }
+
+
+    /**
+    Each ACMG cirterion will be classifed as bening or pathogenic
+    */
+    enum AcmgEvidenceType{bening, pathogenic}
+    /**
+    Each ACMG criterion is weighted using the following terms:
+
+* `stand_alone`: `A`, stand-alone applied for benign variant critieria `(BA1)`
+* `supporting`: `P`, supporting applied for benign variant critieria `(BP1-6)` and pathogenic variant criteria `(PP1-5)`
+* `moderate`: `M`, moderate applied for pathogenic variant critieria (PM1-6)
+* `strong`: `S`, strong applied for pathogenic variant critieria (PS1-4)
+* `very_strong`: `S`, Very Stong applied for pathogenic variant critieria (PVS1)
+    */
+    enum AcmgEvidenceWeight{stand_alone, supporting, moderate, strong, very_strong}
+
+    /**
+    Each ACMG criterion is classified in one of these categories
+    */
+    enum AcmgEvidenceCategory{population_data, computational_and_predictive_data, functional_data, segregation_data,
+        de_novo_data, allelic_data, other_database, other_data}
+
+    /**
+    Activation Strength enumeration:
+* `strong`
+* `moderate`
+* `supporting`
+    */
+    enum ActivationStrength{strong, moderate, supporting}
+
+    /**
+    Type of evidence in the AMP guideline
+    */
+    enum AmpEvidenceType{mutation_type, therapies, variant_frequencies, potential_germline,
+        population_database_presence, germline_database_presence, somatic_database_presence, impact_predictive_software,
+        pathway_involvement, publications}
+    /**
+    AMP tier:
+* `TierI`: Variants of Strong Clinical Significance
+* `TierII`: Variants of Potential Clinical Significance
+* `TierIII`: Variants of Unknown Clinical Significance
+* `TierIV`: Benign or Likely Benign Variants
+    */
+    enum AmpTier{tierI, tierII, tierIII, tierIV}
+
+    /**
+    Categories of Clinical and/or Experimental Evidence as defined in AMP guidelines
+    */
+    enum AmpClinicalOrExperimentalEvidenceCategory {therapeutic, diagnosis, prognosis}
+
+    /**
+    Levels for categories of Clinical and/or Experimental Evidence as defined in AMP guidelines
+    */
+    enum AmpClinicalOrExperimentalEvidenceLevel{levelA, levelB, levelC, levelD}
+
+    /**
+    AcmgEvidence. This should be buit for each one of the evidences assing to a variants following the ACMG guidelines.
+    An AcmgEvidence, should map with one of the criteria defined, i.e, PVS1, BA1, PM1...
+    */
+    record AcmgEvidence {
+        /**
+        Evidence category as defined in ACMG guidelines
+        */
+        AcmgEvidenceCategory category;
+        /**
+        Evidence type: bening or pathogenic
+        */
+        AcmgEvidenceType type;
+        /**
+        Weight categories as described in ACMG guideline
+        */
+        AcmgEvidenceWeight weight;
+        /**
+        modifier of the strength, together define each creteria, i.e the 2 in PM2
+        */
+        int modifier;
+        /**
+        Activation Strength
+        */
+        union {null, ActivationStrength}  activationStrength;
+        /**
+        Description of the evidence
+        */
+        union {null, string} description;
+    }
+
+    /**
+    Full record for the ACMG variant clasiffication, including all selectedd evidences and the final classification.
+    */
+    record AcmgVariantClassification{
+        array<AcmgEvidence> acmgEvidences;
+        ClinicalSignificance clinicalSignificance;
+        union{null, string} assessment;
+    }
+
+    /**
+    Evidences as defined in AMP guidelines, they are composed by a evidence type (first column in the evidence table of
+    the guidlines) and a assessment of the evicence, this last one will define the streght of the evidence, supporting
+    the variant to be classified as TierI-IV
+    */
+    record AmpEvidence {
+        /**
+        AMP evidence type according to Guidlines, i.e germline_database_presence
+        */
+        AmpEvidenceType type;
+        /**
+        Assessment for AMP evidence, i.e Present in ClinVar
+        */
+        string evidenceAssessment;
+    }
+
+    /**
+    Amp Clinical or Experimental Evidence, the level will define the overal clasification of the variant together with
+    the tiering.
+    */
+    record  AmpClincialOrExperimentalEvidence{
+        /**
+        As denined in AMP guidelines: therapeutic, diagnosis or prognosis
+        */
+        AmpClinicalOrExperimentalEvidenceCategory category;
+        /**
+        As denined in AMP guidelines: levelA, levelB, levelC, levelD
+        */
+        AmpClinicalOrExperimentalEvidenceLevel level;
+        /**
+        Description of the evidence
+        */
+        union {null, string} description;
+    }
+
+    /**
+    Full Variant classification acording to AMP guideline, including all supporting evidences and the final
+    assessment
+    */
+    record AmpVariantClassification{
+        /**
+        List of AMP evidences
+        */
+        array<AmpEvidence> ampEvidences;
+        /**
+        Final Clasification taken in account the evidences
+        */
+        AmpTier ampTier;
+        /**
+        Clinical or Experimental evicence
+        */
+        union{null, array<AmpClincialOrExperimentalEvidence>} ampClincialOrExperimentalEvidence;
+        /**
+        Final Assessment
+        */
+        union{null, string} assessment;
+    }
+
+    /**
+    Variant classification based on guidlines, AMP and ACMG are supported
+    */
+    record GuidelineBasedVariantClassification{
+        union{null, AcmgVariantClassification} acmgVariantClassification;
+        union{null, AmpVariantClassification} ampVariantClassification;
+
+    }
+
+
+    record AlgorithmBasedVariantClassification{
+        /**
+        Name of the applied algorithm
+        */
+        string algorithmName;
+        /**
+        classification
+        */
+        string classification;
+        /**
+        rank
+        */
+        union {null, int} rank;
+        /**
+        Score
+        */
+        union {null, int} score;
+    }
+
+    /**
+    For each intervention studied in the clinical study, the general type of intervention
+
+* `drug`: Including placebo
+* `device`: Including sham
+* `biological`: Vaccine
+* `procedure`: Surgery
+* `radiation`
+* `behavioral`: For example, psychotherapy, lifestyle counselling
+* `genetic`: Including gene transfer, stem cell and recombinant DNA
+* `dietary_supplement`: For example, vitamins, minerals
+* `combination_product`: Combining a drug and device, a biological product and device; a drug and biological product; or a drug, biological product, and device
+* `diagnostic_test`: For example, imaging, in-vitro
+* `other`
+
+    Ref. https://prsinfo.clinicaltrials.gov/definitions.htm
+
+    */
+    enum InterventionType {drug, device, procedure, biological, radiation, behavioral, genetic, dietary_supplement,
+        combination_product, diagnostic_test, other}
+
+    /**
+    Treatment: One or more interventions are being evaluated for treating a disease, syndrome, or condition.
+    Prevention: One or more interventions are being assessed for preventing the development of a specific disease or health condition.
+    Diagnostic: One or more interventions are being evaluated for identifying a disease or health condition.
+    Supportive Care: One or more interventions are evaluated for maximizing comfort, minimizing side effects, or mitigating against a decline in the participant's health or function.
+    Screening: One or more interventions are assessed or examined for identifying a condition, or risk factors for a condition, in people who are not yet known to have the condition or risk factor.
+    Health Services Research: One or more interventions for evaluating the delivery, processes, management, organization, or financing of healthcare.
+    Basic Science: One or more interventions for examining the basic mechanism of action (for example, physiology or biomechanics of an intervention).
+    Device Feasibility: An intervention of a device product is being evaluated in a small clinical trial (generally fewer than 10 participants) to determine the feasibility of the product; or a clinical trial to test a prototype device for feasibility and not health outcomes. Such studies are conducted to confirm the design and operating specifications of a device before beginning a full clinical trial.
+    Other: None of the other options applies.
+
+    Ref. https://prsinfo.clinicaltrials.gov/definitions.htm
+    */
+    enum PrimaryPurpose {treatment, prevention, diagnostic, supportive_care, screening, health_services_research,
+        basic_science, device_feasibility, other}
+
+    /**
+    N/A: Trials without phases (for example, studies of devices or behavioural interventions).
+    Early Phase 1 (Formerly listed as "Phase 0"): Exploratory trials, involving very limited human exposure, with no therapeutic or diagnostic intent (e.g., screening studies, microdose studies). See FDA guidance on exploratory IND studies for more information.
+    Phase 1: Includes initial studies to determine the metabolism and pharmacologic actions of drugs in humans, the side effects associated with increasing doses, and to gain early evidence of effectiveness; may include healthy participants and/or patients.
+    Phase 1/Phase 2: Trials that are a combination of phases 1 and 2.
+    Phase 2: Includes controlled clinical studies conducted to evaluate the effectiveness of the drug for a particular indication or indications in participants with the disease or condition under study and to determine the common short-term side effects and risks.
+    Phase 2/Phase 3: Trials that are a combination of phases 2 and 3.
+    Phase 3: Includes trials conducted after preliminary evidence suggesting effectiveness of the drug has been obtained, and are intended to gather additional information to evaluate the overall benefit-risk relationship of the drug.
+    Phase 4: Studies of FDA-approved drugs to delineate additional information including the drug's risks, benefits, and optimal use.
+    */
+    enum StudyPhase {na, early_phase1, phase1, phase1_phase2, phase2, phase2_phase3, phase3, phase4}
+
+    /**
+* `Interventional (clinical trial)`: Participants are assigned prospectively to an intervention or interventions
+according to a protocol to evaluate the effect of the intervention(s) on biomedical or other health related outcomes.
+* `Observational`: Studies in human beings in which biomedical and/or health outcomes are assessed in pre-defined groups
+of individuals. Participants in the study may receive diagnostic, therapeutic, or other interventions, but the
+investigator does not assign specific interventions to the study participants. This includes when participants
+receive interventions as part of routine medical care, and a researcher studies the effect of the intervention.
+* `Expanded Access`: An investigational drug product (including biological product)
+available through expanded access for patients who do not qualify for enrollment in a clinical trial.
+Expanded Access includes all expanded access types under section 561 of the Federal Food, Drug, and
+Cosmetic Act: (1) for individual patients, including emergency use; (2) for intermediate-size patient populations;
+and (3) under a treatment IND or treatment protocol. (For more information on data requirements for this Study Type,
+see Expanded Access Data Element Definitions).
+    */
+    enum StudyType {interventional, observational, patient_registry, expanded_access}
+
+    /**
+    A process or action that is the focus of a clinical study.
+    Ref. https://prsinfo.clinicaltrials.gov/definitions.html
+    */
+    record Intervention{
+        /**
+        Intervention type, i.e drug
+        */
+        InterventionType interventionType;
+        /**
+        Intervention name: Placebo
+        */
+        string interventionName;
+    }
+
+    record AgeRange{
+        int minimumAge;
+        int maximumAge;
+        TimeUnit timeunit;
+    }
+
+    record TrialLocation{
+        union {null, string} name;
+        union {null, string} city;
+        union {null, string} country;
+        union {null, string} zip;
+    }
+
+    record DemographicElegibilityCriteria{
+        org.gel.models.participant.avro.Sex sex;
+        union {null, AgeRange} ageRange;
+    }
+
+    record Trial {
+        /**
+        URL where reference information for this trail can be found
+        */
+        string studyUrl;
+        /**
+        Trail/Study indetifier
+        */
+        string studyIdentifier;
+        /**
+        Start date of the study
+        */
+        union {null, string} startDate;
+        /**
+        Completion date of the study
+        */
+        union {null, string} estimateCompletionDate;
+        /**
+        Title of the study
+        */
+        union {null, string} title;
+        /**
+        Study Phase
+        */
+        union {null, StudyPhase} phase;
+        /**
+        Interventions
+        */
+        union {null, array<Intervention>} interventions;
+        /**
+        Conditions
+        */
+        union {null, array<string>} conditions;
+        /**
+        Primary Purpose of the study
+        */
+        union {null, PrimaryPurpose} primaryPurpose;
+        /**
+        Study Type
+        */
+        union {null, StudyType} studyType;
+        /**
+        Elegigility Criteria based on Age and Sex
+        */
+        union {null, DemographicElegibilityCriteria} demogrphicElegibilityCriteria;
+        /**
+        List with all of the locations where participant can enrolle
+        */
+        union {null, array<TrialLocation>} locations;
+        /**
+        If true, the association was made using the variant information,
+        if not the association was made at Genomic Entity level
+        */
+        boolean variantActionable;
+    }
+
+    record DrugResponse{
+        /**
+        Treatment agent
+        */
+        string TreatmentAgent;
+        /**
+        associated effect of the drug
+        */
+        DrugResponseClassification drugResponseClassification;
+    }
+
+    record Therapy{
+        /**
+        URL where reference information for this therapy association can be found
+        */
+        string referenceUrl;
+        /**
+        Source
+        */
+        union {null, string} source;
+        /**
+        References
+        */
+        union {null, array<string>} references;
+        /**
+        Conditions
+        */
+        union {null, array<string>} conditions;
+        /**
+        Drug responses
+        */
+        union {null, array<DrugResponse>} drugResponse;
+        /**
+        Any other clinical intervention
+        */
+        union {null, array<Intervention>} otherInterventions;
+        /**
+        If true, the association was made at the variant level, if not the association was made at Genomic Entity level
+        */
+        boolean variantActionable;
+    }
+
+    record Prognosis{
+        /**
+        URL where reference information for this prognosis can be found
+        */
+        string referenceUrl;
+        /**
+        Prognosis classification (defined as favourable or unfavourable),
+        in the case that the direction of the prognosis is not known altered_prognosis should be used
+        */
+        union{null, PrognosisClassification} prognosis;
+        /**
+        Source if known
+        */
+        union {null, string} source;
+        /**
+        References
+        */
+        union {null, array<string>} references;
+        /**
+        Conditions
+        */
+        union {null, array<string>} conditions;
+        /**
+        Full description of the associated prognosis
+        */
+        union {null, string} description;
+        /**
+        If true, the association was made at the variant level, if not the association was made at Genomic Entity level
+        */
+        boolean variantActionable;
+    }
+
+    record Diagnostic{
+        /**
+        URL where reference information for this prognosis can be found
+        */
+        string referenceUrl;
+        /**
+        Sources if known
+        */
+        union {null, array<string>} sources;
+        /**
+        References
+        */
+        union {null, array<string>} references;
+        /**
+        Biomarkers
+        */
+        union {null, array<string>} biomarkers;
+        /**
+        Associated conditions
+        */
+        union {null, array<string>} conditions;
+        /**
+        Diagnosis
+        */
+        union {null, string} diagnosis;
+        /**
+        Diagnosis status
+        */
+        union {null, string} diagnosisStatus;
+        /**
+        Other condition
+        */
+        union {null, string} otherCondition;
+        /**
+        If true, the association was made at the variant level, if not the association was made at Genomic Entity level
+        */
+        boolean variantActionable;
+    }
+
+    record OtherAction{
+        /**
+        URL where reference information for this action can be found
+        */
+        string referenceUrl;
+        /**
+        Action identifier
+        */
+        union {null, string} identifier;
+        /**
+        Sources if known
+        */
+        union {null, array<string>} sources;
+        /**
+        Action type
+        */
+        union {null, string} actionType;
+        /**
+        Associated conditions
+        */
+        union {null, array<string>} conditions;
+        /**
+        Other attributes
+        */
+        union {null, map<string>} otherAttributes;
+        /**
+        If true, the association was made at the variant level, if not the association was made at Genomic Entity level
+        */
+        boolean variantActionable;
+    }
+
+
+    /**
+    Clinical actions
+    */
+    record Actions {
+        union {null, array<Trial>} trials;
+        union {null, array<Prognosis>} prognosis;
+        union {null, array<Therapy>} therapies;
+        union {null, array<Diagnostic>} diagnostic;
+        union {null, array<OtherAction>} otherAction;
+    }
+
+    /**
+    Types of genomic features:
+
+* `regulatory_region`: a regulatory region
+* `gene`: a gene
+* `transcript`: a transcript
+* `intergenic`: an intergenic region
+    */
+    enum GenomicEntityType {
+        regulatory_region,
+        gene,
+        transcript,
+        intergenic,
+        gene_fusion,
+        genomic_region,
+        cytobands
+    }
+
+    /**
+    The population allele frequency of a given variant in a given study and optionally population
+    */
+    record AlleleFrequency {
+        /**
+        The study from where this data comes from
+        */
+        string study;
+        /**
+        The specific population where this allele frequency belongs
+        */
+        string population;
+        /**
+        The frequency of the alternate allele
+        */
+        float alternateFrequency;
+    }
+
+    record Identifier{
+        /**
+        Source i.e, esenmbl
+        */
+        string source;
+        /**
+        identifier
+        */
+        string identifier;
+    }
+
+    /**
+    A genomic feature
+    */
+    record GenomicEntity {
+        /**
+        The type of the genomic entity
+        */
+        GenomicEntityType type;
+
+        /**
+        Ensembl identifier for the feature (e.g, ENST00000544455)
+        */
+        union {null, string} ensemblId;
+
+        /**
+        The HGNC gene symbol. This field is optional, BUT it should be filled if possible
+        */
+        union {null, string} geneSymbol;
+
+        /**
+        Others identifiers for this genomic feature
+        */
+        union {null, array<Identifier>} otherIds;
+    }
+
+    /**
+    A panel of genes
+    */
+    record GenePanel{
+        /**
+        Panel name used
+        */
+        union {null, string} panelIdentifier;
+
+        /**
+        Panel name used
+        */
+        union {null, string} panelName;
+        /**
+        Panel version
+        */
+        union {null, string} panelVersion;
+        /**
+        source i.e, PanelApp
+        */
+        union {null, string} source;
+    }
+
+    /**
+    A variant consequence as defined by the Sequence Ontology (SO) (e.g.: id = SO:0001816 ; name = non synonymous)
+    NOTE: this record is equivalent to OpenCB's `ConsequenceType`, but we want to avoid naming collisions
+    */
+    record VariantConsequence {
+        /**
+        The SO term identifier (e.g.: SO:0001816)
+        */
+        string id;
+        /**
+        The SO term name (e.g.: non synonymous)
+        */
+        union {null, string} name;
+    }
+
+    record VariantIdentifiers{
+        /**
+        Variant identifier in dbSNP
+        */
+        union {null, string} dbSnpId;
+
+        /**
+        Variant identifier in Cosmic
+        */
+        union {null, array<string>} cosmicIds;
+
+        /**
+        Variant identifier in ClinVar
+        */
+        union {null, array<string>} clinVarIds;
+
+        union {null, array<Identifier>} otherIds;
+    }
+
+    /**
+    The variant classification according to different properties.
+    */
+    record VariantClassification {
+        /**
+        The variant's clinical significance.
+        */
+        union{null, ClinicalSignificance} clinicalSignificance;
+        /**
+        The variant's pharmacogenomics classification.
+        */
+        union{null, DrugResponseClassification} drugResponseClassification;
+        /**
+        The variant's trait association.
+        */
+        union{null, TraitAssociation} traitAssociation;
+        /**
+        The variant's tumorigenesis classification.
+        */
+        union{null, TumorigenesisClassification} tumorigenesisClassification;
+        /**
+        The variant functional effect
+        */
+        union {null, VariantFunctionalEffect} functionalEffect;
+    }
+
+    /**
+    The ontology to which a standard term belongs
+    */
+    record Ontology {
+        string name;
+        string version;
+    }
+
+    /**
+    Standard phenotype term based on the OBO format (see an example here http://snapshot.geneontology.org/ontology/go-basic.obo)
+    */
+    record StandardPhenotype {
+        string id;
+        union {null, string} name;
+        union {null, string} namespace;
+        union {null, string} definition;
+        union {null, string} comment;
+        union {null, string} alternativeIds;
+        union {null, string} synonyms;
+        union {null, string} isA;
+        /**
+        The ontology (e.g.: HPO, OMIM, SNOMED CT)
+        */
+        Ontology ontology;
+        /**
+        The match between the non standard phenotype and this term when in silico
+        */
+        union {null, float} matchScore;
+    }
+
+    /**
+    Oontology term based on the OBO format (see an example here http://snapshot.geneontology.org/ontology/go-basic.obo)
+    */
+    record Phenotypes {
+        /**
+        The non standardised phenotypes (i.e.: may be free text)
+        */
+        union {null, array<string>} nonStandardPhenotype;
+        /**
+        The standardised phenotypes (i.e.: controlled terminology)
+        */
+        union {null, array<StandardPhenotype>} standardPhenotypes;
+    }
+
+    /**
+    A report event holds all the information about why a given variant is relevant to report. The same variant may have
+    several report events. For instance, we may have two report events from the tiering process when two panels are
+    analysed, a positive report from a Genomic Medicine Centre (GMC) will correspond to an additional report event.
+    */
+    record ReportEvent {
+        /**
+        Unique identifier for each report event, this is unique across the whole report. A report having more than one
+        report event with the same identifier is invalid. Repeating report event identifiers between different reports
+        is valid. The uniqueness of this field will be checked in report validation
+        */
+        string reportEventId;
+
+        /**
+        The list of phenotypes
+        */
+        Phenotypes phenotypes;
+
+        /**
+        Sequence Ontology terms for relevant consequence types for this report event
+        */
+        array<VariantConsequence> variantConsequences;
+
+        /**
+        The panel of genes to which this report corresponds
+        */
+        union {null, GenePanel} genePanel;
+
+        /**
+        Mode of inheritance used to analyse the family
+        */
+        ModeOfInheritance modeOfInheritance;
+
+        /**
+        The list of genomic features of interest for this report event. Please note that one variant can overlap more
+        that one gene/transcript. If more than one gene/transcript is considered interesting for this particular
+        variant, should be reported in two different ReportEvents
+        */
+        array<GenomicEntity> genomicEntities;
+
+        /**
+        Segregation pattern if any calculated using the genotypes information of a family
+        */
+        union {null, SegregationPattern} segregationPattern;
+
+        /**
+        This is the penetrance assumed for scoring or classifying this variant
+        */
+        union {null, org.gel.models.participant.avro.Penetrance} penetrance;
+
+
+        /**
+        Likelihood of being a de novo variant
+        */
+        union {null, float} deNovoQualityScore;
+
+        /**
+        Flag to indicate if this variant using this mode of inheritance can fully explain the phenotype
+        */
+        union {null, boolean} fullyExplainsPhenotype;
+
+        /**
+        This value groups variants that together could explain the phenotype according to the mode of inheritance used.
+        (e.g.: compound heterozygous). All the variants in the same report sharing the same value will be considered in
+        the same group (i.e.: reported together). This value is an integer unique in the whole report.
+        These values are only relevant within the same report.
+        */
+        union {null, int} groupOfVariants;
+
+        /**
+        This is the description of why this variant would be reported, for example that it affects the protein in this way
+        and that this gene has been implicated in this disorder in these publications. Publications should be provided as PMIDs
+        using the format [PMID:8075643]. Other sources can be used in the same manner, e.g. [OMIM:163500]. Brackets need to be included.
+        */
+        union {null, string} eventJustification;
+
+        /**
+        The role of this variant in cancer if any
+        */
+        union {null, array<RoleInCancer>} roleInCancer;
+
+        /**
+        Actions can be taken on the variant if any
+        */
+        union {null, Actions} actions;
+
+        /**
+        This is the score provided to reflect a variant's likelihood of explaining the phenotype using a specific
+        mode of Inheritance. This may be the result of different scoring systems
+        */
+        union {null, float} score;
+
+        /**
+        Other scores that the interpretation provider may add (for example phenotypically informed or family
+        informed scores)
+        */
+        union {null, map<float>} vendorSpecificScores;
+
+        /**
+        Variant classification
+        */
+        union {null, VariantClassification} variantClassification;
+
+        /**
+        Guidelines based Variant classification
+        */
+        union {null, GuidelineBasedVariantClassification} guidelineBasedVariantClassification;
+
+        /**
+        Algorithm based variant classifications
+        */
+        union {null, array<AlgorithmBasedVariantClassification>} algorithmBasedVariantClassifications;
+
+        /**
+        The tier where this variant has been classified. Tier is a property of the model of inheritance and therefore
+        is subject to change depending on the inheritance assumptions
+        */
+        union {null, Tier} tier;
+
+        /**
+        The Domain where this variant has been classified.
+        */
+        union {null, Domain} domain;
+
+    }
+
+    /**
+    The variant coordinates representing uniquely a small variant.
+    No multi-allelic variant supported, alternate only represents one alternate allele.
+    */
+    record VariantCoordinates {
+
+        /**
+        Chromosome
+        */
+        string chromosome;
+
+        /**
+        Genomic position
+        */
+        int position;
+
+        /**
+        The reference bases.
+        */
+        string reference;
+
+        /**
+        The alternate bases
+        */
+        string alternate;
+
+        /**
+        The assembly to which this variant corresponds
+        */
+        Assembly assembly;
+    }
+
+    /**
+    Some additional variant attributes
+    */
+    record VariantAttributes {
+
+        /**
+        gDNA change, HGVS nomenclature (e.g.: g.476A>T)
+        */
+        union {null, array<string>} genomicChanges;
+
+        /**
+        cDNA change, HGVS nomenclature (e.g.: c.76A>T)
+        */
+        union {null, array<string>} cdnaChanges;
+
+        /**
+        Protein change, HGVS nomenclature (e.g.: p.Lys76Asn)
+        */
+        union {null, array<string>} proteinChanges;
+
+        /**
+        Any additional information in a free text field. For example a quote from a paper
+        */
+        union {null, map<string>} additionalTextualVariantAnnotations;
+
+        /**
+        Additional references for ths variant. For example HGMD ID or Pubmed Id
+        */
+        union {null, map<string>} references;
+
+        union {null, VariantIdentifiers} variantIdentifiers;
+
+        /**
+        A list of population allele frequencies
+        */
+        union {null, array<AlleleFrequency>} alleleFrequencies;
+
+        /**
+        Additional numeric variant annotations for this variant. For Example (Allele Frequency, sift, polyphen,
+        mutationTaster, CADD. ..)
+        */
+        union {null, map<float>} additionalNumericVariantAnnotations;
+
+        /**
+        Comments
+        */
+        union {null, array<string>} comments;
+
+        /**
+        List of allele origins for this variant in this report
+        */
+        union {null, array<AlleleOrigin>} alleleOrigins;
+
+        /**
+        Largest reference interrupted homopolymer length intersecting with the indel
+        */
+        union {null, int} ihp;
+        /**
+        Flag indicating if the variant is recurrently reported
+        */
+        union {null, boolean} recurrentlyReported;
+        /**
+        Average tier1 number of basecalls filtered from original read depth within 50 bases
+        */
+        union {null, float} fdp50;
+        /**
+        Map of other attributes where keys are the attribute names and values are the attributes
+        */
+        union {null, map<string>} others;
+    }
+
+    record PhaseGenotype {
+        array<string> sortedAlleles;
+        int phaseSet;
+    }
+
+    record NumberOfCopies {
+        /**
+        Number of copies given by the caller in one of the allele
+        */
+        int numberOfCopies;
+        union{null, int} confidenceIntervalMaximum;
+        union{null, int} confidenceIntervalMinimum;
+    }
+
+    /**
+    This is intended to hold the genotypes for the family members. This assumes that varinats have been split before.
+    In principle it is a phased zygosity as in VCF spec and called by the analysis provider if further phasing is conducted
+    */
+    record VariantCall {
+
+        /**
+        Participant id
+        */
+        string participantId;
+
+        /**
+        Sample Id
+        */
+        string sampleId;
+
+        /**
+        Zygosity. For somatic variants, or variants without zygosity use `na`
+        */
+        Zygosity zygosity;
+
+        /**
+        phase alleles for those in phase
+        */
+        union {null, PhaseGenotype} phaseGenotype;
+
+        /**
+        Sample Variant Allele Frequency
+        */
+        union {null, double} sampleVariantAlleleFrequency;
+
+        /**
+        Depth for Reference Allele
+        */
+        union {null, int} depthReference;
+
+        /**
+        Depth for Alternate Allele
+        */
+        union {null, int} depthAlternate;
+
+        /**
+        Alleles for copy number variation - add doc
+        */
+        union {null, array<NumberOfCopies>} numberOfCopies;
+
+        /**
+        Describe whether this is a somatic or Germline variant
+        */
+        union {null, array<AlleleOrigin>} alleleOrigins;
+
+        union {null, array<SupportingReadType>} supportingReadTypes;
+
+    }
+
+    enum Indel {
+        insertion,
+        deletion
+    }
+
+    record ConfidenceInterval {
+        int left;
+        int right;
+    }
+
+    record Coordinates{
+        Assembly assembly;
+        string chromosome;
+        int start;
+        int end;
+        union {null, ConfidenceInterval} ciStart;
+        union {null, ConfidenceInterval} ciEnd;
+    }
+
+    enum Orientation {
+        start_start,
+        start_end,
+        end_end
+    }
+
+    enum StructuralVariantType {ins, dup, inv, amplification, deletion, dup_tandem, del_me, ins_me}
+
+    record Rearrangement {
+        Coordinates leftCoordinates;
+        Coordinates rightCoordinates;
+        Orientation orientation;
+        union {null, string} leftInsSeq;
+        union {null, string} rightInsSeq;
+    }
+
+    record BreakPoint{
+        Coordinates coordinates;
+        union{null, string} reference;
+        union{null, string} alternate;
+        union{null, map<string>} info;
+    }
+
+    record ShortTandemRepeatReferenceData{
+        string repeatedSequence;
+        int pathogenic_number_of_repeats_threshold;
+        int normal_number_of_repeats_threshold;
+    }
+
+    record ChromosomalRearrangement {
+        union {null, array<BreakPoint>} breakPoints;
+        array<Rearrangement> rearrangements;
+        array<ReportEvent> reportEvents;
+        /**
+        array of genotypes for the samples
+        */
+        array<VariantCall> variantCalls;
+        union {null, VariantAttributes} variantAttributes;
+    }
+
+    record StructuralVariant {
+        /**
+        Structural Variant Type as would appear in VCF
+        */
+        StructuralVariantType variantType;
+        Coordinates coordinates;
+        union {null, string} leftInsSeq;
+        union {null, string} rightInsSeq;
+        array<ReportEvent> reportEvents;
+        /**
+        array of genotypes for the samples
+        */
+        array<VariantCall> variantCalls;
+        union {null, VariantAttributes} variantAttributes;
+
+    }
+
+    record ShortTandemRepeat {
+        Coordinates coordinates;
+        array<ReportEvent> reportEvents;
+        /**
+        array of genotypes for the samples
+        */
+        array<VariantCall> variantCalls;
+        union {null, VariantAttributes} variantAttributes;
+        union {null, ShortTandemRepeatReferenceData} shortTandemRepeatReferenceData;
+
+    }
+
+    /**
+    A reported variant
+    */
+    record SmallVariant {
+
+        /**
+        The variant coordinates. Chromosome is either 1-22, X, Y, MT or any other contif in the reference genome,
+        no "chr" prefix is expected. Position is 1- based. Reference and alternate should never be empty or any
+        character representing emptiness (e.g.: . or -), a VCF-like indel representation is expected.
+        */
+        VariantCoordinates variantCoordinates;
+
+        /**
+        List of variant calls across all samples under analysis for this variant
+        */
+        array<VariantCall> variantCalls;
+
+        /**
+        The list of report events for this variant across multiple modes of inheritance and panels
+        */
+        array<ReportEvent> reportEvents;
+        union {null, VariantAttributes} variantAttributes;
+
+    }
+
+    record IdentityByDescent {
+        string relatedSample;
+        float ibd0;
+        float ibd1;
+        float ibd2;
+        float pihat;
+    }
+
+    record UniparentalDisomyEvidences {
+        union {null, array<IdentityByDescent>} ibds;
+    }
+
+    record UniparentalDisomyFragment {
+        /**
+        Coordinates can be specified to indicate the part of the chromosome affected
+        */
+        union {null, Coordinates} coordinates;
+        /**
+        indicates whether the UPD event involves `isodisomy`, `heterodisomy` or `both`
+        */
+        UniparentalDisomyType uniparentalDisomyType;
+
+    }
+
+    record UniparentalDisomy {
+        /**
+        The assembly
+        */
+        Assembly assembly;
+        /**
+        Chromosome where two homologues were inherited from one parent
+        */
+        string chromosome;
+        /**
+        indicates Whether the UPD event involves an entire chromosome or part of a chromosome
+        */
+        union {null, boolean} complete;
+        /**
+        The parent who contributed two chromosomes was the mother (maternal) or the father (paternal)
+        */
+        UniparentalDisomyOrigin origin;
+        /**
+        List of all of the UPD fragments for this UPD event
+        */
+        union {null, array<UniparentalDisomyFragment>} uniparentalDisomyFragments;
+        /**
+        Participant affected by this UPD
+        */
+        string participantId;
+        /**
+        Evidences for the UPD call
+        */
+        union {null, UniparentalDisomyEvidences} uniparentalDisomyEvidences;
+    }
+
+    record Aneuploidy {
+
+        /**
+        International System for Human Cytogenetic Nomenclature (.e.g: "+14p+", "+t(13q21 q)")
+        */
+        union {null, string} iscn;
+        /**
+        The assembly
+        */
+        Assembly assembly;
+        /**
+        Chromosome involved in the aneuploidy
+        */
+        string chromosome;
+        /**
+        Wheter the aneuploidy is for the whole chromosme or just a fragment
+        */
+        boolean complete;
+        /**
+        Coordinates can be specified to indicate the part of the chromosome affected
+        */
+        union {null, Coordinates} coordinates;
+        /**
+        Number of copies
+        */
+        int numberOfCopies;
+    }
+
+    record Karyotype {
+
+        /**
+        International System for Human Cytogenetic Nomenclature (e.g.: "46,XY", "46,XY,-5,-12,+t(5pl2p),+t(5ql2q)")
+        */
+        union {null, string} iscn;
+        /**
+        Full description of the karyotype
+        */
+        union {null, string} description;
+        /**
+        List of aneuploidies
+        */
+        union {null, array<Aneuploidy>} aneuploidies;
+        /**
+        Total number of chromosomes
+        */
+        int numberOfChromosomes;
+        /**
+        Kariotypic sex
+        */
+        org.gel.models.participant.avro.PersonKaryotipicSex personKaryotipicSex;
+        /**
+        Participant identifier
+        */
+        string participantId;
+    }
+
+
+
+}

--- a/schemas/IDLs/org.gel.models.report.avro/6.2.0/CommonInterpreted.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.2.0/CommonInterpreted.avdl
@@ -287,6 +287,10 @@ enum TimeUnit {years, months, weeks, days, hours, minutes, na}
         array<AcmgEvidence> acmgEvidences;
         ClinicalSignificance clinicalSignificance;
         union{null, string} assessment;
+        /**
+        ACMG evidence categories for which the user has indicated there is no evidence available
+        */
+        union{null, array<AcmgEvidenceCategory>} noAcmgEvidence;
     }
 
     /**

--- a/schemas/IDLs/org.gel.models.report.avro/6.2.0/CommonRequest.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.2.0/CommonRequest.avdl
@@ -1,0 +1,169 @@
+@namespace("org.gel.models.report.avro")
+/**
+This protocol defines the Commons for GEL models
+*/
+protocol CommonRequest {
+
+    /*
+Types of files:
+
+* `BAM`: alignment
+* `gVCF`: genomic VCF for variants
+* `VCF_small`: VCF file for SNV and indel
+* `VCF_somatic_small`: VCF file for somatic SNV and indel
+* `VCF_CNV`: VCF file for copy number variants
+* `VCF_somatic_CNV`: VCF file somatic for copy number variants
+* `VCF_SV`: VCF file for structural variants only
+* `VCF_somatic_SV`: VCF file for somatic structural variants only
+* `VCF_SV_CNV`: VCF file for CNV and SVs
+* `SVG`: an SVG for example of a pedigree
+* `ANN`: a Json File for the annotation file from openCBschema/IDLs/variantAnnotation.avdl
+* `BigWig`: a bigwig file with the genome coverage
+* `MD5Sum`: a MD5Sum file
+* `ROH`: a BED file with Regions of homozygosity
+* `OTHER`: other unspecified file type
+* `PARTITION`: Canvas output of coverage in high density areas
+* `VARIANT_FREQUENCIES`: b-allele frequencies
+* `COVERAGE`: whole genome coverage metrics in JSON format
+    **/
+    enum FileType {
+        BAM,
+        gVCF,
+        VCF_small,
+        VCF_somatic_small,
+        VCF_CNV,
+        VCF_somatic_CNV,
+        VCF_SV,
+        VCF_somatic_SV,
+        VCF_SV_CNV,
+        SVG,
+        ANN,
+        BigWig,
+        MD5Sum,
+        ROH,
+        OTHER,
+        PARTITION,
+        VARIANT_FREQUENCIES,
+        COVERAGE
+        }
+
+    /**
+    This defines a file
+    This record is uniquely defined by the sample identfier and an URI
+    Currently sample identifier can be a single string or a list of strings if multiple samples are associated with the same file
+    **/
+    record File {
+        /**
+        Unique identifier(s) of the sample. For example in a multisample vcf this would have an array of all the sample identifiers
+        */
+        union {null, array<string>} sampleId;
+
+        /**
+        URI path of the file
+        */
+        string uriFile;
+
+        /**
+        The type of the file
+        */
+        FileType fileType;
+
+        /**
+        The MD5 checksum
+        */
+        union {null, string} md5Sum;
+
+    }
+
+    /**
+    Family history for secondary findings.
+    Arrays of strings describing discrete family history phenotypes.
+    Usually: `EndocrineTumours`, `colorectal`, `BreastOvarian` and `HDOrStroke` but can be others
+    */
+    record OtherFamilyHistory {
+        /**
+        Relevant Maternal family history
+        */
+        union {null, array<string>} maternalFamilyHistory;
+        /**
+        Relevant Maternal family history
+        */
+        union {null, array<string>} paternalFamilyHistory;
+    }
+
+    /**
+    The Genomics England program
+    */
+    enum Program {
+        cancer,
+        rare_disease
+    }
+
+    /**
+    Some flags relevant to the interpretation of a case
+    */
+    enum InterpretationFlags {
+        mixed_chemistries,
+        mixedLab_preparation,
+        low_tumour_purity,
+        uniparental_isodisomy,
+        uniparental_heterodisomy,
+        unusual_karyotype,
+        high_cnv_count,
+        high_estimate_human_contamination_fraction,
+        mixed_recruiting_gmc,
+        suspected_mosaicism,
+        low_quality_sample,
+        ffpe_tumour_sample,
+        ff_nano_tumour_sample,
+        missing_values_for_proband_in_reported_variant,
+        reissued,
+        supplementary_report_errors,
+        internal_use_only,
+        high_priority,
+        suspected_increased_number_of_false_positive_heterozygous_loss_calls,
+        suspected_poor_quality_cnv_calls,
+        cnv_calls_assumed_xx_karyo,
+        cnv_calls_assumed_xy_karyo,
+        other
+    }
+
+    /**
+    A given interpretation flag together with an optional description
+    */
+    record InterpretationFlag{
+        /**
+        The interpretation flag
+        */
+        InterpretationFlags  interpretationFlag;
+        /**
+        The description for the flag
+        */
+        union {null, string} additionalDescription;
+    }
+
+    /**
+    Interpretation flags at the participant level
+    */
+    record ParticipantInterpretationFlags{
+        /**
+        The interpretation flag
+        */
+        InterpretationFlags  interpretationFlag;
+        /**
+        The description for the flag
+        */
+        union {null, string} additionalDescription;
+        /**
+        Sample Id fron which this flag was reported
+        */
+        string SampleId;
+        /**
+        Participant Id as appeared in the pedigree
+        */
+        union {null, string} participantId;
+
+    }
+
+
+}

--- a/schemas/IDLs/org.gel.models.report.avro/6.2.0/ExitQuestionnaire.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.2.0/ExitQuestionnaire.avdl
@@ -1,0 +1,566 @@
+@namespace("org.gel.models.report.avro")
+/**
+This protocol defines ExitQuestionnaires
+*/
+protocol ExitQuestionnaires {
+
+    import idl "CommonInterpreted.avdl";
+
+    enum CaseSolvedFamily {yes, no, partially, unknown}
+    enum PhenotypesSolved {yes, no, partially, unknown}
+    enum SegregationQuestion {yes, no}
+    enum ReportingQuestion {yes, no, na}
+    enum ConfirmationDecision {yes, no, na}
+    enum ConfirmationOutcome {yes, no, na}
+    enum Actionability {yes, no, not_yet, na}
+    // TODO: refactor with VariantClassification in CommonInterpreted.avdl
+    enum ACMGClassification {pathogenic_variant, likely_pathogenic_variant, variant_of_unknown_clinical_significance, likely_benign_variant,  benign_variant, not_assessed, na}
+    enum ClinicalUtility {none, change_in_medication, surgical_option, additional_surveillance_for_proband_or_relatives, clinical_trial_eligibility, informs_reproductive_choice, unknown, other}
+    enum FamilyHistoryCondition {yes, no, unknown}
+    enum FamilyHistoryPatient {yes, no, unknown}
+    enum FamilyHistoryFamily {yes, no, unknown}
+
+    /**
+    The family level questions
+    */
+    record FamilyLevelQuestions{
+        /**
+        Have the results reported here explained the genetic basis of the family’s presenting phenotype(s)?
+        */
+        CaseSolvedFamily caseSolvedFamily;
+        /**
+        Have you done any segregation testing in non-participating family members?
+        */
+        SegregationQuestion segregationQuestion;
+        /**
+        Comments regarding report
+        */
+        string additionalComments;
+    }
+
+    /**
+    The variant level questions
+    */
+    record VariantLevelQuestions{
+        /**
+        Variant coordinates
+        */
+        VariantCoordinates variantCoordinates;
+        /**
+        Did you carry out technical confirmation of this variant via an alternative test?
+        */
+        ConfirmationDecision confirmationDecision;
+        /**
+        Did the test confirm that the variant is present?
+        */
+        ConfirmationOutcome confirmationOutcome;
+        /**
+        Did you include the variant in your report to the clinician?
+        */
+        ReportingQuestion reportingQuestion;
+        /**
+        What ACMG pathogenicity score (1-5) did you assign to this variant?
+        */
+        ACMGClassification acmgClassification;
+        /**
+        Please provide PMIDs for papers which you have used to inform your assessment for this variant, separated by a `;` for multiple papers
+        */
+        string publications;
+
+    }
+
+    /**
+    Structural variant level questions
+    */
+    record StructuralVariantLevelQuestions{
+        /**
+        Structural variant type
+        */
+        StructuralVariantType variantType;
+        /**
+        Variant coordinates
+        */
+        Coordinates coordinates;
+        /**
+        Did you carry out technical confirmation of this variant via an alternative test?
+        */
+        ConfirmationDecision confirmationDecision;
+        /**
+        Did the test confirm that the variant is present?
+        */
+        ConfirmationOutcome confirmationOutcome;
+        /**
+        Did you include the variant in your report to the clinician?
+        */
+        ReportingQuestion reportingQuestion;
+        /**
+        What ACMG pathogenicity score (1-5) did you assign to this variant?
+        */
+        ACMGClassification acmgClassification;
+        /**
+        Please provide PMIDs for papers which you have used to inform your assessment for this variant, separated by a `;` for multiple papers
+        */
+        string publications;
+
+    }
+
+    /**
+    The variant level questions
+    */
+    record ShortTandemRepeatLevelQuestions{
+        /**
+        Variant coordinates
+        */
+        Coordinates coordinates;
+        /**
+        Did you carry out technical confirmation of this variant via an alternative test?
+        */
+        ConfirmationDecision confirmationDecision;
+        /**
+        Did the test confirm that the variant is present?
+        */
+        ConfirmationOutcome confirmationOutcome;
+        /**
+        Did you include the variant in your report to the clinician?
+        */
+        ReportingQuestion reportingQuestion;
+        /**
+        What ACMG pathogenicity score (1-5) did you assign to this variant?
+        */
+        ACMGClassification acmgClassification;
+        /**
+        Please provide PMIDs for papers which you have used to inform your assessment for this variant, separated by a `;` for multiple papers
+        */
+        string publications;
+
+    }
+
+    /**
+    The variant group level questions
+    */
+    record VariantGroupLevelQuestions{
+
+        /**
+        This value groups variants that together could explain the phenotype according to the mode of inheritance used.
+        (e.g.: compound heterozygous). All the variants in the same report sharing the same value will be considered in
+        the same group (i.e.: reported together). This value is an integer unique in the whole report.
+        These values are only relevant within the same report.
+        */
+        int variantGroup;
+
+        /**
+        Variant level questions for each of the variants in the group
+        */
+        union {null, array<VariantLevelQuestions>} variantLevelQuestions;
+
+        /**
+        STR level questions for each of the variants in the group
+        */
+        union {null, array<ShortTandemRepeatLevelQuestions>} shortTandemRepeatLevelQuestions;
+
+        /**
+        Structural level questions for each of the variants in the group
+        */
+        union {null, array<StructuralVariantLevelQuestions>} structuralVariantLevelQuestions;
+
+        /**
+        Is evidence for this variant/variant pair sufficient to use it for clinical purposes such as prenatal diagnosis or predictive testing?
+        */
+        Actionability actionability;
+
+        /**
+        Has the clinical team identified any changes to clinical care which could potentially arise as a result of this variant/variant pair?
+        */
+        array<ClinicalUtility> clinicalUtility;
+
+        /**
+        Did you report the variant(s) as being partially or completely causative of the family's presenting phenotype(s)?
+        */
+        PhenotypesSolved phenotypesSolved;
+
+        /**
+        If you indicated that the variant(s) only partially explained the family’s presenting phenotypes, please indicate which HPO terms you are confident that they DO explain
+        */
+        union {null, array<string>}  phenotypesExplained;
+    }
+
+    /**
+    The additional findings variant group level questions
+    */
+    record AdditionalFindingsVariantGroupLevelQuestions{
+
+        /**
+        This value groups variants that together could explain the phenotype according to the mode of inheritance used.
+        (e.g.: compound heterozygous). All the variants in the same report sharing the same value will be considered in
+        the same group (i.e.: reported together). This value is an integer unique in the whole report.
+        These values are only relevant within the same report.
+        */
+        int variantGroup;
+
+        /**
+        Variant level questions for each of the variants in the group
+        */
+        union {null, array<VariantLevelQuestions>} variantLevelQuestions;
+
+        /**
+        STR level questions for each of the variants in the group
+        */
+        union {null, array<ShortTandemRepeatLevelQuestions>} shortTandemRepeatLevelQuestions;
+
+        /**
+        Structural level questions for each of the variants in the group
+        */
+        union {null, array<StructuralVariantLevelQuestions>} structuralVariantLevelQuestions;
+
+        /**
+        Does this patient have a positive family history relevant to this condition?
+        */
+        FamilyHistoryCondition familyHistoryCondition;
+
+        /**
+        Was this variant previously known to be present in this patient/family?
+        */
+        /**
+        In patient:
+        */
+        FamilyHistoryPatient familyHistoryPatient;
+
+        /**
+        In family:
+        */
+        FamilyHistoryFamily familyHistoryFamily;
+
+        /**
+        Has the clinical team identified any changes to clinical care which could potentially arise as a result of this variant/variant pair?
+        */
+        array<ClinicalUtility> clinicalUtility;
+
+    }
+
+    /**
+    The rare disease program exit questionnaire
+    */
+    record RareDiseaseExitQuestionnaire{
+        /**
+        The date when the questionnaire was submitted
+        */
+        string eventDate;
+        /**
+        The person that submitted the questionnaire
+        */
+        string reporter;
+        /**
+        The set of questions at family level
+        */
+        FamilyLevelQuestions familyLevelQuestions;
+        /**
+        The list of variant group level variants (ungrouped variants are to be set in single variant group)
+        */
+        array<VariantGroupLevelQuestions> variantGroupLevelQuestions;
+    }
+
+    /*
+    -------------------------------------------------
+    ADDITIONAL FINDINGS EXIT QUESTIONNAIRE
+    -------------------------------------------------
+    */
+
+    record AdditionalFindingsExitQuestionnaire{
+        /**
+        The date when the questionnaire was submitted
+        */
+        string eventDate;
+        /**
+        The person that submitted the questionnaire
+        */
+        string reporter;
+        /**
+        The list of variant group level variants (ungrouped variants are to be set in single variant group)
+        */
+        array<AdditionalFindingsVariantGroupLevelQuestions> additionalFindingsVariantGroupLevelQuestions;
+    }
+
+    /*
+    -------------------------------------------------
+    CANCER EXIT QUESTIONNAIRE
+    -------------------------------------------------
+    */
+
+    /**
+    An enumeration for Which parts of the WGA were reviewed?:
+* `domain_1`: Domain 1 only
+* `domain_1_and_2`: Domains 1 and 2
+* `domain_1_2_and_suplementary`: Domains 1, 2 and supplementary analysis
+    */
+    enum ReviewedParts {domain_1, domain_1_and_2, domain_1_2_and_suplementary, somatic_if_relevant}
+
+    /**
+    Are the variants actionable?
+* `yes`: yes
+* `no`: no
+    */
+    enum CancerActionableVariants {yes, no}
+
+    /**
+    The variant actionabilities:
+* `predicts_therapeutic_response`: Predicts therapeutic response
+* `prognostic`: Prognostic
+* `defines_diagnosis_group`: Defines diagnosis group
+* `eligibility_for_trial`: Eligibility for trial
+* `other`:  Other (please specify)
+    */
+    enum CancerActionabilitySomatic {predicts_therapeutic_response, prognostic, defines_diagnosis_group, eligibility_for_trial, other}
+
+    /**
+    An enumeration Variant Actionability:
+      * `predicts_therapeutic_response`: Predicts therapeutic response
+      * `prognostic`: Prognostic
+      * `defines_diagnosis_group`: Defines diagnosis group
+      * `eligibility_for_trial`: Eligibility for trial
+      * `germline_susceptibility`: Germline susceptibility
+      * `other`:  Other (please specify)
+    */
+    enum CancerActionability {germline_susceptibility, predicts_therapeutic_response, prognostic, defines_diagnosis_group, eligibility_for_trial, other}
+
+
+    /**
+    Variant usability for somatic variants:
+* `already_actioned`: Already actioned (i.e. prior to receiving this WGA)
+* `actioned_result_of_this_wga`: actioned as a result of receiving this WGA
+* `not_yet_actioned`: not yet actioned, but potentially actionable in the future
+    */
+    enum CancerUsabilitySomatic {already_actioned, actioned_result_of_this_wga, not_yet_actioned}
+
+    /**
+    Variant usability for germline variants:
+* `already_actioned`: Already actioned (i.e. prior to receiving this WGA)
+* `actioned_result_of_this_wga`: actioned as a result of receiving this WGA
+    */
+    enum CancerUsabilityGermline {already_actioned, actioned_result_of_this_wga}
+
+    /**
+    Was the variant validated with an orthogonal technology?
+* `not_indicated_for_patient_care`: No: not indicated for patient care at this time
+* `no_orthologous_test_available`: No: no orthologous test available
+* `test_performed_prior_to_wga`: Yes: test performed prior to receiving WGA (eg using standard-of-care assay such as panel testing, or sanger sequencing)
+* `technical_validation_following_WGA`: Yes: technical validation performed/planned following receiving this WGA
+    */
+    enum CancerTested {not_indicated_for_patient_care, no_orthologous_test_available, test_performed_prior_to_wga, technical_validation_following_wga}
+
+    /**
+    An enumeration Variant tested:
+      * `not_indicated_for_patient_care`: No: not indicated for patient care at this time
+      * `no_orthologous_test_available`: No: no orthologous test available
+      * `test_performed_prior_to_wga`: Yes: test performed prior to receiving WGA (eg using standard-of-care assay such as panel testing, or sanger sequencing)
+      * `technical_validation_following_wga`: Yes: technical validation performed/planned following receiving this WGA
+      * `na`: N/A
+    */
+    enum CancerTestedAdditional {not_indicated_for_patient_care, no_orthologous_test_available, test_performed_prior_to_wga, technical_validation_following_wga, na}
+
+
+    /**
+    The questions for the cancer program exit questionnaire at case level
+    */
+    record CancerCaseLevelQuestions{
+        /**
+        Total time taken to review/collate evidence for variants (hours).
+        Include all literature review time, consultation with relevant experts etc.
+        */
+        double total_review_time;
+
+        /**
+        Time taken to discuss case at MDT (hours).
+        */
+        double mdt1_time;
+
+        /**
+        If the case is discussed at a 2nd MDT please enter time here (hours).
+        */
+        union {null, double} mdt2_time;
+
+        /**
+        Total time to design ALL validation assay(s) for case (hours).
+        Only applicable if it is necessary to design a new assay to validate the variant.
+        */
+        union {null, double} validation_assay_time;
+
+        /**
+        Technical Laboratory Validation. Total time for validation test wet work for all variants (hours).
+        */
+        union {null, double} wet_validation_time;
+
+        /**
+        Analytical Laboratory Validation. Total time for analysis of validation results for all variants (hours).
+        */
+        union {null, double} analytical_validation_time;
+
+        /**
+        Primary Reporting. Time taken to complete primary reporting stage (hours).
+        */
+        double primary_reporting_time;
+
+        /**
+        Report Authorisation. Time taken to check and authorise report (hours).
+        */
+        double primary_authorisation_time;
+
+        /**
+        Report Distribution.
+        Please enter, where possible/accessible how long it takes for the result to be conveyed to the patient.
+        E.g. via letter from the clinician (days).
+        */
+        double report_distribution_time;
+
+        /**
+        Total time from result to report.
+        The total time taken from when the analysis of the WGS results started  to a report being received
+        by the patient include any 'waiting' time (days).
+        */
+        double total_time;
+
+        /**
+        Which parts of the WGA were reviewed?
+        */
+        ReviewedParts reviewedInMdtWga;
+
+        /**
+        Were potentially actionable variants detected?
+        */
+        CancerActionableVariants actionableVariants;
+    }
+
+    /**
+    The questions for the cancer program exit questionnaire for germline variants
+    */
+    record CancerGermlineVariantLevelQuestions{
+        /**
+        Variant coordinates following format `chromosome:position:reference:alternate`
+        */
+        VariantCoordinates variantCoordinates;
+
+        /**
+        Type of potential actionability:
+        */
+        array<CancerActionability> variantActionability;
+        union {null, string} otherVariantActionability;
+
+        /**
+        How has/will this potentially actionable variant been/be used?
+        */
+        CancerUsabilityGermline variantUsability;
+
+        /**
+        Has this variant been tested by another method (either prior to or following receipt of this WGA)?
+        */
+        CancerTested variantTested;
+
+        /**
+        Please enter validation assay type e.g Pyrosequencing, NGS panel, COBAS, Sanger sequencing. If not applicable enter NA;
+        */
+        string validationAssayType;
+    }
+
+    record AdditionalVariantsQuestions{
+        /**
+        Chr: Pos Ref > Alt
+        */
+        VariantCoordinates variantCoordinates;
+
+        /**
+        Type of potential actionability:
+        */
+        array<CancerActionability> variantActionability;
+        union {null, string} otherVariantActionability;
+
+        /**
+        How has/will this potentially actionable variant been/be used?
+        */
+        CancerUsabilitySomatic variantUsability;
+
+        /**
+        Has this variant been tested by another method (either prior to or following receipt of this WGA)?
+        */
+        CancerTestedAdditional variantTested;
+
+        /**
+        Please enter validation assay type e.g Pyrosequencing, NGS panel, COBAS, Sanger sequencing. If not applicable enter NA;
+        */
+        string validationAssayType;
+    }
+
+    /**
+    The questions for the cancer program exit questionnaire for somatic variants
+    */
+    record CancerSomaticVariantLevelQuestions{
+        /**
+        Variant coordinates following format `chromosome:position:reference:alternate`
+        */
+        VariantCoordinates variantCoordinates;
+
+        /**
+        Type of potential actionability:
+        */
+        array<CancerActionabilitySomatic> variantActionability;
+
+        /**
+        Other information about variant actionability
+        */
+        union {null, string} otherVariantActionability;
+
+        /**
+        How has/will this potentially actionable variant been/be used?
+        */
+        CancerUsabilitySomatic variantUsability;
+
+        /**
+        Has this variant been tested by another method (either prior to or following receipt of this WGA)?
+        */
+        CancerTested variantTested;
+
+        /**
+        Please enter validation assay type e.g Pyrosequencing, NGS panel, COBAS, Sanger sequencing. If not applicable enter NA;
+        */
+        string validationAssayType;
+    }
+
+    /**
+    The cancer program exit questionnaire
+    */
+    record CancerExitQuestionnaire{
+        /**
+        The date when the questionnaire was submitted
+        */
+        string eventDate;
+
+        /**
+        The person that submitted the questionnaire
+        */
+        string reporter;
+
+        /**
+        The case level questions
+        */
+        CancerCaseLevelQuestions caseLevelQuestions;
+
+        /**
+        The questions for somatic variants
+        */
+        union {null, array<CancerSomaticVariantLevelQuestions>} somaticVariantLevelQuestions;
+
+        /**
+        The questions for germline variants
+        */
+        union {null, array<CancerGermlineVariantLevelQuestions>} germlineVariantLevelQuestions;
+
+        /**
+        Please enter any additional comments you may have about the case here.
+        */
+        union {null, string} additionalComments;
+
+        /**
+        Other actionable variants or entities.
+        Please provide other (potentially) actionable entities: e.g domain 3 small variants or SV/CNV, mutational signatures, mutational burden
+        */
+        union {null, array<AdditionalVariantsQuestions>} otherActionableVariants;
+    }
+}

--- a/schemas/IDLs/org.gel.models.report.avro/6.2.0/InterpretationRequestCancer.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.2.0/InterpretationRequestCancer.avdl
@@ -1,0 +1,108 @@
+@namespace("org.gel.models.report.avro")
+
+/**
+This protocol defines the mechanism that Genomics England uses to trigger a clinical interpretation process from a third
+party in the cancer program
+The record report is the top level class. This includes clinical information + various version
+The annotation provided by Genomics England is created using CellBase https://github.com/opencb/cellbase/wiki
+All annotations are against Ensembl gene models
+*/
+protocol CancerInterpretationRequests {
+
+    import idl "CancerParticipant.avdl";
+    import idl "CommonRequest.avdl";
+    import idl "CommonInterpreted.avdl";
+    import idl "ReportVersionControl.avdl";
+
+    /**
+    This record represents basic information for this report
+    */
+    record CancerInterpretationRequest {
+        /**
+        Model version number
+        */
+        ReportVersionControl versionControl;
+
+        /**
+        Identifier for this interpretation request
+        */
+        string interpretationRequestId;
+
+        /**
+        Version for this interpretation request
+        */
+        int interpretationRequestVersion;
+
+        /**
+        Internal study identifier
+        */
+        string internalStudyId;
+
+        /**
+        Participant internal identifier
+        */
+        union {null, string} participantInternalId;
+
+        /**
+        This is the version of the assembly used to align the reads
+        */
+        Assembly genomeAssembly;
+
+        /**
+        The genome shall be assigned to the workspaces(projects or domains with a predefined set of users) to control user access
+        */
+        array<string> workspace;
+
+        /**
+        BAMs Files
+        */
+        union {null, array<File>} bams;
+
+        /**
+        VCFs Files where SVs and CNVs are represented
+        */
+        union {null, array<File>} vcfs;
+
+        /**
+        BigWig Files
+        */
+        union {null, array<File>} bigWigs;
+
+        /**
+        Variant Annotation File
+        */
+        union {null, File} annotationFile;
+
+        /**
+        Other files that may be vendor specific
+        map of key: type of file, value: record of type File
+        */
+        union {null, map<File>} otherFiles;
+
+        /**
+        Cancer Particiapnt Data.
+        */
+        union {null, org.gel.models.participant.avro.CancerParticipant} cancerParticipant;
+
+        /**
+        It is paternal or maternal with reference to the participant.
+        */
+        union {null, OtherFamilyHistory} otherFamilyHistory;
+
+        /**
+        This map of key: panel_name, value: (map of key: gene, value: (map of metrics of key: metric name, value: float))
+        That is: a map of tables of genes and metrics
+        */
+        union {null, map<map<map<float>>>} genePanelsCoverage;
+
+        /**
+        Flags about this case relevant for interpretation
+        */
+        union {null, array<InterpretationFlag>} interpretationFlags;
+
+        /**
+        Additional information
+        */
+        union {null, map<string>} additionalInfo;
+    }
+}

--- a/schemas/IDLs/org.gel.models.report.avro/6.2.0/InterpretationRequestRD.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.2.0/InterpretationRequestRD.avdl
@@ -1,0 +1,117 @@
+@namespace("org.gel.models.report.avro")
+
+/**
+This protocol defines the mechanism that Genomics England uses to trigger a clinical interpretation process from a third party
+The record report is the top level class. This includes clinical information + various version
+The annotation provided by Genomics England is created using CellBase https://github.com/opencb/cellbase/wiki
+All annotations are against Ensembl gene models
+*/
+protocol InterpretationRequestsRD {
+
+    import idl "CommonRequest.avdl";
+    import idl "ReportVersionControl.avdl";
+    import idl "CommonInterpreted.avdl";
+    import idl "RDParticipant.avdl";
+
+    /**
+    This record represents basic information for this report
+    */
+    record InterpretationRequestRD {
+        /**
+        Model version number
+        */
+        ReportVersionControl versionControl;
+
+        /**
+        Identifier for this interpretation request
+        */
+        string interpretationRequestId;
+
+        /**
+        Version for this interpretation request
+        */
+        int interpretationRequestVersion;
+
+        /**
+        Internal study identifier
+        */
+        string internalStudyId;
+
+        /**
+        Family internal identifier
+        */
+        union {null, string} familyInternalId;
+
+        /**
+        This is the version of the assembly used to align the reads
+        */
+        Assembly genomeAssembly;
+
+        /**
+        The genome shall be assigned to the workspaces(projects or domains with a predefined set of users) to control user access
+        */
+        array<string> workspace;
+
+        /**
+        BAMs Files
+        */
+        union {null, array<File>} bams;
+
+        /**
+        VCFs Files where SVs and CNVs are represented
+        */
+        union {null, array<File>} vcfs;
+
+        /**
+        BigWig Files
+        */
+        union {null, array<File>} bigWigs;
+
+        /**
+        Pedigree Diagram Files as an SGV
+        */
+        union {null, File} pedigreeDiagram;
+
+        /**
+        Variant Annotation File
+        */
+        union {null, File} annotationFile;
+
+        /**
+        Other files that may be vendor specific
+        map of key: type of file, value: record of type File
+        */
+        union {null, map<File>} otherFiles;
+
+        /**
+        Pedigree of the family.
+        */
+        union {null, org.gel.models.participant.avro.Pedigree} pedigree;
+
+        /**
+        It is paternal or maternal with reference to the participant.
+        */
+        union {null, OtherFamilyHistory} otherFamilyHistory;
+
+        /**
+        This map of key: panel_name, value: (map of key: gene, value: (map of metrics of key: metric name, value: float))
+        That is: a map of tables of genes and metrics
+        */
+        union {null, map<map<map<float>>>} genePanelsCoverage;
+
+        /**
+        Flags for this case relevant for interpretation
+        */
+        union {null, array<InterpretationFlag>} interpretationFlags;
+
+        /**
+        Flags for this case relevant for interpretation per participant
+        */
+        union {null, array<ParticipantInterpretationFlags>} participantsInterpretationFlags;
+
+        /**
+        Additional information
+        */
+        union {null, map<string>} additionalInfo;
+    }
+}

--- a/schemas/IDLs/org.gel.models.report.avro/6.2.0/InterpretedGenome.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.2.0/InterpretedGenome.avdl
@@ -1,0 +1,90 @@
+@namespace("org.gel.models.report.avro")
+
+/**
+Define the report used by Genomics England to get the clinical interpretation companies results for bronze level
+*/
+protocol InterpretedGenomes {
+
+    import idl "CommonInterpreted.avdl";
+    import idl "ReportVersionControl.avdl";
+
+    /**
+    A interpreted genome for the rare disease program. This holds the list of candidate variants reported by an
+    interpretation service together with all the relevant information that identify the case and how these conclusions were reached.
+    */
+    record InterpretedGenome {
+
+        /**
+        Model version number
+        */
+        ReportVersionControl versionControl;
+
+        /**
+        Identifier for this interpretation request
+        */
+        string interpretationRequestId;
+
+        /**
+        Version for this interpretation request
+        */
+        int interpretationRequestVersion;
+
+        /**
+        Name of the interpretation service
+        */
+        string interpretationService;
+
+        /**
+        URL where the results can be accessed in the company's web interface
+        */
+        union {null, string} reportUrl;
+
+        /**
+        List of small reported variants
+        */
+        union {null, array<SmallVariant>} variants;
+
+        /**
+        List of simple structural reported variants (duplications, deletions, insertions, inversions, CNVs)
+        */
+        union {null, array<StructuralVariant>} structuralVariants;
+
+        /**
+        List of complex structural reported variants (chomosomal rearrangement)
+        */
+        union {null, array<ChromosomalRearrangement>} chromosomalRearrangements;
+
+        /**
+        List of short tandem repeat variants
+        */
+        union {null, array<ShortTandemRepeat>} shortTandemRepeats;
+
+        /**
+        List of uniparental disomies across all the individuals in this report
+        */
+        union {null, array<UniparentalDisomy>} uniparentalDisomies;
+
+        /**
+        List of inferred karyotypes across all the individuals in this report
+        */
+        union {null, array<Karyotype>} karyotypes;
+
+        /**
+        This map contains the versions of the different databases used in the process, being the database names the
+        keys and the versions the values.
+        */
+        map <string> referenceDatabasesVersions;
+
+        /**
+        This map contains the versions of the different software systems used in the process, being the software
+        names the keys and the versions the values.
+        */
+        map <string> softwareVersions;
+
+        /**
+        Comments about the report
+        */
+        union {null, array<string>} comments;
+
+    }
+}

--- a/schemas/IDLs/org.gel.models.report.avro/6.2.0/MDTDeliveryProtocol.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.2.0/MDTDeliveryProtocol.avdl
@@ -1,0 +1,42 @@
+@namespace("org.gel.models.report.avro")
+
+/**
+This protocol defines the integration mechanism to store analysis results in the MDT (Multi-disciplinary Tool).
+*/
+protocol MDTDelivery {
+
+    import idl "ReportVersionControl.avdl";
+    import idl "CommonRequest.avdl";
+    import idl "CommonInterpreted.avdl";
+    import idl "InterpretationRequestRD.avdl";
+    import idl "InterpretationRequestCancer.avdl";
+    import idl "InterpretedGenome.avdl";
+
+    /**
+    Represents the set of all interpretation data (excluding file contents) to be stored in MDT for
+one TieringResult.
+Semantic restrictions (not automatically verifiable):
+
+* All InterpretedGenomes in interpretationResults refer to the TieringResult tieringResult.
+* All InterpretedGenomes in interpretationResults have passed the QC stage and have been approved by the originating GMCs
+    */
+    record InterpretationDataRd {
+        InterpretationRequestRD interpretationMetaData;
+        union{null, InterpretedGenome} tieringResult;
+        union{null, array<InterpretedGenome>} otherInterpretationResults;
+    }
+
+    /**
+    Represents the set of all interpretation data (excluding file contents) to be stored in MDT for
+one TieringResult.
+Semantic restrictions (not automatically verifiable):
+
+* All InterpretedGenomes in interpretationResults refer to the TieringResult tieringResult.
+* All InterpretedGenomes in interpretationResults have passed the QC stage and have been approved by the originating GMCs
+    */
+    record InterpretationDataCancer {
+        CancerInterpretationRequest interpretationMetaData;
+        union{null, InterpretedGenome} tieringResult;
+        union{null, array<InterpretedGenome>} otherInterpretationResults;
+    }
+}

--- a/schemas/IDLs/org.gel.models.report.avro/6.2.0/ReportVersionControl.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.2.0/ReportVersionControl.avdl
@@ -1,0 +1,15 @@
+@namespace("org.gel.models.report.avro")
+/**
+This protocol defines the version control
+*/
+protocol VersionControl {
+
+    record ReportVersionControl {
+
+        /**
+        This is the version for the entire set of data models as referred to the Git release tag
+        */
+        string gitVersionControl = "6.1.1";
+    }
+}
+

--- a/schemas/IDLs/org.gel.models.report.avro/6.2.0/VariantInterpretationLog.avdl
+++ b/schemas/IDLs/org.gel.models.report.avro/6.2.0/VariantInterpretationLog.avdl
@@ -1,0 +1,33 @@
+@namespace("org.gel.models.report.avro")
+
+protocol VariantInterpretationLogProtocol {
+
+    import idl "CommonInterpreted.avdl";
+
+    record User{
+        string username;
+        string role;
+        string email;
+        array<string> groups;
+    }
+    enum ValidationResult{NotPerformed, Confirmed, NotConfirmed}
+
+    record VariantValidation{
+        string validationTechnology;
+        ValidationResult validationResult;
+    }
+
+    record VariantInterpretationLog{
+        VariantCoordinates variantCoordinates;
+        User user;
+        string timestamp;
+        string familyId;
+        string caseId;
+        union {null, VariantValidation} variantValidation;
+        union {null, array<string>} comments;
+        GuidelineBasedVariantClassification variantClassification;
+        union {null, boolean} Artifact;
+        union {null, map<string>} decisionSupportSystemFilters;
+
+    }
+}

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ elif target_version == '3':
 else:
     raise ValueError("Not supported python version {}".format(target_version))
 
-VERSION = "7.7.0"
+VERSION = "7.8.0"
 
 # read the contents of your README file
 this_directory = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Adding field for no evidences as detailed in https://jira.extge.co.uk/browse/GRM-29

The new feature is added in this commit: https://github.com/genomicsengland/GelReportModels/commit/fd29eaebf9acf051d1dbea1e52680fb06c0227c8

CVA models depend on reports so had to create a new version of these too (1.5.2), but this contains no changes.

There are other changes to be made in the same epic (https://jira.extge.co.uk/browse/GRM-38), so keeping everything in separate branch for now

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/genomicsengland/gelreportmodels/521)
<!-- Reviewable:end -->
